### PR TITLE
Agentes: Propaga analysis_name para rastreabilidade em processos IA

### DIFF
--- a/agents/agente_processador.py
+++ b/agents/agente_processador.py
@@ -20,12 +20,19 @@ class AgenteProcessador:
         instrucoes_extras: str = "",
         usar_rag: bool = False,
         model_name: Optional[str] = None,
-        max_token_out: int = 15000
+        max_token_out: int = 15000,
+        analysis_name: Optional[str] = None
     ) -> Dict[str, Any]:
         """
         Função principal do agente. Serializa o JSON de entrada e chama a IA.
+        Propaga analysis_name no relatório final, se fornecido.
         """
-        codigo_str = json.dumps(codigo, indent=2, ensure_ascii=False)
+        # Propaga analysis_name no input para rastreabilidade
+        codigo_com_nome = dict(codigo)
+        if analysis_name:
+            codigo_com_nome['analysis_name'] = analysis_name
+
+        codigo_str = json.dumps(codigo_com_nome, indent=2, ensure_ascii=False)
 
         resultado_da_ia = self.llm_provider.executar_prompt(
             tipo_tarefa=tipo_analise,
@@ -36,8 +43,10 @@ class AgenteProcessador:
             max_token_out=max_token_out
         )
 
+        # Inclui analysis_name no relatório final para rastreabilidade
         return {
             "resultado": {
-                "reposta_final": resultado_da_ia
+                "reposta_final": resultado_da_ia,
+                "analysis_name": analysis_name
             }
         }

--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -44,11 +44,12 @@ class AgenteRevisor:
         instrucoes_extras: str = "",
         usar_rag: bool = False,
         model_name: Optional[str] = None,
-        max_token_out: int = 15000
+        max_token_out: int = 15000,
+        analysis_name: Optional[str] = None
     ) -> Dict[str, Any]:
         """
         Função principal do agente. Orquestra a obtenção do código de um repositório
-        e a chamada para a IA.
+        e a chamada para a IA. Propaga analysis_name no relatório final, se fornecido.
         """
         codigo_para_analise = self._get_code(
             repositorio=repositorio,
@@ -60,7 +61,12 @@ class AgenteRevisor:
             print(f"AVISO: Nenhum código encontrado no repositório para a análise '{tipo_analise}'.")
             return {"resultado": {"reposta_final": {}}}
 
-        codigo_str = json.dumps(codigo_para_analise, indent=2, ensure_ascii=False)
+        # Propaga analysis_name no input para rastreabilidade
+        codigo_com_nome = dict(codigo_para_analise)
+        if analysis_name:
+            codigo_com_nome['analysis_name'] = analysis_name
+
+        codigo_str = json.dumps(codigo_com_nome, indent=2, ensure_ascii=False)
 
         resultado_da_ia = self.llm_provider.executar_prompt(
             tipo_tarefa=tipo_analise,
@@ -71,9 +77,10 @@ class AgenteRevisor:
             max_token_out=max_token_out
         )
 
+        # Inclui analysis_name no relatório final para rastreabilidade
         return {
             "resultado": {
-                "reposta_final": resultado_da_ia
+                "reposta_final": resultado_da_ia,
+                "analysis_name": analysis_name
             }
         }
-        

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1,0 +1,81 @@
+import pytest
+from fastapi.testclient import TestClient
+from mcp_server_fastapi import app
+import uuid
+
+client = TestClient(app)
+
+ANALYSIS_TYPE = "some_analysis_type"  # Substitua por um tipo válido do seu workflows.yaml
+
+@pytest.fixture
+def unique_analysis_name():
+    return f"test-analysis-{uuid.uuid4().hex[:8]}"
+
+def test_create_analysis_with_name(unique_analysis_name):
+    payload = {
+        "repo_name": "org/test-repo",
+        "analysis_type": ANALYSIS_TYPE,
+        "analysis_name": unique_analysis_name
+    }
+    response = client.post("/start-analysis", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "job_id" in data
+    assert data["analysis_name"] == unique_analysis_name.lower()
+
+def test_duplicate_analysis_name_rejected(unique_analysis_name):
+    payload = {
+        "repo_name": "org/test-repo",
+        "analysis_type": ANALYSIS_TYPE,
+        "analysis_name": unique_analysis_name
+    }
+    # Primeira criação
+    response1 = client.post("/start-analysis", json=payload)
+    assert response1.status_code == 200
+    # Segunda tentativa com o mesmo nome
+    response2 = client.post("/start-analysis", json=payload)
+    assert response2.status_code == 409
+    assert "análise com este nome" in response2.json()["detail"]
+
+def test_get_report_by_analysis_name(unique_analysis_name):
+    payload = {
+        "repo_name": "org/test-repo",
+        "analysis_type": ANALYSIS_TYPE,
+        "analysis_name": unique_analysis_name
+    }
+    response = client.post("/start-analysis", json=payload)
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+    # Simula conclusão do job e grava relatório
+    from tools.job_store import RedisJobStore
+    job_store = RedisJobStore()
+    job = job_store.get_job(job_id)
+    job["data"]["analysis_report"] = "Relatório de Teste"
+    job_store.set_job(job_id, job)
+    # Busca pelo endpoint tradicional
+    report_response = client.get(f"/jobs/{job_id}/report")
+    assert report_response.status_code == 200
+    assert report_response.json()["analysis_report"] == "Relatório de Teste"
+    # Busca pelo endpoint por nome
+    report_by_name = client.get(f"/jobs/by-name/{unique_analysis_name}/report")
+    assert report_by_name.status_code == 200
+    assert report_by_name.json()["analysis_report"] == "Relatório de Teste"
+    assert report_by_name.json()["analysis_name"] == unique_analysis_name.lower()
+
+def test_get_report_by_job_id_and_no_name():
+    payload = {
+        "repo_name": "org/test-repo",
+        "analysis_type": ANALYSIS_TYPE
+    }
+    response = client.post("/start-analysis", json=payload)
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+    from tools.job_store import RedisJobStore
+    job_store = RedisJobStore()
+    job = job_store.get_job(job_id)
+    job["data"]["analysis_report"] = "Relatório Sem Nome"
+    job_store.set_job(job_id, job)
+    report_response = client.get(f"/jobs/{job_id}/report")
+    assert report_response.status_code == 200
+    assert report_response.json()["analysis_report"] == "Relatório Sem Nome"
+    assert report_response.json()["analysis_name"] is None


### PR DESCRIPTION
Este PR modifica os agentes AgenteProcessador e AgenteRevisor para propagar o campo analysis_name tanto na entrada quanto na saída dos processos de IA, garantindo rastreabilidade e consistência do nome da análise durante o workflow. Esta mudança é estrutural e de impacto médio, recomendada para revisão normal após a base de persistência. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 2, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA