### PR TITLE
Adapta AgenteProcessador para aceitar relatório existente e adiciona testes para nomeação e recuperação

### DIFF
--- a/agents/agente_processador.py
+++ b/agents/agente_processador.py
@@ -7,6 +7,7 @@ class AgenteProcessador:
     """
     Um agente simples focado em processar dados estruturados (JSON)
     que são passados de etapas anteriores em um workflow.
+    Agora aceita relatório existente como entrada principal.
     """
     def __init__(self, llm_provider: ILLMProvider):
         self.llm_provider = llm_provider
@@ -20,12 +21,17 @@ class AgenteProcessador:
         instrucoes_extras: str = "",
         usar_rag: bool = False,
         model_name: Optional[str] = None,
-        max_token_out: int = 15000
+        max_token_out: int = 15000,
+        relatorio_existente: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """
         Função principal do agente. Serializa o JSON de entrada e chama a IA.
+        Se relatorio_existente for fornecido, usa-o como entrada principal.
         """
-        codigo_str = json.dumps(codigo, indent=2, ensure_ascii=False)
+        if relatorio_existente is not None:
+            codigo_str = json.dumps(relatorio_existente, indent=2, ensure_ascii=False)
+        else:
+            codigo_str = json.dumps(codigo, indent=2, ensure_ascii=False)
 
         resultado_da_ia = self.llm_provider.executar_prompt(
             tipo_tarefa=tipo_analise,

--- a/backend/tests/test_analysis_naming.py
+++ b/backend/tests/test_analysis_naming.py
@@ -1,0 +1,70 @@
+import pytest
+from fastapi.testclient import TestClient
+from mcp_server_fastapi import app, job_store
+import uuid
+
+client = TestClient(app)
+
+ANALYSIS_NAME = f"test-analysis-{uuid.uuid4()}"
+
+# Mock payload para criação de análise
+def get_payload():
+    return {
+        "repo_name": "org/testrepo",
+        "analysis_type": "default", # ajuste conforme workflow
+        "branch_name": "main",
+        "instrucoes_extras": "Teste de nomeação de análise.",
+        "usar_rag": False,
+        "gerar_relatorio_apenas": True,
+        "model_name": None,
+        "analysis_name": ANALYSIS_NAME
+    }
+
+# Teste: Criação de análise com nome
+def test_create_analysis_with_name():
+    response = client.post("/start-analysis", json=get_payload())
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+    job = job_store.get_job(job_id)
+    assert job is not None
+    assert job["data"].get("analysis_name") == ANALYSIS_NAME
+
+# Teste: Recuperação de relatório por nome
+def test_retrieve_report_by_analysis_name():
+    # Cria análise
+    response = client.post("/start-analysis", json=get_payload())
+    job_id = response.json()["job_id"]
+    # Aguarda processamento
+    import time; time.sleep(2)
+    # Busca relatório por nome
+    response2 = client.get(f"/analyses/by-name/{ANALYSIS_NAME}")
+    assert response2.status_code == 200
+    data = response2.json()
+    assert data["job_id"] == job_id
+    assert data["analysis_name"] == ANALYSIS_NAME
+    assert "analysis_report" in data
+
+# Teste: Geração de código a partir de relatório existente
+def test_code_generation_from_existing_report():
+    # Cria análise
+    response = client.post("/start-analysis", json=get_payload())
+    job_id = response.json()["job_id"]
+    import time; time.sleep(2)
+    # Inicia geração de código a partir do relatório
+    response2 = client.post(f"/start-code-generation-from-report/{ANALYSIS_NAME}")
+    assert response2.status_code == 200
+    assert "job_id" in response2.json()
+
+# Teste: Nomes duplicados (política: sobrescrita)
+def test_duplicate_analysis_name_overwrites():
+    payload = get_payload()
+    response1 = client.post("/start-analysis", json=payload)
+    job_id1 = response1.json()["job_id"]
+    # Cria nova análise com mesmo nome
+    response2 = client.post("/start-analysis", json=payload)
+    job_id2 = response2.json()["job_id"]
+    assert job_id1 != job_id2
+    # Busca pelo nome deve retornar o último job_id
+    response3 = client.get(f"/analyses/by-name/{ANALYSIS_NAME}")
+    assert response3.status_code == 200
+    assert response3.json()["job_id"] == job_id2


### PR DESCRIPTION
Este PR adapta o agente processador para aceitar relatório existente como entrada principal, permitindo iniciar geração de código a partir de relatório recuperado. Além disso, adiciona testes automatizados para criação de análises com nome, recuperação por nome, geração a partir de relatório e política de nomes duplicados. Prioridade NORMAL por ser melhoria funcional e cobertura de testes. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 3, revisores_sugeridos: Engenheiro de QA, Desenvolvedor Sênior (Backend)