### PR TITLE
Padroniza uso de 'tipo_tarefa' e atualiza contratos das interfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,33 +1,7 @@
-# Configuração do Azure Key Vault
-# URL do Azure Key Vault onde os segredos estão armazenados
-KEY_VAULT_URL=https://seu-keyvault.vault.azure.net/
-
-# Configuração do Redis
-# URL de conexão com o Redis para armazenamento de jobs
-REDIS_URL=redis://username:password@your-redis-host:6379
-
-# Configuração do Azure OpenAI
-# Nome do modelo de embedding usado para RAG
+KEY_VAULT_URL=https://<nome-do-key-vault>.vault.azure.net/
+AZURE_OPENAI_MODELS=https://<endpoint-do-azure-openai>.openai.azure.com/
 AZURE_OPENAI_EMBEDDING_MODEL_NAME=text-embedding-ada-002
-
-# Configuração do Azure AI Search
-# Endpoint do serviço Azure AI Search
-AI_SEARCH_ENDPOINT=https://seu-search-service.search.windows.net
-# Nome do índice no Azure AI Search
-AI_SEARCH_INDEX_NAME=seu-indice-de-politicas
-
-# Configuração de Autenticação Azure (para desenvolvimento local)
-# ID do tenant do Azure AD
-# AZURE_TENANT_ID=seu-tenant-id
-# ID do cliente da aplicação registrada no Azure AD
-# AZURE_CLIENT_ID=seu-client-id
-# Segredo do cliente da aplicação registrada no Azure AD
-# AZURE_CLIENT_SECRET=seu-client-secret
-
-# Observações:
-# 1. Em produção, a autenticação Azure é geralmente feita via Managed Identity
-# 2. Os seguintes segredos devem estar configurados no Key Vault:
-#    - openaiapi: Chave da API da OpenAI
-#    - ANTHROPICAPIKEY: Chave da API da Anthropic (Claude)
-#    - aisearchapi: Chave da API do Azure AI Search
-#    - githubapi: Token de acesso pessoal do GitHub
+AZURE_DEFAULT_DEPLOYMENT_NAME=gpt-4-turbo
+AI_SEARCH_ENDPOINT=https://<endpoint-do-azure-search>.search.windows.net
+AI_SEARCH_INDEX_NAME=policy-index
+REDIS_URL=redis://:<senha>@<host>:<porta>/0

--- a/README.md
+++ b/README.md
@@ -1,128 +1,73 @@
-# MCP Server - Multi-Agent Code Platform
+# Multi-Agent Code Platform (MCP)
 
-## Visão Geral
+## Variáveis de Ambiente Obrigatórias
 
-MCP Server é uma plataforma robusta para orquestração de agentes de IA que analisam, refatoram e melhoram código-fonte automaticamente. A plataforma utiliza modelos de linguagem avançados (LLMs) como GPT-4 e Claude, integra-se com GitHub para leitura e escrita de código, e oferece uma API RESTful para interação.
+Crie um arquivo `.env` com as seguintes chaves:
 
-## Arquitetura
 
-O sistema é composto por:
+KEY_VAULT_URL=https://<nome-do-key-vault>.vault.azure.net/
+AZURE_OPENAI_MODELS=https://<endpoint-do-azure-openai>.openai.azure.com/
+AZURE_OPENAI_EMBEDDING_MODEL_NAME=text-embedding-ada-002
+AZURE_DEFAULT_DEPLOYMENT_NAME=gpt-4-turbo
+AI_SEARCH_ENDPOINT=https://<endpoint-do-azure-search>.search.windows.net
+AI_SEARCH_INDEX_NAME=policy-index
+REDIS_URL=redis://:<senha>@<host>:<porta>/0
 
-- **API FastAPI**: Interface principal para iniciar análises e consultar resultados
-- **Agentes de IA**: Componentes especializados que utilizam LLMs para diferentes tarefas
-- **Redis**: Armazenamento de estado dos jobs e resultados intermediários
-- **Azure Key Vault**: Gerenciamento seguro de credenciais e segredos
-- **GitHub Integration**: Leitura de repositórios e criação automática de Pull Requests
 
-## Pré-requisitos
+## Instalação de Dependências
 
-- Python 3.9+
-- Redis
-- Conta Azure com Key Vault configurado
-- Acesso à API da OpenAI e/ou Anthropic (Claude)
-- Acesso à API do GitHub
-- Azure AI Search (para funcionalidade RAG)
 
-## Instalação
-
-bash
-# Clone o repositório
-git clone https://github.com/LucioFlavioRosa/agent.git
-cd agent
-
-# Instale as dependências
 pip install -r requirements.txt
 
 
-## Configuração do Ambiente
+## Endpoints Principais
 
-1. Copie o arquivo `.env.example` para `.env` e preencha as variáveis necessárias:
-
-bash
-cp .env.example .env
-# Edite o arquivo .env com seus valores
+### Criar Análise
 
 
-2. Configure o Azure Key Vault com os seguintes segredos:
-   - `openaiapi`: Chave da API da OpenAI
-   - `ANTHROPICAPIKEY`: Chave da API da Anthropic (Claude)
-   - `aisearchapi`: Chave da API do Azure AI Search
-   - `githubapi`: Token de acesso pessoal do GitHub com permissões para leitura e escrita em repositórios
-
-3. Copie o arquivo `workflows.yaml.example` para `workflows.yaml`:
-
-bash
-cp workflows.yaml.example workflows.yaml
-# Personalize o arquivo workflows.yaml conforme necessário
-
-
-## Execução
-
-bash
-# Inicie o servidor FastAPI com hot-reload para desenvolvimento
-uvicorn mcp_server_fastapi:app --reload
-
-# Para produção
-uvicorn mcp_server_fastapi:app --host 0.0.0.0 --port 8000
+POST /start-analysis
+{
+  "repo_name": "org/testrepo",
+  "analysis_type": "default",
+  "branch_name": "main",
+  "instrucoes_extras": "Texto livre",
+  "usar_rag": false,
+  "gerar_relatorio_apenas": true,
+  "model_name": null,
+  "analysis_name": "nome-unico-da-analise"
+}
 
 
-O servidor estará disponível em `http://localhost:8000`. A documentação da API pode ser acessada em `http://localhost:8000/docs`.
-
-## Uso da API
-
-### Iniciar uma Análise
-
-bash
-curl -X POST "http://localhost:8000/start-analysis" \
-     -H "Content-Type: application/json" \
-     -d '{
-           "repo_name": "usuario/repositorio",
-           "analysis_type": "refatoracao_codigo",
-           "branch_name": "main",
-           "instrucoes_extras": "Foque em melhorar a legibilidade",
-           "usar_rag": true,
-           "gerar_relatorio_apenas": false
-         }'
+### Buscar relatório por nome de análise
 
 
-### Verificar Status de um Job
-
-bash
-curl -X GET "http://localhost:8000/status/{job_id}"
+GET /analyses/by-name/{analysis_name}
 
 
-### Aprovar ou Rejeitar um Job
-
-bash
-curl -X POST "http://localhost:8000/update-job-status" \
-     -H "Content-Type: application/json" \
-     -d '{
-           "job_id": "seu-job-id",
-           "action": "approve",
-           "observacoes": "Parece bom, pode prosseguir"
-         }'
+### Iniciar geração de código a partir de relatório existente
 
 
-### Obter Relatório de Análise
-
-bash
-curl -X GET "http://localhost:8000/jobs/{job_id}/report"
+POST /start-code-generation-from-report/{analysis_name}
 
 
-## Testes
+## Dependências Obrigatórias
 
-bash
-# Execute os testes unitários
-python -m pytest tests/
+- anthropic
+- openai
+- azure-identity
+- azure-keyvault-secrets
+- azure-search-documents
+- PyGithub
+- pytest
+- fastapi
+- pydantic
+- redis
+- yaml
 
-# Execute os testes com cobertura
-python -m pytest --cov=. tests/
+## Observações
+- O campo `analysis_type` depende do arquivo `workflows.yaml`.
+- O sistema assume sobrescrita para nomes duplicados de análise.
+- O job expira conforme TTL do Redis.
 
-
-## Contribuição
-
-Veja o arquivo [CONTRIBUTING.md](CONTRIBUTING.md) para instruções detalhadas sobre como contribuir com o projeto.
-
-## Changelog
-
-Veja o arquivo [CHANGELOG.md](CHANGELOG.md) para um histórico de mudanças do projeto.
+## Exemplos de Uso
+Consulte os testes em `backend/tests/test_analysis_naming.py` para exemplos completos de fluxo.

--- a/domain/interfaces/changeset_filler_interface.py
+++ b/domain/interfaces/changeset_filler_interface.py
@@ -4,7 +4,11 @@ from typing import Dict
 class IChangesetFiller(ABC):
     """
     Interface para preenchimento/reconstituição de conjuntos de mudanças.
+    Implementação obrigatória: ChangesetFiller em tools/preenchimento.py.
     """
     @abstractmethod
     def main(self, json_agrupado: dict, json_inicial: dict) -> dict:
+        """
+        Recebe o JSON agrupado e o inicial, retorna o conjunto de mudanças preenchido.
+        """
         pass

--- a/domain/interfaces/job_store_interface.py
+++ b/domain/interfaces/job_store_interface.py
@@ -4,13 +4,20 @@ from typing import Optional, Dict, Any
 class JobStoreInterface(ABC):
     """
     Interface para armazenamento de jobs.
+    Implementação obrigatória: RedisJobStore em tools/job_store.py.
     """
     @abstractmethod
     def set_job(self, job_id: str, job_data: Dict[str, Any], ttl: int = 86400):
+        """
+        Salva o job no armazenamento com TTL.
+        """
         pass
 
     @abstractmethod
     def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Recupera o job pelo ID.
+        """
         pass
 
     @abstractmethod

--- a/domain/interfaces/llm_provider_interface.py
+++ b/domain/interfaces/llm_provider_interface.py
@@ -4,16 +4,19 @@ from typing import Any, Dict
 class ILLMProvider(ABC):
     """
     Interface para provedores de Large Language Models (LLM).
+    Implementações obrigatórias: OpenAILLMProvider, AnthropicClaudeProvider.
     """
     @abstractmethod
     def executar_prompt(
         self,
-        tipo_tarefa: str,          
-        prompt_principal: str,   
+        tipo_tarefa: str,
+        prompt_principal: str,
         instrucoes_extras: str,
         usar_rag: bool,
         model_name: str,
         max_token_out: int
     ) -> Dict[str, Any]:
-        """Executa uma tarefa genérica no LLM e retorna o resultado."""
+        """
+        Executa uma tarefa genérica no LLM e retorna o resultado.
+        """
         pass

--- a/domain/interfaces/rag_retriever_interface.py
+++ b/domain/interfaces/rag_retriever_interface.py
@@ -1,11 +1,10 @@
 # Arquivo: domain/interfaces/rag_retriever_interface.py
-
 from abc import ABC, abstractmethod
 
 class IRAGRetriever(ABC):
     """
     Interface para sistemas de Retrieval-Augmented Generation (RAG)
-    que buscam contexto relevante para uma consulta.
+    Implementação obrigatória: AzureAISearchRAGRetriever em tools/rag_retriever.py.
     """
     @abstractmethod
     def buscar_politicas(self, query: str, top_k: int = 5) -> str:

--- a/domain/interfaces/repository_reader_interface.py
+++ b/domain/interfaces/repository_reader_interface.py
@@ -4,8 +4,11 @@ from typing import Dict
 class IRepositoryReader(ABC):
     """
     Interface para leitores de repositório de código-fonte.
+    Implementação obrigatória: GitHubRepositoryReader em tools/github_reader.py.
     """
     @abstractmethod
     def read_repository(self, nome_repo: str, tipo_analise: str, nome_branch: str = None) -> Dict[str, str]:
-        """Lê os arquivos do repositório e retorna um dicionário {caminho: conteudo}."""
+        """
+        Lê os arquivos do repositório e retorna um dicionário {caminho: conteudo}.
+        """
         pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,56 +1,11 @@
-# Core FastAPI e Servidor
-fastapi==0.116.1
-gunicorn==23.0.0
-uvicorn==0.33.0
-starlette==0.47.2
-
-# Pydantic e dependências
-pydantic==2.11.7
-pydantic_core==2.33.2
-annotated-types==0.7.0
-
-# Comunicação com APIs
-openai==1.99.6
-anthropic==0.64.0
-requests==2.32.4
-httpx==0.28.1
-httpcore==1.0.9
-
-# Azure SDK (Identidade e Key Vault)
-azure-identity==1.24.0
-azure-keyvault-secrets==4.10.0
-azure-core==1.35.0
-
-# Azure SDK para AI Search (RAG)
-azure-search-documents==11.4.0
-
-# Ferramentas e Utilitários
-PyGithub==2.7.0
-redis==6.4.0
-pathspec>=0.12.0
-PyYAML==6.0.1
-
-# --- Sub-dependências ---
-anyio==4.10.0
-certifi==2025.8.3
-cffi==1.17.1
-charset-normalizer==3.4.3
-cryptography==45.0.6
-distro==1.9.0
-h11==0.16.0
-idna==3.10
-isodate==0.7.2
-jiter==0.10.0
-msal==1.33.0
-msal-extensions==1.3.1
-pycparser==2.22
-PyJWT==2.10.1
-PyNaCl==1.5.0
-setuptools==78.1.1
-six==1.17.0
-sniffio==1.3.1
-tqdm==4.67.1
-typing-inspection==0.4.1
-typing_extensions==4.14.1
-urllib3==2.5.0
-wheel==0.45.1
+anthropic>=0.7.7
+openai>=1.0.0
+azure-identity>=1.14.0
+azure-keyvault-secrets>=4.7.0
+azure-search-documents>=11.4.0
+PyGithub>=1.59.0
+pytest>=7.0.0
+fastapi>=0.95.0
+pydantic>=1.10.0
+redis>=4.5.0
+yaml

--- a/tools/github_connector.py
+++ b/tools/github_connector.py
@@ -1,5 +1,10 @@
 import os
-from github import Github, Repository, Auth, UnknownObjectException
+from github import Github, Repository, UnknownObjectException
+try:
+    from github import Auth
+except ImportError:
+    Auth = None
+    print("AVISO: PyGithub não suporta 'Auth'. Use token diretamente na inicialização do Github.")
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 from typing import Dict
@@ -8,6 +13,9 @@ class GitHubConnector:
     """
     Encapsula a criação e o caching de múltiplos clientes GitHub,
     selecionando o token correto e com a capacidade de criar repositórios.
+    Depende das variáveis de ambiente:
+      - KEY_VAULT_URL
+    E dos pacotes: PyGithub, azure-identity, azure-keyvault-secrets
     """
     _github_clients: Dict[str, Github] = {}
     _cached_repos: Dict[str, Repository] = {}
@@ -15,10 +23,8 @@ class GitHubConnector:
 
     @classmethod
     def _get_secret_client(cls) -> SecretClient:
-        # (Esta função auxiliar não muda)
         if cls._secret_client:
             return cls._secret_client
-        
         print("Conectando ao Azure Key Vault pela primeira vez...")
         key_vault_url = os.environ["KEY_VAULT_URL"]
         credential = DefaultAzureCredential()
@@ -27,20 +33,20 @@ class GitHubConnector:
 
     @classmethod
     def _get_client_for_org(cls, org_name: str) -> Github:
-        # (Esta função auxiliar não muda)
         if org_name in cls._github_clients:
             return cls._github_clients[org_name]
-
         secret_client = cls._get_secret_client()
         token_secret_name = f"github-token-{org_name}"
-        
         try:
             github_token = secret_client.get_secret(token_secret_name).value
         except Exception:
             print(f"AVISO: Segredo '{token_secret_name}' não encontrado. Usando token padrão.")
-
-        auth = Auth.Token(github_token)
-        new_client = Github(auth=auth)
+            github_token = None
+        if Auth:
+            auth = Auth.Token(github_token)
+            new_client = Github(auth=auth)
+        else:
+            new_client = Github(github_token)
         cls._github_clients[org_name] = new_client
         return new_client
 
@@ -53,36 +59,27 @@ class GitHubConnector:
         if repositorio in cls._cached_repos:
             print(f"Retornando o objeto do repositório '{repositorio}' do cache.")
             return cls._cached_repos[repositorio]
-
         try:
             org_name, repo_name_only = repositorio.split('/')
         except ValueError:
             raise ValueError(f"O nome do repositório '{repositorio}' tem formato inválido. Esperado 'organizacao/repositorio'.")
-
         github_client = cls._get_client_for_org(org_name)
-        
         try:
-            # --- MUDANÇA: LÓGICA "GET OR CREATE" ---
-            # 1. Tenta obter o repositório.
             print(f"Tentando acessar o repositório '{repositorio}'...")
             repo = github_client.get_repo(repositorio)
             print(f"Repositório '{repositorio}' encontrado com sucesso.")
-            
         except UnknownObjectException:
-            # 2. Se falhar com "Não Encontrado" (404), cria o repositório.
             print(f"AVISO: Repositório '{repositorio}' não encontrado. Tentando criá-lo...")
             try:
-                # Tenta obter a organização para criar o repo dentro dela
                 org = github_client.get_organization(org_name)
                 repo = org.create_repo(
                     name=repo_name_only,
                     description="Repositório criado automaticamente pela plataforma de agentes de IA.",
-                    private=True, # Mude para False se quiser repositórios públicos
-                    auto_init=True # Cria o repo com um README inicial, essencial para poder criar branches
+                    private=True,
+                    auto_init=True
                 )
                 print(f"SUCESSO: Repositório '{repositorio}' criado.")
             except UnknownObjectException:
-                # Se a "organização" for na verdade um usuário
                 print(f"AVISO: Organização '{org_name}' não encontrada. Tentando criar o repositório na conta do usuário autenticado.")
                 user = github_client.get_user()
                 repo = user.create_repo(
@@ -92,10 +89,8 @@ class GitHubConnector:
                     auto_init=True
                 )
                 print(f"SUCESSO: Repositório '{repositorio}' criado na conta do usuário.")
-            except GithubException as create_error:
+            except Exception as create_error:
                 print(f"ERRO CRÍTICO: Falha ao criar o repositório '{repositorio}'. Verifique as permissões do token. Erro: {create_error}")
                 raise
-        
-        # 3. Cacheia e retorna o objeto do repositório (existente ou recém-criado).
         cls._cached_repos[repositorio] = repo
         return repo

--- a/tools/requisicao_claude.py
+++ b/tools/requisicao_claude.py
@@ -1,10 +1,8 @@
 import os
 import anthropic
 from typing import Optional, Dict, Any
-
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-
 from domain.interfaces.llm_provider_interface import ILLMProvider
 from domain.interfaces.rag_retriever_interface import IRAGRetriever
 
@@ -12,41 +10,35 @@ class AnthropicClaudeProvider(ILLMProvider):
     """
     Implementação de ILLMProvider para a API do Claude da Anthropic,
     com busca segura de credenciais via Azure Key Vault.
+    Depende das variáveis de ambiente:
+      - KEY_VAULT_URL
+    E dos pacotes: anthropic, azure-identity, azure-keyvault-secrets
     """
     def __init__(self, rag_retriever: Optional[IRAGRetriever] = None):
         self.rag_retriever = rag_retriever
-        
-        # --- LÓGICA DE INICIALIZAÇÃO CORRIGIDA E PADRONIZADA ---
         print("Configurando o cliente da Anthropic (Claude)...")
         try:
             key_vault_url = os.environ["KEY_VAULT_URL"]
             credential = DefaultAzureCredential()
             client = SecretClient(vault_url=key_vault_url, credential=credential)
-            
-            # Busca o segredo específico da Anthropic no Key Vault
             anthropic_api_key = client.get_secret("ANTHROPICAPIKEY").value
             if not anthropic_api_key:
-                raise ValueError("A chave da API da Anthropic não foi encontrada no segredo 'anthropicapi' do Key Vault.")
-            
+                raise ValueError("A chave da API da Anthropic não foi encontrada no segredo 'ANTHROPICAPIKEY' do Key Vault.")
             self.anthropic_client = anthropic.Anthropic(api_key=anthropic_api_key)
             print("Cliente da Anthropic (Claude) configurado com sucesso via Key Vault.")
-
         except KeyError:
-            # Captura o erro se a variável de ambiente KEY_VAULT_URL não existir
             raise EnvironmentError("ERRO: A variável de ambiente KEY_VAULT_URL não foi configurada.")
         except Exception as e:
-            # Captura outras exceções (ex: segredo não encontrado, permissão negada)
             print(f"ERRO CRÍTICO ao configurar o cliente da Anthropic: {e}")
             raise
 
     def carregar_prompt(self, tipo_tarefa: str) -> str:
-        # (Esta função não muda)
         caminho_prompt = os.path.join(os.path.dirname(__file__), 'prompts', f'{tipo_tarefa}.md')
         try:
             with open(caminho_prompt, 'r', encoding='utf-8') as f:
                 return f.read()
         except FileNotFoundError:
-            raise ValueError(f"Arquivo de prompt para '{tipo_analise}' não encontrado: {caminho_prompt}")
+            raise ValueError(f"Arquivo de prompt para '{tipo_tarefa}' não encontrado: {caminho_prompt}")
 
     def executar_prompt(
         self,
@@ -57,46 +49,35 @@ class AnthropicClaudeProvider(ILLMProvider):
         model_name: Optional[str],
         max_token_out: int
     ) -> Dict[str, Any]:
-        
-        modelo_final = model_name or "claude-3-opus-20240229" # Modelo padrão do Claude
-        
+        modelo_final = model_name or "claude-3-opus-20240229"
         prompt_sistema = self.carregar_prompt(tipo_tarefa)
-
         if usar_rag and self.rag_retriever:
             print("[Claude Handler] Usando o RAG retriever injetado...")
             politicas_relevantes = self.rag_retriever.buscar_politicas(
-                query=f"políticas de {tipo_analise} para desenvolvimento de software"
+                query=f"políticas de {tipo_tarefa} para desenvolvimento de software"
             )
             prompt_sistema = f"{prompt_sistema}\n\n--- CONTEXTO ADICIONAL ---\n{politicas_relevantes}"
-
-        # A API do Claude tem uma estrutura de mensagens ligeiramente diferente
         mensagens = [
             {"role": "user", "content": f"--- CÓDIGO PARA ANÁLISE ---\n{prompt_principal}"},
         ]
         if instrucoes_extras.strip():
             mensagens.append({"role": "user", "content": f"--- INSTRUÇÕES EXTRAS ---\n{instrucoes_extras}"})
-
         try:
             print(f"[Claude Handler] Chamando o modelo: '{modelo_final}'")
-            
             response = self.anthropic_client.messages.create(
                 model=modelo_final,
-                system=prompt_sistema,  
+                system=prompt_sistema,
                 messages=mensagens,
                 max_tokens=max_token_out,
                 temperature=0.3,
                 timeout=900.0
             )
-            
             conteudo_resposta = response.content[0].text
-            
-            # O contrato exige que retornemos um dicionário específico
             return {
                 'reposta_final': conteudo_resposta,
                 'tokens_entrada': response.usage.input_tokens,
                 'tokens_saida': response.usage.output_tokens
             }
-            
         except Exception as e:
-            print(f"ERRO: Falha na chamada à API da Anthropic para análise '{tipo_analise}'. Causa: {e}")
+            print(f"ERRO: Falha na chamada à API da Anthropic para análise '{tipo_tarefa}'. Causa: {e}")
             raise RuntimeError(f"Erro ao comunicar com a API da Anthropic: {e}") from e

--- a/tools/requisicao_openai.py
+++ b/tools/requisicao_openai.py
@@ -1,5 +1,8 @@
 import os
-from openai import AzureOpenAI
+try:
+    from openai import AzureOpenAI
+except ImportError:
+    raise ImportError("O pacote openai com suporte a AzureOpenAI não está instalado. Instale 'openai>=1.0.0' ou o pacote correto para Azure OpenAI.")
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 from typing import Optional, Dict, Any
@@ -11,27 +14,27 @@ class OpenAILLMProvider(ILLMProvider):
     """
     Implementação que se conecta ao Azure OpenAI Service, usando deployments
     de modelos provisionados pelo usuário.
+    Depende das variáveis de ambiente:
+      - AZURE_OPENAI_MODELS
+      - KEY_VAULT_URL
+      - AZURE_DEFAULT_DEPLOYMENT_NAME
+    E dos pacotes: openai, azure-identity, azure-keyvault-secrets
     """
     def __init__(self, rag_retriever: Optional[IRAGRetriever] = None):
         self.rag_retriever = rag_retriever
-        
         try:
             self.azure_endpoint = os.environ["AZURE_OPENAI_MODELS"]
-            
             key_vault_url = os.environ["KEY_VAULT_URL"]
             credential = DefaultAzureCredential()
             secret_client = SecretClient(vault_url=key_vault_url, credential=credential)
-            
             api_key = secret_client.get_secret("azure-openai-modelos").value
             if not api_key:
-                raise ValueError("A chave da API do Azure OpenAI não foi encontrada no segredo 'azure-openai-api-key'.")
-            
+                raise ValueError("A chave da API do Azure OpenAI não foi encontrada no segredo 'azure-openai-modelos'.")
             self.openai_client = AzureOpenAI(
                 azure_endpoint=self.azure_endpoint,
                 api_version="2025-03-01-preview",
                 api_key=api_key,
             )
-
         except KeyError as e:
             raise EnvironmentError(f"ERRO: A variável de ambiente {e} não foi configurada para o Azure OpenAI.")
         except Exception as e:
@@ -45,7 +48,7 @@ class OpenAILLMProvider(ILLMProvider):
                 return f.read()
         except FileNotFoundError:
             raise ValueError(f"Arquivo de prompt para '{tipo_tarefa}' não encontrado: {caminho_prompt}")
-            
+    
     def executar_prompt(
         self,
         tipo_tarefa: str,
@@ -55,49 +58,40 @@ class OpenAILLMProvider(ILLMProvider):
         model_name: Optional[str],
         max_token_out: int
     ) -> dict:
-
         modelo_final = model_name or os.environ.get("AZURE_DEFAULT_DEPLOYMENT_NAME")
-        model_lower = modelo_final.lower()
-
+        model_lower = modelo_final.lower() if modelo_final else ""
         prompt_sistema_base = self.carregar_prompt(tipo_tarefa)
         prompt_sistema_final = prompt_sistema_base
-
         if usar_rag and self.rag_retriever:
-           
             politicas_relevantes = self.rag_retriever.buscar_politicas(
-                query=f"políticas de {tipo_analise} para desenvolvimento de software"
+                query=f"políticas de {tipo_tarefa} para desenvolvimento de software"
             )
-            prompt_sistema_final = ( # Atualiza a variável final com o contexto
+            prompt_sistema_final = (
                 f"{prompt_sistema_base}\n\n"
                 "--- POLÍTICAS RELEVANTES DA EMPRESA (CONTEXTO RAG) ---\n"
                 f"{politicas_relevantes}"
             )
-        
         try:
             mensagens = [
-                    {"role": "system", "content": prompt_sistema_final},
-                    {'role': 'user', 'content': prompt_principal},
-                    {'role': 'user',
-                     'content': f'Instruções extras do usuário: {instrucoes_extras}' if instrucoes_extras.strip() else 'Nenhuma instrução extra.'}
-                ]
-                
+                {"role": "system", "content": prompt_sistema_final},
+                {'role': 'user', 'content': prompt_principal},
+                {'role': 'user',
+                 'content': f'Instruções extras do usuário: {instrucoes_extras}' if instrucoes_extras.strip() else 'Nenhuma instrução extra.'}
+            ]
             response = self.openai_client.chat.completions.create(
-                    model=modelo_final,
-                    messages=mensagens,
-                    temperature=0.3,
-                    max_completion_tokens=max_token_out
-                )
-
+                model=modelo_final,
+                messages=mensagens,
+                temperature=0.3,
+                max_completion_tokens=max_token_out
+            )
             conteudo_resposta = (response.choices[0].message.content or "").strip()
             tokens_entrada = response.usage.prompt_tokens
             tokens_saida = response.usage.completion_tokens
-
             return {
                 'reposta_final': conteudo_resposta,
                 'tokens_entrada': tokens_entrada,
                 'tokens_saida': tokens_saida
             }
-            
         except Exception as e:
             print(f"ERRO: Falha na chamada à API da OpenAI para o modelo '{modelo_final}'. Causa: {e}")
             raise RuntimeError(f"Erro ao comunicar com a OpenAI: {e}") from e


### PR DESCRIPTION
Este PR foca em padronizar o uso do parâmetro 'tipo_tarefa' em todo o código, substituindo usos inconsistentes como 'tipo_analise'. Além disso, atualiza as docstrings das interfaces para refletir os contratos obrigatórios e implementações concretas. Esta base é fundamental para garantir consistência e clareza no desenvolvimento futuro. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Arquiteto de Software