### PR TITLE
Corrige UnboundLocalError crítico no tratamento de tokens no GitHubConnector

### DIFF
--- a/tools/github_connector.py
+++ b/tools/github_connector.py
@@ -37,7 +37,11 @@ class GitHubConnector:
         try:
             github_token = secret_client.get_secret(token_secret_name).value
         except Exception:
-            print(f"AVISO: Segredo '{token_secret_name}' não encontrado. Usando token padrão.")
+            print(f"AVISO: Segredo '{token_secret_name}' não encontrado. Tentando usar token padrão 'github-token'.")
+            try:
+                github_token = secret_client.get_secret("github-token").value
+            except Exception as e:
+                raise ValueError(f"ERRO CRÍTICO: Nenhum token do GitHub encontrado no Key Vault. Verifique se existe '{token_secret_name}' ou 'github-token'. Erro: {e}")
 
         auth = Auth.Token(github_token)
         new_client = Github(auth=auth)
@@ -92,7 +96,7 @@ class GitHubConnector:
                     auto_init=True
                 )
                 print(f"SUCESSO: Repositório '{repositorio}' criado na conta do usuário.")
-            except GithubException as create_error:
+            except Exception as create_error:
                 print(f"ERRO CRÍTICO: Falha ao criar o repositório '{repositorio}'. Verifique as permissões do token. Erro: {create_error}")
                 raise
         


### PR DESCRIPTION
Este PR corrige um erro crítico de UnboundLocalError causado pela ausência de fallback para o token padrão 'github-token' quando o token específico da organização não é encontrado no Azure Key Vault. Agora, o GitHubConnector tenta buscar o token padrão e lança erro claro se nenhum token for encontrado. Esta correção é fundamental para garantir a autenticação correta e evitar falhas na criação ou acesso a repositórios. prioridade_de_revisao: CRÍTICA, ordem_de_merge_sugerida: 3, revisores_sugeridos: Engenheiro de DevOps/SRE, Desenvolvedor Sênior (Backend), Engenheiro de QA