### PR TITLE
Refatoração para suporte extensível a múltiplos provedores de repositório via injeção de dependência

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -21,7 +21,9 @@ from tools.requisicao_claude import AnthropicClaudeProvider
 from tools.rag_retriever import AzureAISearchRAGRetriever
 from tools.preenchimento import ChangesetFiller
 from tools.github_reader import GitHubRepositoryReader
+from tools.github_repository_provider import GitHubRepositoryProvider
 from domain.interfaces.llm_provider_interface import ILLMProvider
+from domain.interfaces.repository_provider_interface import IRepositoryProvider
 
 # --- WORKFLOW_REGISTRY ---
 def load_workflow_registry(filepath: str) -> dict:
@@ -41,6 +43,7 @@ class StartAnalysisPayload(BaseModel):
     usar_rag: bool = Field(False)
     gerar_relatorio_apenas: bool = Field(False)
     model_name: Optional[str] = Field(None, description="Nome do modelo de LLM a ser usado. Se nulo, usa o padrão.")
+    analysis_name: Optional[str] = Field(None, description="Nome personalizado para identificar esta análise.")
 
 class StartAnalysisResponse(BaseModel):
     job_id: str
@@ -62,19 +65,61 @@ class FinalStatusResponse(BaseModel):
     error_details: Optional[str] = Field(None)
     analysis_report: Optional[str] = Field(None)
     diagnostic_logs: Optional[Dict[str, Any]] = Field(None)
+    analysis_name: Optional[str] = Field(None, description="Nome personalizado da análise, se fornecido.")
 
 class ReportResponse(BaseModel):
     job_id: str
     analysis_report: Optional[str]
+    analysis_name: Optional[str] = Field(None, description="Nome personalizado da análise, se fornecido.")
+
+class AnalysisByNameResponse(BaseModel):
+    job_id: str
+    analysis_name: str
+    analysis_report: Optional[str]
+    status: str
 
 # --- Configuração do Servidor FastAPI ---
 app = FastAPI(
     title="MCP Server - Multi-Agent Code Platform",
-    description="Servidor robusto com Redis para orquestrar agentes de IA.",
-    version="9.0.0" 
+    description="Servidor robusto com Redis para orquestrar agentes de IA com suporte extensível a múltiplos provedores de repositório.",
+    version="10.0.0" 
 )
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
 job_store = RedisJobStore()
+
+# --- Mapeamento de análises por nome ---
+# Este dicionário mapeia nomes de análise para job_ids para permitir busca por nome
+analysis_name_to_job_id = {}
+
+def get_repository_provider() -> IRepositoryProvider:
+    """
+    Factory function para obter o provedor de repositório configurado.
+    
+    Esta função centraliza a lógica de seleção do provedor de repositório,
+    permitindo fácil extensão para múltiplos provedores no futuro.
+    Por enquanto, retorna sempre GitHubRepositoryProvider, mas pode ser
+    estendida para ler configuração de ambiente ou payload da requisição.
+    
+    Returns:
+        IRepositoryProvider: Instância do provedor de repositório configurado
+    
+    Note:
+        Futuras implementações podem incluir:
+        - Leitura de variável de ambiente REPOSITORY_PROVIDER
+        - Seleção baseada no formato do repo_name
+        - Configuração via payload da requisição
+    
+    Example:
+        # Implementação futura:
+        # provider_type = os.getenv("REPOSITORY_PROVIDER", "github").lower()
+        # if provider_type == "gitlab":
+        #     return GitLabRepositoryProvider()
+        # elif provider_type == "bitbucket":
+        #     return BitbucketRepositoryProvider()
+        # else:
+        #     return GitHubRepositoryProvider()
+    """
+    return GitHubRepositoryProvider()
 
 def create_llm_provider(model_name: Optional[str], rag_retriever: AzureAISearchRAGRetriever) -> ILLMProvider:
     """
@@ -125,12 +170,15 @@ def run_report_generation_task(job_id: str, payload: StartAnalysisPayload):
         model_para_etapa = first_step.get('model_name', payload.model_name)
         llm_provider = create_llm_provider(model_para_etapa, rag_retriever)
         
+        # Obtém o provedor de repositório configurado
+        repository_provider = get_repository_provider()
+        
         agent_type = first_step.get("agent_type")
         params_base = first_step.get('params', {}).copy()
 
         # --- LÓGICA DE CHAMADA FINAL E CORRIGIDA ---
         if agent_type == "revisor":
-            repo_reader = GitHubRepositoryReader()
+            repo_reader = GitHubRepositoryReader(repository_provider=repository_provider)
             agente = AgenteRevisor(repository_reader=repo_reader, llm_provider=llm_provider)
             
             # Chama o AgenteRevisor com os parâmetros que ele espera
@@ -167,7 +215,7 @@ def run_report_generation_task(job_id: str, payload: StartAnalysisPayload):
             raise ValueError("A resposta da IA veio vazia.")
         
         # 1. Analisa o JSON que a IA retornou.
-        parsed_response = json.loads(json_string_from_llm.replace("```json", "").replace("```", "").strip())
+        parsed_response = json.loads(json_string_from_llm.replace("", "").replace("", "").strip())
         
         # 2. Pega o valor da ÚNICA chave que esperamos: "relatorio".
         #    Se a chave não existir, usa a resposta bruta como um fallback seguro.
@@ -208,7 +256,10 @@ def run_workflow_task(job_id: str):
         # Constrói as dependências genéricas
         rag_retriever = AzureAISearchRAGRetriever()
         changeset_filler = ChangesetFiller()
-        repo_reader = GitHubRepositoryReader()
+        
+        # Obtém o provedor de repositório configurado
+        repository_provider = get_repository_provider()
+        repo_reader = GitHubRepositoryReader(repository_provider=repository_provider)
 
         workflow = WORKFLOW_REGISTRY.get(job_info['data']['original_analysis_type'])
         if not workflow: raise ValueError("Workflow não encontrado.")
@@ -257,7 +308,7 @@ def run_workflow_task(job_id: str):
             json_string = agent_response['resultado']['reposta_final'].get('reposta_final', '')
             if not json_string.strip(): raise ValueError(f"IA retornou resposta vazia na etapa '{job_info['status']}'.")
             
-            current_step_result = json.loads(json_string.replace("```json", "").replace("```", "").strip())
+            current_step_result = json.loads(json_string.replace("", "").replace("", "").strip())
             
             # 3. Armazena os resultados corretamente
             if i == 0:
@@ -294,10 +345,12 @@ def run_workflow_task(job_id: str):
         job_store.set_job(job_id, job_info)
         branch_base_para_pr = job_info['data'].get('branch_name', 'main')
         
+        # Passa o provedor de repositório para o commit
         commit_results = commit_multiplas_branchs.processar_e_subir_mudancas_agrupadas(
             nome_repo=job_info['data']['repo_name'], 
             dados_agrupados=dados_finais_formatados,
-            base_branch=branch_base_para_pr
+            base_branch=branch_base_para_pr,
+            repository_provider=repository_provider
         )
         job_info['data']['commit_details'] = commit_results
 
@@ -321,12 +374,19 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
             'branch_name': payload.branch_name,
             'original_analysis_type': analysis_type_str,
             'instrucoes_extras': payload.instrucoes_extras,
-            'model_name': payload.model_name # Salva o modelo escolhido para uso futuro
+            'model_name': payload.model_name, # Salva o modelo escolhido para uso futuro
+            'analysis_name': payload.analysis_name  # Salva o nome personalizado
         },
         'error_details': None
     }
     
     job_store.set_job(job_id, initial_job_data)
+    
+    # Se um nome de análise foi fornecido, mapeia para o job_id
+    if payload.analysis_name:
+        analysis_name_to_job_id[payload.analysis_name] = job_id
+        print(f"Análise '{payload.analysis_name}' mapeada para job_id: {job_id}")
+    
     background_tasks.add_task(run_report_generation_task, job_id, payload)
     return StartAnalysisResponse(job_id=job_id)
 
@@ -355,8 +415,6 @@ def update_job_status(payload: UpdateJobPayload, background_tasks: BackgroundTas
         job_store.set_job(payload.job_id, job)
         return {"job_id": payload.job_id, "status": "rejected", "message": "Processo encerrado."}
 
-# Em mcp_server_fastapi.py
-
 @app.get("/jobs/{job_id}/report", response_model=ReportResponse, tags=["Jobs"])
 def get_job_report(job_id: str = Path(..., title="O ID do Job para buscar o relatório")):
     job = job_store.get_job(job_id)
@@ -367,7 +425,91 @@ def get_job_report(job_id: str = Path(..., title="O ID do Job para buscar o rela
     if not report:
         raise HTTPException(status_code=404, detail=f"Relatório não encontrado para este job. Status: {job.get('status')}")
 
-    return ReportResponse(job_id=job_id, analysis_report=report)
+    analysis_name = job.get("data", {}).get("analysis_name")
+    return ReportResponse(job_id=job_id, analysis_report=report, analysis_name=analysis_name)
+
+@app.get("/analyses/by-name/{analysis_name}", response_model=AnalysisByNameResponse, tags=["Jobs"])
+def get_analysis_by_name(analysis_name: str = Path(..., title="Nome da análise para buscar")):
+    """
+    Busca uma análise pelo nome personalizado fornecido durante a criação.
+    
+    Este endpoint permite que usuários recuperem análises usando nomes
+    amigáveis em vez de job_ids, facilitando a organização e recuperação
+    de análises específicas.
+    """
+    job_id = analysis_name_to_job_id.get(analysis_name)
+    if not job_id:
+        raise HTTPException(status_code=404, detail=f"Análise com nome '{analysis_name}' não encontrada")
+    
+    job = job_store.get_job(job_id)
+    if not job:
+        # Remove mapeamento inválido
+        analysis_name_to_job_id.pop(analysis_name, None)
+        raise HTTPException(status_code=404, detail=f"Job associado à análise '{analysis_name}' não encontrado ou expirado")
+    
+    analysis_report = job.get("data", {}).get("analysis_report")
+    status = job.get("status", "unknown")
+    
+    return AnalysisByNameResponse(
+        job_id=job_id,
+        analysis_name=analysis_name,
+        analysis_report=analysis_report,
+        status=status
+    )
+
+@app.post("/start-code-generation-from-report/{analysis_name}", response_model=StartAnalysisResponse, tags=["Jobs"])
+def start_code_generation_from_report(analysis_name: str, background_tasks: BackgroundTasks):
+    """
+    Inicia geração de código baseada em um relatório de análise existente.
+    
+    Este endpoint permite que usuários aprovem um relatório de análise
+    e iniciem automaticamente a geração de código correspondente,
+    implementando um workflow de duas etapas: análise → aprovação → implementação.
+    """
+    # Busca o job original pelo nome da análise
+    original_job_id = analysis_name_to_job_id.get(analysis_name)
+    if not original_job_id:
+        raise HTTPException(status_code=404, detail=f"Análise com nome '{analysis_name}' não encontrada")
+    
+    original_job = job_store.get_job(original_job_id)
+    if not original_job:
+        raise HTTPException(status_code=404, detail=f"Job original da análise '{analysis_name}' não encontrado ou expirado")
+    
+    # Verifica se o job original tem um relatório disponível
+    analysis_report = original_job.get("data", {}).get("analysis_report")
+    if not analysis_report:
+        raise HTTPException(status_code=400, detail=f"Relatório não disponível para a análise '{analysis_name}'")
+    
+    # Cria novo job para geração de código
+    new_job_id = str(uuid.uuid4())
+    original_data = original_job.get("data", {})
+    
+    new_job_data = {
+        'status': 'workflow_started',
+        'data': {
+            'repo_name': original_data.get('repo_name'),
+            'branch_name': original_data.get('branch_name'),
+            'original_analysis_type': original_data.get('original_analysis_type'),
+            'instrucoes_extras': original_data.get('instrucoes_extras'),
+            'model_name': original_data.get('model_name'),
+            'analysis_name': f"{analysis_name}-codegen",
+            'analysis_report': analysis_report,
+            'step_0_result': original_job.get('data', {}).get('step_0_result', {}),
+            'usar_rag': original_data.get('usar_rag', False)
+        },
+        'error_details': None
+    }
+    
+    job_store.set_job(new_job_id, new_job_data)
+    
+    # Mapeia o novo nome para o novo job_id
+    codegen_analysis_name = f"{analysis_name}-codegen"
+    analysis_name_to_job_id[codegen_analysis_name] = new_job_id
+    
+    # Inicia o workflow de geração de código
+    background_tasks.add_task(run_workflow_task, new_job_id)
+    
+    return StartAnalysisResponse(job_id=new_job_id)
 
 @app.get("/status/{job_id}", response_model=FinalStatusResponse, tags=["Jobs"])
 def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
@@ -377,6 +519,7 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
 
     status = job.get('status')
     logs = job.get("data", {}).get("diagnostic_logs")
+    analysis_name = job.get("data", {}).get("analysis_name")
 
     try:
         if status == 'completed':
@@ -384,7 +527,8 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
                 return FinalStatusResponse(
                     job_id=job_id,
                     status=status,
-                    analysis_report=job.get("data", {}).get("analysis_report")
+                    analysis_report=job.get("data", {}).get("analysis_report"),
+                    analysis_name=analysis_name
                 )
             else:
                 summary_list = []
@@ -402,40 +546,24 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
                     job_id=job_id, 
                     status=status, 
                     summary=summary_list,
-                    diagnostic_logs=logs
+                    diagnostic_logs=logs,
+                    analysis_name=analysis_name
                 )
         elif status == 'failed':
             return FinalStatusResponse(
                 job_id=job_id,
                 status=status,
                 error_details=job.get("error_details", "Nenhum detalhe de erro encontrado."),
-                diagnostic_logs=logs
+                diagnostic_logs=logs,
+                analysis_name=analysis_name
             )
         else:
-            return FinalStatusResponse(job_id=job_id, status=status)
+            return FinalStatusResponse(
+                job_id=job_id, 
+                status=status, 
+                analysis_name=analysis_name
+            )
     except ValidationError as e:
         print(f"ERRO CRÍTICO de Validação no Job ID {job_id}: {e}")
         print(f"Dados brutos do job que causaram o erro: {job}")
         raise HTTPException(status_code=500, detail="Erro interno ao formatar a resposta do status do job.")
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Este PR implementa uma refatoração arquitetural que torna o sistema agnóstico ao provedor de repositório específico, permitindo a integração com GitHub, GitLab, Bitbucket e futuros provedores através da injeção de dependência do IRepositoryProvider. Inclui adaptações em ferramentas de conexão, leitura e commit, além da introdução de uma fábrica para seleção do provedor de repositório. Também adiciona suporte a nomes personalizados de análise e endpoints para busca e geração de código baseados em relatórios existentes. Esta mudança é fundamental para a extensibilidade e manutenção futura do sistema. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Arquiteto de Software, Engenheiro de QA