### PR TITLE
Refatora GitHubRepositoryReader para suporte multi-provedor com detecção automática

### DIFF
--- a/.github/workflows/pr_grupo_1_suporte_multi_provedor_github_reader_poc-agent-revisor(staging-agent-revisor).yml
+++ b/.github/workflows/pr_grupo_1_suporte_multi_provedor_github_reader_poc-agent-revisor(staging-agent-revisor).yml
@@ -1,0 +1,71 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+# More info on Python, GitHub Actions, and Azure App Service: https://aka.ms/python-webapps-actions
+
+name: Build and deploy Python app to Azure Web App - poc-agent-revisor
+
+on:
+  push:
+    branches:
+      - pr_grupo_1_suporte_multi_provedor_github_reader
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read #This is required for actions/checkout
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python version
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Create and start virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+      
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        
+      # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
+
+      - name: Upload artifact for deployment jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-app
+          path: |
+            .
+            !venv/
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write #This is required for requesting the JWT
+      contents: read #This is required for actions/checkout
+
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: python-app
+      
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_86E6D3E4889B419789A18C595DFF358C }}
+          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_2482CAC414C244FFAD954449D9CCBA7F }}
+          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_A70DB1D442CF4772BBF9972311609C36 }}
+
+      - name: 'Deploy to Azure Web App'
+        uses: azure/webapps-deploy@v3
+        id: deploy-to-webapp
+        with:
+          app-name: 'poc-agent-revisor'
+          slot-name: 'staging-agent-revisor'
+          

--- a/agents/agente_processador.py
+++ b/agents/agente_processador.py
@@ -144,8 +144,8 @@ class AgenteProcessador:
             ValueError: Se tipo_analise for inválido ou codigo estiver vazio,
                 ou se o provedor retornar dados inválidos
             RuntimeError: Se houver falha na comunicação com o provedor de LLM
-            json.JSONEncodeError: Se os dados de entrada não forem serializáveis
-            TypeError: Se o retorno do provedor não for do tipo esperado
+            TypeError: Se os dados de entrada não forem serializáveis
+                ou se o retorno do provedor não for do tipo esperado
         
         Note:
             - Os parâmetros repositorio e nome_branch são ignorados intencionalmente
@@ -164,10 +164,8 @@ class AgenteProcessador:
             # Serializa os dados de entrada em formato JSON legível para o LLM
             codigo_str = json.dumps(codigo, indent=2, ensure_ascii=False)
         except (TypeError, ValueError) as e:
-            raise json.JSONEncodeError(
-                f"Erro ao serializar dados de entrada: {e}", 
-                doc=str(codigo), 
-                pos=0
+            raise TypeError(
+                f"Erro ao serializar dados de entrada: {e}"
             ) from e
 
         try:

--- a/agents/agente_processador.py
+++ b/agents/agente_processador.py
@@ -16,6 +16,7 @@ class AgenteProcessador:
     - Ignora parâmetros de repositório (repositorio, nome_branch)
     - Foca na transformação de dados através de IA
     - Mantém interface consistente com outros agentes do sistema
+    - Tratamento robusto de retornos do provedor LLM
     
     Attributes:
         llm_provider (ILLMProvider): Provedor de LLM injetado para processamento
@@ -42,7 +43,59 @@ class AgenteProcessador:
         Raises:
             TypeError: Se llm_provider não implementar ILLMProvider
         """
+        if not hasattr(llm_provider, 'executar_prompt'):
+            raise TypeError("llm_provider deve implementar ILLMProvider com método executar_prompt")
         self.llm_provider = llm_provider
+
+    def _validar_e_extrair_resposta(self, resultado_llm: Any) -> str:
+        """
+        Valida e extrai a resposta final do retorno do provedor LLM.
+        
+        Este método garante compatibilidade com diferentes implementações de ILLMProvider,
+        tratando tanto retornos diretos (string) quanto estruturados (dict).
+        
+        Args:
+            resultado_llm (Any): Retorno do método executar_prompt do provedor
+            
+        Returns:
+            str: Resposta final extraída e validada
+            
+        Raises:
+            ValueError: Se o retorno não contiver dados válidos
+            TypeError: Se o retorno não for do tipo esperado
+        """
+        # Caso 1: Retorno direto como string
+        if isinstance(resultado_llm, str):
+            if not resultado_llm.strip():
+                raise ValueError("Provedor LLM retornou string vazia")
+            return resultado_llm.strip()
+        
+        # Caso 2: Retorno estruturado como dict (conforme interface ILLMProvider)
+        if isinstance(resultado_llm, dict):
+            # Verifica se contém a chave obrigatória 'reposta_final'
+            if 'reposta_final' not in resultado_llm:
+                raise ValueError(
+                    "Retorno do provedor LLM não contém chave obrigatória 'reposta_final'. "
+                    f"Chaves disponíveis: {list(resultado_llm.keys())}"
+                )
+            
+            resposta_final = resultado_llm['reposta_final']
+            
+            # Valida se a resposta final é uma string não vazia
+            if not isinstance(resposta_final, str):
+                raise TypeError(
+                    f"Chave 'reposta_final' deve ser string, recebido: {type(resposta_final).__name__}"
+                )
+            
+            if not resposta_final.strip():
+                raise ValueError("Chave 'reposta_final' contém string vazia")
+            
+            return resposta_final.strip()
+        
+        # Caso 3: Tipo não suportado
+        raise TypeError(
+            f"Retorno do provedor LLM deve ser string ou dict, recebido: {type(resultado_llm).__name__}"
+        )
 
     def main(
         self,
@@ -61,7 +114,8 @@ class AgenteProcessador:
         Este método é a função principal do agente, responsável por:
         1. Serializar os dados JSON de entrada
         2. Enviar para o provedor de LLM com as configurações especificadas
-        3. Retornar o resultado estruturado
+        3. Validar e extrair a resposta do provedor
+        4. Retornar o resultado estruturado
         
         Args:
             tipo_analise (str): Tipo de análise a ser executada (ex: 'refatoracao', 
@@ -87,31 +141,57 @@ class AgenteProcessador:
                 - Estrutura: {"resultado": {"reposta_final": <resposta_do_llm>}}
         
         Raises:
-            ValueError: Se tipo_analise for inválido ou codigo estiver vazio
+            ValueError: Se tipo_analise for inválido ou codigo estiver vazio,
+                ou se o provedor retornar dados inválidos
             RuntimeError: Se houver falha na comunicação com o provedor de LLM
             json.JSONEncodeError: Se os dados de entrada não forem serializáveis
+            TypeError: Se o retorno do provedor não for do tipo esperado
         
         Note:
             - Os parâmetros repositorio e nome_branch são ignorados intencionalmente
             - O código de entrada é serializado em JSON com formatação legível
             - Instruções extras são passadas diretamente ao provedor de LLM
+            - Validação robusta do retorno do provedor garante compatibilidade
         """
-        # Serializa os dados de entrada em formato JSON legível para o LLM
-        codigo_str = json.dumps(codigo, indent=2, ensure_ascii=False)
+        # Validação de entrada
+        if not tipo_analise or not isinstance(tipo_analise, str):
+            raise ValueError("tipo_analise deve ser uma string não vazia")
+        
+        if not codigo or not isinstance(codigo, dict):
+            raise ValueError("codigo deve ser um dicionário não vazio")
+        
+        try:
+            # Serializa os dados de entrada em formato JSON legível para o LLM
+            codigo_str = json.dumps(codigo, indent=2, ensure_ascii=False)
+        except (TypeError, ValueError) as e:
+            raise json.JSONEncodeError(
+                f"Erro ao serializar dados de entrada: {e}", 
+                doc=str(codigo), 
+                pos=0
+            ) from e
 
-        # Delega o processamento para o provedor de LLM injetado
-        resultado_da_ia = self.llm_provider.executar_prompt(
-            tipo_tarefa=tipo_analise,
-            prompt_principal=codigo_str,
-            instrucoes_extras=instrucoes_extras,
-            usar_rag=usar_rag,
-            model_name=model_name,
-            max_token_out=max_token_out
-        )
+        try:
+            # Delega o processamento para o provedor de LLM injetado
+            resultado_da_ia = self.llm_provider.executar_prompt(
+                tipo_tarefa=tipo_analise,
+                prompt_principal=codigo_str,
+                instrucoes_extras=instrucoes_extras,
+                usar_rag=usar_rag,
+                model_name=model_name,
+                max_token_out=max_token_out
+            )
+        except Exception as e:
+            raise RuntimeError(f"Falha na comunicação com o provedor de LLM: {e}") from e
+
+        # Valida e extrai a resposta final do provedor
+        try:
+            resposta_final_validada = self._validar_e_extrair_resposta(resultado_da_ia)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Retorno inválido do provedor LLM: {e}") from e
 
         # Retorna resultado em formato padronizado esperado pelo sistema
         return {
             "resultado": {
-                "reposta_final": resultado_da_ia
+                "reposta_final": resposta_final_validada
             }
         }

--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -6,8 +6,8 @@ from domain.interfaces.llm_provider_interface import ILLMProvider
 from tools.repository_provider_factory import get_repository_provider
 from tools.github_reader import GitHubRepositoryReader
 
-TAMANHO_LOTE = 5
-ATRASO_ENTRE_LOTES_SEGUNDOS = 45
+TAMANHO_LOTE = 10
+ATRASO_ENTRE_LOTES_SEGUNDOS = 60
 
 class AgenteRevisor:
     """

--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -1,4 +1,5 @@
 import json
+import time
 from typing import Optional, Dict, Generator, Any, List
 from domain.interfaces.repository_reader_interface import IRepositoryReader
 from domain.interfaces.llm_provider_interface import ILLMProvider

--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Generator, Any, List
 from domain.interfaces.repository_reader_interface import IRepositoryReader
 from domain.interfaces.llm_provider_interface import ILLMProvider
 from tools.repository_provider_factory import get_repository_provider

--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -6,7 +6,7 @@ from domain.interfaces.llm_provider_interface import ILLMProvider
 from tools.repository_provider_factory import get_repository_provider
 from tools.github_reader import GitHubRepositoryReader
 
-TAMANHO_LOTE = 10
+TAMANHO_LOTE = 5
 ATRASO_ENTRE_LOTES_SEGUNDOS = 60
 
 class AgenteRevisor:

--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -91,17 +91,19 @@ def create_llm_provider(model_name: Optional[str], rag_retriever: AzureAISearchR
 
 
 # --- Funções de Tarefa (Tasks) ---
-def handle_task_exception(job_id: str, e: Exception, step: str):
+def handle_task_exception(job_id: str, e: Exception, step: str, job_info: Optional[Dict] = None):
     error_message = f"Erro fatal durante a etapa '{step}': {str(e)}"
     print(f"[{job_id}] {error_message}")
     try:
-        job_info = job_store.get_job(job_id)
-        if job_info:
-            job_info['status'] = 'failed'
-            job_info['error_details'] = error_message
-            job_store.set_job(job_id, job_info)
+        # Usa o job_info passado para evitar uma nova leitura do Redis se já o tivermos
+        current_job_info = job_info or job_store.get_job(job_id)
+        if current_job_info:
+            current_job_info['status'] = 'failed'
+            current_job_info['error_details'] = error_message
+            job_store.set_job(job_id, current_job_info)
     except Exception as redis_e:
         print(f"[{job_id}] ERRO CRÍTICO ADICIONAL: Falha ao registrar o erro no Redis. Erro: {redis_e}")
+
 
 def run_workflow_task(job_id: str, start_from_step: int = 0):
     """
@@ -371,6 +373,7 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
         print(f"ERRO CRÍTICO de Validação no Job ID {job_id}: {e}")
         print(f"Dados brutos do job que causaram o erro: {job}")
         raise HTTPException(status_code=500, detail="Erro interno ao formatar a resposta do status do job.")
+
 
 
 

--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -171,8 +171,9 @@ def run_workflow_task(job_id: str, start_from_step: int = 0):
             else:
                 raise ValueError(f"Tipo de agente desconhecido '{agent_type}'.")
 
-            provider_response = agent_response.get("resultado", {})
+            provider_response = agent_response.get("resultado", {}).get("reposta_final", {})
             json_string = provider_response.get("reposta_final", "")
+            
             if not json_string.strip(): raise ValueError(f"IA retornou resposta vazia.")
             
             current_step_result = json.loads(json_string.replace("```json", "").replace("```", "").strip())
@@ -374,6 +375,7 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
         print(f"ERRO CRÍTICO de Validação no Job ID {job_id}: {e}")
         print(f"Dados brutos do job que causaram o erro: {job}")
         raise HTTPException(status_code=500, detail="Erro interno ao formatar a resposta do status do job.")
+
 
 
 

--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -171,7 +171,8 @@ def run_workflow_task(job_id: str, start_from_step: int = 0):
             else:
                 raise ValueError(f"Tipo de agente desconhecido '{agent_type}'.")
 
-            json_string = agent_response['resultado']['reposta_final'].get('reposta_final', '')
+            provider_response = agent_response.get("resultado", {})
+            json_string = provider_response.get("reposta_final", "")
             if not json_string.strip(): raise ValueError(f"IA retornou resposta vazia.")
             
             current_step_result = json.loads(json_string.replace("```json", "").replace("```", "").strip())
@@ -373,6 +374,7 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
         print(f"ERRO CRÍTICO de Validação no Job ID {job_id}: {e}")
         print(f"Dados brutos do job que causaram o erro: {job}")
         raise HTTPException(status_code=500, detail="Erro interno ao formatar a resposta do status do job.")
+
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ azure-core==1.35.0
 azure-search-documents==11.4.0
 
 # Ferramentas e Utilitários
+python-gitlab==6.3.0
 PyGithub==2.7.0
 redis==6.4.0
 pathspec>=0.12.0

--- a/tools/preenchimento.py
+++ b/tools/preenchimento.py
@@ -28,10 +28,11 @@ class ChangesetFiller(IChangesetFiller):
         contenha todas as informações necessárias para commit (conteúdo, status, etc.).
         
         Fluxo do processamento:
-        1. Cria mapa de mudanças originais indexado por caminho do arquivo
-        2. Para cada grupo no JSON agrupado, localiza os dados completos no JSON inicial
-        3. Reconstitui o conjunto de mudanças com dados completos
-        4. Preserva justificativas específicas do agrupamento quando disponíveis
+        1. Valida rigorosamente os dados de entrada
+        2. Cria mapa de mudanças originais indexado por caminho do arquivo
+        3. Para cada grupo no JSON agrupado, localiza os dados completos no JSON inicial
+        4. Reconstitui o conjunto de mudanças com dados completos
+        5. Preserva justificativas específicas do agrupamento quando disponíveis
         
         Args:
             json_agrupado (dict): Estrutura de agrupamento contendo:
@@ -48,50 +49,108 @@ class ChangesetFiller(IChangesetFiller):
                 estrutura do json_agrupado, mas com dados completos.
         
         Raises:
-            ValueError: Se json_inicial estiver vazio ou não contiver 'conjunto_de_mudancas'
-            KeyError: Se houver inconsistência entre os JSONs (arquivo no agrupado
-                mas não no inicial)
+            ValueError: Se json_inicial estiver vazio, não contiver 'conjunto_de_mudancas',
+                ou se json_agrupado for inválido
+            TypeError: Se os parâmetros não forem dicionários
         
         Note:
             - Arquivos sem conteúdo são ignorados (exceto status 'REMOVIDO')
             - Justificativas do agrupamento sobrescrevem as originais quando presentes
             - Fallback de 'codigo_novo' para 'conteudo' é aplicado automaticamente
+            - Validação rigorosa previne erros de integração em etapas posteriores
         """
         print("\n" + "="*50)
-        print("INICIANDO PROCESSO DE PREENCHIMENTO (ChangesetFiller v3.0 - Lógica Corrigida)")
+        print("INICIANDO PROCESSO DE PREENCHIMENTO (ChangesetFiller v4.0 - Com Validação Rigorosa)")
         print("="*50)
 
-        # Validação de entrada - garante que o JSON inicial seja válido
-        if not isinstance(json_inicial, dict) or not json_inicial.get('conjunto_de_mudancas'):
-            print("AVISO CRÍTICO: O JSON inicial (resultado_refatoracao) está vazio ou inválido.")
+        # VALIDAÇÃO CRÍTICA 1: Verificar tipos dos parâmetros
+        if not isinstance(json_inicial, dict):
+            raise TypeError(f"json_inicial deve ser um dicionário, recebido: {type(json_inicial).__name__}")
+        
+        if not isinstance(json_agrupado, dict):
+            raise TypeError(f"json_agrupado deve ser um dicionário, recebido: {type(json_agrupado).__name__}")
+        
+        # VALIDAÇÃO CRÍTICA 2: Verificar se json_inicial contém dados válidos
+        if not json_inicial:
+            raise ValueError("ERRO CRÍTICO: O JSON inicial (resultado_refatoracao) está vazio. Não é possível prosseguir sem dados de origem.")
+        
+        conjunto_mudancas_inicial = json_inicial.get('conjunto_de_mudancas')
+        if conjunto_mudancas_inicial is None:
+            raise ValueError("ERRO CRÍTICO: O JSON inicial não contém a chave obrigatória 'conjunto_de_mudancas'. Estrutura de dados inválida.")
+        
+        if not isinstance(conjunto_mudancas_inicial, list):
+            raise ValueError(f"ERRO CRÍTICO: A chave 'conjunto_de_mudancas' deve ser uma lista, encontrado: {type(conjunto_mudancas_inicial).__name__}")
+        
+        if not conjunto_mudancas_inicial:
+            raise ValueError("ERRO CRÍTICO: A lista 'conjunto_de_mudancas' no JSON inicial está vazia. Não há dados para processar.")
+        
+        # VALIDAÇÃO CRÍTICA 3: Verificar se json_agrupado contém dados válidos
+        if not json_agrupado:
+            print("AVISO: O JSON agrupado está vazio. Retornando estrutura vazia.")
             return {}
+        
+        print(f"Validação concluída: JSON inicial contém {len(conjunto_mudancas_inicial)} mudanças.")
+        print(f"JSON agrupado contém {len(json_agrupado)} grupos para processar.")
 
         # Cria mapa indexado por caminho do arquivo para acesso rápido aos dados originais
-        mapa_de_mudancas_originais = {
-            mudanca.get('caminho_do_arquivo'): mudanca
-            for mudanca in json_inicial.get('conjunto_de_mudancas', [])
-            if mudanca.get('caminho_do_arquivo')
-        }
-        print(f"Mapa de dados originais criado com {len(mapa_de_mudancas_originais)} arquivos.")
+        mapa_de_mudancas_originais = {}
+        mudancas_sem_caminho = 0
+        
+        for mudanca in conjunto_mudancas_inicial:
+            caminho = mudanca.get('caminho_do_arquivo')
+            if caminho:
+                mapa_de_mudancas_originais[caminho] = mudanca
+            else:
+                mudancas_sem_caminho += 1
+        
+        if mudancas_sem_caminho > 0:
+            print(f"AVISO: {mudancas_sem_caminho} mudanças no JSON inicial não possuem 'caminho_do_arquivo' e serão ignoradas.")
+        
+        print(f"Mapa de dados originais criado com {len(mapa_de_mudancas_originais)} arquivos válidos.")
 
         resultado_preenchido = {}
+        grupos_processados = 0
+        grupos_ignorados = 0
         
         # Processa cada grupo do JSON agrupado
         for nome_do_grupo, dados_do_grupo in json_agrupado.items():
             # Preserva resumo geral sem processamento
-            if not isinstance(dados_do_grupo, dict) or 'conjunto_de_mudancas' not in dados_do_grupo:
-                if nome_do_grupo == "resumo_geral":
-                    resultado_preenchido[nome_do_grupo] = dados_do_grupo
+            if nome_do_grupo == "resumo_geral":
+                resultado_preenchido[nome_do_grupo] = dados_do_grupo
+                continue
+            
+            # Valida estrutura do grupo
+            if not isinstance(dados_do_grupo, dict):
+                print(f"AVISO: Grupo '{nome_do_grupo}' não é um dicionário. Ignorando.")
+                grupos_ignorados += 1
+                continue
+            
+            if 'conjunto_de_mudancas' not in dados_do_grupo:
+                print(f"AVISO: Grupo '{nome_do_grupo}' não contém 'conjunto_de_mudancas'. Ignorando.")
+                grupos_ignorados += 1
                 continue
 
             print(f"\n--- Processando grupo: '{nome_do_grupo}' ---")
             conjunto_do_grupo_leve = dados_do_grupo.get('conjunto_de_mudancas', [])
+            
+            if not isinstance(conjunto_do_grupo_leve, list):
+                print(f"AVISO: 'conjunto_de_mudancas' do grupo '{nome_do_grupo}' não é uma lista. Ignorando grupo.")
+                grupos_ignorados += 1
+                continue
+            
             conjunto_preenchido = []
+            mudancas_processadas = 0
+            mudancas_ignoradas = 0
             
             # Para cada mudança no grupo, busca dados completos no mapa original
             for mudanca_leve in conjunto_do_grupo_leve:
+                if not isinstance(mudanca_leve, dict):
+                    mudancas_ignoradas += 1
+                    continue
+                
                 caminho_do_arquivo = mudanca_leve.get('caminho_do_arquivo')
                 if not caminho_do_arquivo:
+                    mudancas_ignoradas += 1
                     continue
                 
                 if caminho_do_arquivo in mapa_de_mudancas_originais:
@@ -111,17 +170,32 @@ class ChangesetFiller(IChangesetFiller):
                     if mudanca_completa.get("conteudo") is not None or mudanca_completa.get("status") == "REMOVIDO":
                         print(f"  [SUCESSO] Detalhes de '{caminho_do_arquivo}' preenchidos com sucesso.")
                         conjunto_preenchido.append(mudanca_completa)
+                        mudancas_processadas += 1
                     else:
                         print(f"  [AVISO] '{caminho_do_arquivo}' ignorado por falta de conteúdo no JSON INICIAL.")
+                        mudancas_ignoradas += 1
                 else:
                     print(f"  [ERRO] Detalhes para '{caminho_do_arquivo}' NÃO encontrados no JSON inicial. Ignorando.")
+                    mudancas_ignoradas += 1
 
             # Adiciona grupo ao resultado apenas se tiver mudanças válidas
             if conjunto_preenchido:
                 dados_do_grupo['conjunto_de_mudancas'] = conjunto_preenchido
                 resultado_preenchido[nome_do_grupo] = dados_do_grupo
+                grupos_processados += 1
+                print(f"Grupo '{nome_do_grupo}' processado: {mudancas_processadas} mudanças válidas, {mudancas_ignoradas} ignoradas.")
+            else:
+                print(f"AVISO: Grupo '{nome_do_grupo}' não contém mudanças válidas e será omitido do resultado.")
+                grupos_ignorados += 1
         
         print("\n" + "="*50)
-        print("PROCESSO DE PREENCHIMENTO CONCLUÍDO")
+        print("PROCESSO DE PREENCHIMENTO CONCLUÍDO COM VALIDAÇÃO RIGOROSA")
+        print(f"Grupos processados: {grupos_processados}")
+        print(f"Grupos ignorados: {grupos_ignorados}")
         print("="*50)
+        
+        # VALIDAÇÃO FINAL: Garantir que o resultado não está vazio se havia dados para processar
+        if not resultado_preenchido and json_agrupado:
+            print("AVISO CRÍTICO: Nenhum grupo foi processado com sucesso. Verifique a compatibilidade entre os JSONs.")
+        
         return resultado_preenchido


### PR DESCRIPTION
Este PR implementa a refatoração do GitHubRepositoryReader para suportar múltiplos provedores de repositório (GitHub, GitLab, Azure DevOps) por meio de detecção automática baseada no formato do nome do repositório. Foi adicionado o método _get_or_detect_provider que utiliza a factory get_repository_provider para determinar o provider correto quando nenhum é injetado. Essa mudança torna o leitor agnóstico ao provedor, permitindo uso transparente e otimizado com diferentes plataformas. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Arquiteto de Software