### PR TITLE
Corrige erro crítico de exceção incorreta na serialização JSON no agente_processador.py

### DIFF
--- a/agents/agente_processador.py
+++ b/agents/agente_processador.py
@@ -144,8 +144,8 @@ class AgenteProcessador:
             ValueError: Se tipo_analise for inválido ou codigo estiver vazio,
                 ou se o provedor retornar dados inválidos
             RuntimeError: Se houver falha na comunicação com o provedor de LLM
-            json.JSONEncodeError: Se os dados de entrada não forem serializáveis
-            TypeError: Se o retorno do provedor não for do tipo esperado
+            TypeError: Se os dados de entrada não forem serializáveis
+                ou se o retorno do provedor não for do tipo esperado
         
         Note:
             - Os parâmetros repositorio e nome_branch são ignorados intencionalmente
@@ -164,10 +164,8 @@ class AgenteProcessador:
             # Serializa os dados de entrada em formato JSON legível para o LLM
             codigo_str = json.dumps(codigo, indent=2, ensure_ascii=False)
         except (TypeError, ValueError) as e:
-            raise json.JSONEncodeError(
-                f"Erro ao serializar dados de entrada: {e}", 
-                doc=str(codigo), 
-                pos=0
+            raise TypeError(
+                f"Erro ao serializar dados de entrada: {e}"
             ) from e
 
         try:


### PR DESCRIPTION
Este PR corrige um erro crítico no arquivo agents/agente_processador.py onde a exceção json.JSONEncodeError, inexistente na biblioteca padrão Python, foi substituída por TypeError, que é a exceção correta para erros de serialização JSON. Essa correção evita falhas de execução (AttributeError) e garante a robustez do agente no processamento de dados JSON. Prioridade de revisão: CRÍTICA, ordem de merge sugerida: 1, revisores sugeridos: Desenvolvedor Sênior (Backend), Especialista em Python