### PR TITLE
Implementa filtro para leitura de arquivos específicos na interface e na implementação do leitor de repositórios

### DIFF
--- a/domain/interfaces/repository_reader_interface.py
+++ b/domain/interfaces/repository_reader_interface.py
@@ -1,11 +1,39 @@
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Dict, Optional, List
 
 class IRepositoryReader(ABC):
     """
     Interface para leitores de repositório de código-fonte.
+    
+    Esta interface define o contrato para leitura de repositórios,
+    suportando tanto leitura completa quanto leitura filtrada por
+    lista específica de arquivos.
     """
     @abstractmethod
-    def read_repository(self, nome_repo: str, tipo_analise: str, nome_branch: str = None) -> Dict[str, str]:
-        """Lê os arquivos do repositório e retorna um dicionário {caminho: conteudo}."""
+    def read_repository(
+        self, 
+        nome_repo: str, 
+        tipo_analise: str, 
+        nome_branch: str = None,
+        arquivos_especificos: Optional[List[str]] = None
+    ) -> Dict[str, str]:
+        """
+        Lê os arquivos do repositório e retorna um dicionário {caminho: conteudo}.
+        
+        Args:
+            nome_repo (str): Nome do repositório no formato 'org/repo'
+            tipo_analise (str): Tipo de análise que determina extensões relevantes
+            nome_branch (str, optional): Nome da branch. Se None, usa branch padrão
+            arquivos_especificos (Optional[List[str]], optional): Lista de caminhos
+                específicos de arquivos para ler. Se fornecido, ignora filtro por
+                extensão e lê apenas os arquivos listados. Defaults to None
+        
+        Returns:
+            Dict[str, str]: Dicionário mapeando caminhos de arquivo para conteúdo
+        
+        Note:
+            - Quando arquivos_especificos é fornecido, o filtro por extensão é ignorado
+            - Arquivos não encontrados são tratados com warning, não erro fatal
+            - Modo padrão (arquivos_especificos=None) mantém comportamento original
+        """
         pass


### PR DESCRIPTION
Este PR adiciona suporte à leitura filtrada por uma lista específica de arquivos no leitor de repositórios. A interface IRepositoryReader foi estendida com o parâmetro opcional 'arquivos_especificos' para permitir essa funcionalidade sem quebrar compatibilidade. A implementação GitHubRepositoryReader foi atualizada para suportar dois modos de leitura: leitura completa otimizada por extensão e leitura filtrada por arquivos específicos, conforme solicitado. Essa mudança melhora a flexibilidade e eficiência na leitura de repositórios, mantendo o comportamento original para casos sem filtro. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA