### PR TITLE
Implementa suporte à leitura filtrada de arquivos específicos no repositório

### DIFF
--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from domain.interfaces.repository_reader_interface import IRepositoryReader
 from domain.interfaces.llm_provider_interface import ILLMProvider
 
@@ -16,6 +16,7 @@ class AgenteRevisor:
     - Processamento de código via provedores de LLM
     - Tratamento robusto de erros de leitura de repositório
     - Suporte a diferentes tipos de análise configuráveis
+    - Suporte à leitura filtrada de arquivos específicos
     
     Attributes:
         repository_reader (IRepositoryReader): Interface para leitura de repositórios
@@ -30,7 +31,8 @@ class AgenteRevisor:
         >>> resultado = agente.main(
         ...     tipo_analise="refatoracao",
         ...     repositorio="org/projeto",
-        ...     nome_branch="main"
+        ...     nome_branch="main",
+        ...     arquivos_especificos=["src/main.py", "tests/test_main.py"]
         ... )
     """
     
@@ -58,20 +60,25 @@ class AgenteRevisor:
         self,
         repositorio: str,
         nome_branch: Optional[str],
-        tipo_analise: str
+        tipo_analise: str,
+        arquivos_especificos: Optional[List[str]] = None
     ) -> Dict[str, str]:
         """
         Obtém código-fonte de um repositório usando a interface injetada.
         
         Este método privado encapsula a lógica de leitura de repositório,
         fornecendo tratamento de erro consistente e logging para debugging.
+        Agora suporta leitura filtrada de arquivos específicos.
         
         Args:
             repositorio (str): Nome do repositório no formato 'org/repo'
             nome_branch (Optional[str]): Nome da branch a ser lida. Se None,
                 usa a branch padrão do repositório
             tipo_analise (str): Tipo de análise que determina quais arquivos
-                serão filtrados durante a leitura
+                serão filtrados durante a leitura (ignorado se arquivos_especificos fornecido)
+            arquivos_especificos (Optional[List[str]], optional): Lista de caminhos
+                específicos de arquivos para ler. Se fornecido, ignora filtro por
+                extensão e lê apenas os arquivos listados. Defaults to None
         
         Returns:
             Dict[str, str]: Dicionário mapeando caminhos de arquivo para seu conteúdo.
@@ -82,17 +89,23 @@ class AgenteRevisor:
                 a exceção original para contexto adicional
         
         Note:
-            - O tipo_analise é usado pelo repository_reader para filtrar arquivos relevantes
+            - Se arquivos_especificos for fornecido, o tipo_analise é usado apenas para logs
             - Logging é feito para facilitar debugging de problemas de conectividade
+            - Modo de leitura (completa vs filtrada) é determinado automaticamente
         """
         try:
-            print(f"Iniciando a leitura do repositório: {repositorio}, branch: {nome_branch}")
+            if arquivos_especificos and len(arquivos_especificos) > 0:
+                print(f"Iniciando a leitura filtrada do repositório: {repositorio}, branch: {nome_branch}")
+                print(f"Arquivos específicos solicitados: {len(arquivos_especificos)} arquivos")
+            else:
+                print(f"Iniciando a leitura completa do repositório: {repositorio}, branch: {nome_branch}")
             
-            # Delega a leitura para a implementação injetada
+            # Delega a leitura para a implementação injetada com suporte a arquivos específicos
             codigo_para_analise = self.repository_reader.read_repository(
                 nome_repo=repositorio,
                 tipo_analise=tipo_analise,
-                nome_branch=nome_branch
+                nome_branch=nome_branch,
+                arquivos_especificos=arquivos_especificos
             )
             
             return codigo_para_analise
@@ -109,7 +122,8 @@ class AgenteRevisor:
         instrucoes_extras: str = "",
         usar_rag: bool = False,
         model_name: Optional[str] = None,
-        max_token_out: int = 15000
+        max_token_out: int = 15000,
+        arquivos_especificos: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         """
         Orquestra a obtenção de código de repositório e análise via IA.
@@ -120,6 +134,8 @@ class AgenteRevisor:
         3. Serializa código em formato JSON
         4. Envia para análise via llm_provider
         5. Retorna resultado estruturado
+        
+        Agora suporta leitura filtrada de arquivos específicos quando solicitado.
         
         Args:
             tipo_analise (str): Tipo de análise a ser executada. Deve corresponder
@@ -135,6 +151,9 @@ class AgenteRevisor:
                 Se None, usa o modelo padrão do provedor. Defaults to None
             max_token_out (int, optional): Limite máximo de tokens na resposta
                 do LLM. Defaults to 15000
+            arquivos_especificos (Optional[List[str]], optional): Lista de caminhos
+                específicos de arquivos para ler. Se fornecido, ignora filtro por
+                extensão e lê apenas os arquivos listados. Defaults to None
         
         Returns:
             Dict[str, Any]: Resultado estruturado da análise contendo:
@@ -151,17 +170,22 @@ class AgenteRevisor:
             - Se nenhum código for encontrado, retorna resultado vazio sem erro
             - O código é serializado em JSON com formatação legível
             - Avisos são impressos para facilitar debugging
+            - Modo de leitura (completa vs filtrada) é determinado pelos parâmetros
         """
-        # Etapa 1: Obter código do repositório
+        # Etapa 1: Obter código do repositório (com suporte a leitura filtrada)
         codigo_para_analise = self._get_code(
             repositorio=repositorio,
             nome_branch=nome_branch,
-            tipo_analise=tipo_analise
+            tipo_analise=tipo_analise,
+            arquivos_especificos=arquivos_especificos
         )
 
         # Etapa 2: Validar se código foi encontrado
         if not codigo_para_analise:
-            print(f"AVISO: Nenhum código encontrado no repositório para a análise '{tipo_analise}'.")
+            if arquivos_especificos and len(arquivos_especificos) > 0:
+                print(f"AVISO: Nenhum dos arquivos específicos foi encontrado no repositório para a análise '{tipo_analise}'.")
+            else:
+                print(f"AVISO: Nenhum código encontrado no repositório para a análise '{tipo_analise}'.")
             return {"resultado": {"reposta_final": {}}}
 
         # Etapa 3: Serializar código em formato JSON legível

--- a/tools/github_reader.py
+++ b/tools/github_reader.py
@@ -12,12 +12,46 @@ import base64
 from typing import Dict, Optional, List
 
 class GitHubRepositoryReader(IRepositoryReader):
+    """
+    Leitor de repositórios GitHub com suporte a leitura filtrada de arquivos específicos.
+    
+    Esta classe implementa a interface IRepositoryReader e fornece funcionalidades
+    para leitura completa (por extensão) ou filtrada (arquivos específicos) de repositórios.
+    
+    Características principais:
+    - Leitura completa baseada em filtros de extensão por tipo de análise
+    - Leitura filtrada de arquivos específicos quando solicitado
+    - Suporte a múltiplos provedores de repositório via injeção de dependência
+    - Tratamento robusto de erros e arquivos não encontrados
+    - Logging detalhado para debugging
+    
+    Attributes:
+        repository_provider (IRepositoryProvider): Provedor de repositório injetado
+        _mapeamento_tipo_extensoes (Dict): Mapeamento de tipos de análise para extensões
+    """
     
     def __init__(self, repository_provider: Optional[IRepositoryProvider] = None):
+        """
+        Inicializa o leitor com provedor de repositório opcional.
+        
+        Args:
+            repository_provider (Optional[IRepositoryProvider], optional): Provedor
+                de repositório a ser usado. Se None, usa GitHubRepositoryProvider
+                como padrão. Defaults to None
+        """
         self.repository_provider = repository_provider or GitHubRepositoryProvider()
         self._mapeamento_tipo_extensoes = self._carregar_config_workflows()
 
     def _carregar_config_workflows(self):
+        """
+        Carrega configuração de workflows e cria mapeamento de tipos para extensões.
+        
+        Returns:
+            Dict: Mapeamento de tipos de análise (lowercase) para listas de extensões
+        
+        Raises:
+            Exception: Se houver falha ao carregar o arquivo workflows.yaml
+        """
         try:
             script_dir = os.path.dirname(__file__)
             project_root = os.path.abspath(os.path.join(script_dir, '..'))
@@ -52,6 +86,27 @@ class GitHubRepositoryReader(IRepositoryReader):
         branch_a_ler: str, 
         arquivos_especificos: List[str]
     ) -> Dict[str, str]:
+        """
+        Lê uma lista específica de arquivos do repositório.
+        
+        Este método implementa a leitura filtrada, processando apenas os arquivos
+        listados em arquivos_especificos. Arquivos não encontrados são tratados
+        com warning, não erro fatal.
+        
+        Args:
+            repositorio: Objeto repositório do provedor
+            branch_a_ler (str): Nome da branch a ser lida
+            arquivos_especificos (List[str]): Lista de caminhos de arquivos para ler
+        
+        Returns:
+            Dict[str, str]: Dicionário mapeando caminhos para conteúdo dos arquivos
+                encontrados e lidos com sucesso
+        
+        Note:
+            - Arquivos não encontrados geram warning, não erro fatal
+            - Falhas de leitura individual são tratadas graciosamente
+            - Progresso é logado a cada arquivo processado
+        """
         arquivos_lidos = {}
         total_arquivos = len(arquivos_especificos)
         
@@ -61,8 +116,10 @@ class GitHubRepositoryReader(IRepositoryReader):
             try:
                 print(f"  [{i+1}/{total_arquivos}] Lendo: {caminho_arquivo}")
                 
+                # Obtém conteúdo do arquivo específico
                 file_content = repositorio.get_contents(caminho_arquivo, ref=branch_a_ler)
                 
+                # Decodifica conteúdo base64
                 decoded_content = base64.b64decode(file_content.content).decode('utf-8')
                 arquivos_lidos[caminho_arquivo] = decoded_content
                 
@@ -81,6 +138,30 @@ class GitHubRepositoryReader(IRepositoryReader):
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None
     ) -> Dict[str, str]:
+        """
+        Lê os arquivos do repositório e retorna um dicionário {caminho: conteudo}.
+        
+        Este método implementa tanto leitura completa (filtrada por extensão)
+        quanto leitura filtrada (arquivos específicos). O modo é determinado
+        pela presença do parâmetro arquivos_especificos.
+        
+        Args:
+            nome_repo (str): Nome do repositório no formato 'org/repo'
+            tipo_analise (str): Tipo de análise que determina extensões relevantes
+                (ignorado se arquivos_especificos for fornecido)
+            nome_branch (str, optional): Nome da branch. Se None, usa branch padrão
+            arquivos_especificos (Optional[List[str]], optional): Lista de caminhos
+                específicos de arquivos para ler. Se fornecido, ignora filtro por
+                extensão e lê apenas os arquivos listados. Defaults to None
+        
+        Returns:
+            Dict[str, str]: Dicionário mapeando caminhos de arquivo para conteúdo
+        
+        Note:
+            - Quando arquivos_especificos é fornecido, o filtro por extensão é ignorado
+            - Arquivos não encontrados são tratados com warning, não erro fatal
+            - Modo padrão (arquivos_especificos=None) mantém comportamento original
+        """
         provider_name = type(self.repository_provider).__name__
         print(f"Iniciando leitura do repositório: {nome_repo} via {provider_name}")
 
@@ -93,6 +174,7 @@ class GitHubRepositoryReader(IRepositoryReader):
         else:
             branch_a_ler = nome_branch
         
+        # Determina modo de leitura baseado na presença de arquivos_especificos
         if arquivos_especificos and len(arquivos_especificos) > 0:
             print(f"Modo de leitura filtrada ativado para {len(arquivos_especificos)} arquivos específicos.")
             return self._ler_arquivos_especificos(repositorio, branch_a_ler, arquivos_especificos)
@@ -101,6 +183,24 @@ class GitHubRepositoryReader(IRepositoryReader):
             return self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise)
     
     def _ler_repositorio_completo(self, repositorio, branch_a_ler: str, tipo_analise: str) -> Dict[str, str]:
+        """
+        Implementa leitura completa do repositório filtrada por extensões.
+        
+        Este método mantém o comportamento original de leitura completa,
+        filtrando arquivos baseado nas extensões definidas para o tipo de análise.
+        
+        Args:
+            repositorio: Objeto repositório do provedor
+            branch_a_ler (str): Nome da branch a ser lida
+            tipo_analise (str): Tipo de análise para determinar extensões relevantes
+        
+        Returns:
+            Dict[str, str]: Dicionário mapeando caminhos para conteúdo dos arquivos
+        
+        Raises:
+            ValueError: Se tipo de análise não for encontrado ou não tiver extensões
+            GithubException: Se houver falha na comunicação com a API
+        """
         extensoes_alvo = self._mapeamento_tipo_extensoes.get(tipo_analise.lower())
         if extensoes_alvo is None:
             raise ValueError(f"Tipo de análise '{tipo_analise}' não encontrado ou não possui 'extensions' definidas em workflows.yaml")
@@ -122,6 +222,7 @@ class GitHubRepositoryReader(IRepositoryReader):
             if tree_response.truncated:
                 print(f"AVISO: A lista de arquivos do repositório '{nome_repo}' foi truncada pela API.")
 
+            # Filtra arquivos por extensão
             arquivos_para_ler = [
                 element for element in tree_elements
                 if element.type == 'blob' and any(element.path.endswith(ext) for ext in extensoes_alvo)
@@ -129,6 +230,7 @@ class GitHubRepositoryReader(IRepositoryReader):
             
             print(f"Filtragem concluída. {len(arquivos_para_ler)} arquivos com as extensões {extensoes_alvo} serão lidos.")
             
+            # Lê conteúdo de cada arquivo filtrado
             for i, element in enumerate(arquivos_para_ler):
                 if (i + 1) % 50 == 0:
                     print(f"  ...lendo arquivo {i + 1} de {len(arquivos_para_ler)} ({element.path})")


### PR DESCRIPTION
Este PR adiciona a funcionalidade de leitura filtrada de arquivos específicos no fluxo de análise de código. Inclui a extensão do modelo StartAnalysisPayload para aceitar uma lista de arquivos específicos, a propagação deste parâmetro pelo fluxo de jobs, e a adaptação do agente revisor para suportar essa leitura filtrada. Também implementa a lógica detalhada na classe GitHubRepositoryReader para leitura seletiva de arquivos, mantendo retrocompatibilidade com a leitura completa por extensão. Esta mudança é fundamental para permitir análises mais focadas e eficientes, mantendo a estabilidade do sistema. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA