### PR TITLE
Unifica o conector para suportar GitHub e GitLab com tipagem flexível

### DIFF
--- a/tools/github_connector.py
+++ b/tools/github_connector.py
@@ -1,76 +1,18 @@
 from github import Repository
-from typing import Dict
+from typing import Dict, Union
 from domain.interfaces.secret_manager_interface import ISecretManager
 from domain.interfaces.repository_provider_interface import IRepositoryProvider
 from tools.azure_secret_manager import AzureSecretManager
 from tools.github_repository_provider import GitHubRepositoryProvider
 
 class GitHubConnector:
-    """
-    Conector refatorado seguindo princípios SOLID para integração com repositórios.
-    
-    Esta classe orquestra a conexão com repositórios usando abstrações para
-    gerenciamento de segredos e provedores de repositório. Implementa cache de
-    conexões para otimizar performance e reduzir chamadas à API.
-    
-    IMPORTANTE: Esta classe agora é agnóstica ao provedor de repositório específico.
-    Aceita qualquer implementação de IRepositoryProvider (GitHub, GitLab, Bitbucket, etc.)
-    através de injeção de dependência, seguindo o mesmo padrão usado para LLMs.
-    
-    Responsabilidade única: gerenciar conexões com repositórios de forma eficiente
-    e segura, abstraindo a complexidade de autenticação e cache.
-    
-    Attributes:
-        _cached_repos (Dict[str, Repository]): Cache de repositórios conectados
-        secret_manager (ISecretManager): Gerenciador de segredos injetado
-        repository_provider (IRepositoryProvider): Provedor de repositório injetado
-    
-    Example:
-        >>> # Uso com GitHub (padrão)
-        >>> github_provider = GitHubRepositoryProvider()
-        >>> connector = GitHubConnector(repository_provider=github_provider)
-        >>> 
-        >>> # Uso futuro com GitLab
-        >>> # gitlab_provider = GitLabRepositoryProvider()
-        >>> # connector = GitHubConnector(repository_provider=gitlab_provider)
-    """
-    _cached_repos: Dict[str, Repository] = {}
+    _cached_repos: Dict[str, Union[Repository, object]] = {}
     
     def __init__(self, repository_provider: IRepositoryProvider, secret_manager: ISecretManager = None):
-        """
-        Inicializa o conector com dependências injetadas.
-        
-        Args:
-            repository_provider (IRepositoryProvider): Provedor de repositório a ser usado.
-                Deve implementar IRepositoryProvider (ex: GitHubRepositoryProvider,
-                GitLabRepositoryProvider, BitbucketRepositoryProvider)
-            secret_manager (ISecretManager, optional): Gerenciador de segredos.
-                Se None, usa AzureSecretManager como padrão
-        
-        Note:
-            O repository_provider é obrigatório para garantir explicitamente qual
-            provedor será usado, evitando dependências implícitas e facilitando testes.
-        """
         self.repository_provider = repository_provider
         self.secret_manager = secret_manager or AzureSecretManager()
     
     def _get_token_for_org(self, org_name: str) -> str:
-        """
-        Obtém o token de autenticação para uma organização específica.
-        
-        Implementa fallback para token padrão caso não encontre token específico
-        da organização, garantindo flexibilidade na configuração de tokens.
-        
-        Args:
-            org_name (str): Nome da organização
-            
-        Returns:
-            str: Token de autenticação válido para a organização
-            
-        Raises:
-            ValueError: Se nenhum token válido for encontrado (nem específico nem padrão)
-        """
-        # Determina o prefixo do token baseado no tipo de provedor
         provider_type = type(self.repository_provider).__name__.lower()
         if 'github' in provider_type:
             token_prefix = 'github-token'
@@ -79,7 +21,7 @@ class GitHubConnector:
         elif 'bitbucket' in provider_type:
             token_prefix = 'bitbucket-token'
         else:
-            token_prefix = 'repo-token'  # Fallback genérico
+            token_prefix = 'repo-token'
         
         token_secret_name = f"{token_prefix}-{org_name}"
         
@@ -92,66 +34,30 @@ class GitHubConnector:
             except ValueError as e:
                 raise ValueError(f"ERRO CRÍTICO: Nenhum token encontrado. Verifique se existe '{token_secret_name}' ou '{token_prefix}' no gerenciador de segredos.") from e
     
-    def connection(self, repositorio: str) -> Repository:
-        """
-        Obtém um objeto de repositório, criando-o se necessário.
-        
-        Implementa cache para evitar reconexões desnecessárias e melhora
-        a performance. Se o repositório não existir, tenta criá-lo automaticamente.
-        
-        Args:
-            repositorio (str): Nome do repositório no formato 'org/repo'
-            
-        Returns:
-            Repository: Objeto do repositório pronto para uso
-            
-        Raises:
-            ValueError: Se o formato do nome do repositório for inválido
-                ou se não conseguir obter/criar o repositório
-        """
-        # Verifica cache primeiro para otimizar performance
+    def connection(self, repositorio: str) -> Union[Repository, object]:
         if repositorio in self._cached_repos:
             print(f"Retornando o objeto do repositório '{repositorio}' do cache.")
             return self._cached_repos[repositorio]
         
-        # Valida formato do nome do repositório
         try:
             org_name, _ = repositorio.split('/')
         except ValueError:
             raise ValueError(f"O nome do repositório '{repositorio}' tem formato inválido. Esperado 'organizacao/repositorio'.")
         
-        # Obtém token de autenticação para a organização
         token = self._get_token_for_org(org_name)
         
         try:
-            # Tenta obter o repositório existente usando o provedor injetado
             print(f"Tentando acessar o repositório '{repositorio}' via {type(self.repository_provider).__name__}...")
             repo = self.repository_provider.get_repository(repositorio, token)
             print(f"Repositório '{repositorio}' encontrado com sucesso.")
         except ValueError:
-            # Se não encontrar, cria o repositório automaticamente
             print(f"AVISO: Repositório '{repositorio}' não encontrado. Tentando criá-lo...")
             repo = self.repository_provider.create_repository(repositorio, token)
             print(f"SUCESSO: Repositório '{repositorio}' criado.")
         
-        # Armazena no cache e retorna o repositório
         self._cached_repos[repositorio] = repo
         return repo
     
     @classmethod
     def create_with_defaults(cls) -> 'GitHubConnector':
-        """
-        Método de conveniência para criar uma instância com dependências padrão GitHub.
-        
-        Este método factory mantém compatibilidade com código existente que
-        não precisa de injeção de dependência customizada. Por padrão, usa GitHub.
-        
-        Returns:
-            GitHubConnector: Instância configurada com GitHubRepositoryProvider
-                e AzureSecretManager como dependências padrão
-        
-        Note:
-            Para usar outros provedores, instancie diretamente a classe:
-            GitHubConnector(repository_provider=seu_provedor)
-        """
         return cls(repository_provider=GitHubRepositoryProvider())

--- a/tools/github_reader.py
+++ b/tools/github_reader.py
@@ -1,5 +1,3 @@
-# Arquivo: tools/github_reader.py (VERSÃO FINAL E CORRIGIDA)
-
 import time
 import yaml
 import os
@@ -9,49 +7,15 @@ from domain.interfaces.repository_reader_interface import IRepositoryReader
 from domain.interfaces.repository_provider_interface import IRepositoryProvider
 from tools.github_repository_provider import GitHubRepositoryProvider
 import base64
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 
 class GitHubRepositoryReader(IRepositoryReader):
-    """
-    Leitor de repositórios GitHub com suporte a leitura filtrada de arquivos específicos.
-    
-    Esta classe implementa a interface IRepositoryReader e fornece funcionalidades
-    para leitura completa (por extensão) ou filtrada (arquivos específicos) de repositórios.
-    
-    Características principais:
-    - Leitura completa baseada em filtros de extensão por tipo de análise
-    - Leitura filtrada de arquivos específicos quando solicitado
-    - Suporte a múltiplos provedores de repositório via injeção de dependência
-    - Tratamento robusto de erros e arquivos não encontrados
-    - Logging detalhado para debugging
-    
-    Attributes:
-        repository_provider (IRepositoryProvider): Provedor de repositório injetado
-        _mapeamento_tipo_extensoes (Dict): Mapeamento de tipos de análise para extensões
-    """
     
     def __init__(self, repository_provider: Optional[IRepositoryProvider] = None):
-        """
-        Inicializa o leitor com provedor de repositório opcional.
-        
-        Args:
-            repository_provider (Optional[IRepositoryProvider], optional): Provedor
-                de repositório a ser usado. Se None, usa GitHubRepositoryProvider
-                como padrão. Defaults to None
-        """
         self.repository_provider = repository_provider or GitHubRepositoryProvider()
         self._mapeamento_tipo_extensoes = self._carregar_config_workflows()
 
     def _carregar_config_workflows(self):
-        """
-        Carrega configuração de workflows e cria mapeamento de tipos para extensões.
-        
-        Returns:
-            Dict: Mapeamento de tipos de análise (lowercase) para listas de extensões
-        
-        Raises:
-            Exception: Se houver falha ao carregar o arquivo workflows.yaml
-        """
         try:
             script_dir = os.path.dirname(__file__)
             project_root = os.path.abspath(os.path.join(script_dir, '..'))
@@ -80,33 +44,33 @@ class GitHubRepositoryReader(IRepositoryReader):
             print(f"ERRO INESPERADO ao carregar workflows: {e}")
             raise
 
-    def _ler_arquivos_especificos(
-        self, 
-        repositorio, 
-        branch_a_ler: str, 
-        arquivos_especificos: List[str]
-    ) -> Dict[str, str]:
-        """
-        Lê uma lista específica de arquivos do repositório.
+    def _is_gitlab_project(self, repositorio) -> bool:
+        return hasattr(repositorio, 'web_url') and 'gitlab' in str(type(repositorio)).lower()
+
+    def _ler_arquivos_especificos_gitlab(self, repositorio, branch_a_ler: str, arquivos_especificos: List[str]) -> Dict[str, str]:
+        arquivos_lidos = {}
+        total_arquivos = len(arquivos_especificos)
         
-        Este método implementa a leitura filtrada, processando apenas os arquivos
-        listados em arquivos_especificos. Arquivos não encontrados são tratados
-        com warning, não erro fatal.
+        print(f"Modo de leitura filtrada GitLab ativado. Lendo {total_arquivos} arquivos específicos...")
         
-        Args:
-            repositorio: Objeto repositório do provedor
-            branch_a_ler (str): Nome da branch a ser lida
-            arquivos_especificos (List[str]): Lista de caminhos de arquivos para ler
+        for i, caminho_arquivo in enumerate(arquivos_especificos):
+            try:
+                print(f"  [{i+1}/{total_arquivos}] Lendo: {caminho_arquivo}")
+                
+                file_content = repositorio.files.get(file_path=caminho_arquivo, ref=branch_a_ler)
+                decoded_content = base64.b64decode(file_content.content).decode('utf-8')
+                arquivos_lidos[caminho_arquivo] = decoded_content
+                
+            except Exception as e:
+                print(f"  [AVISO] Falha ao ler arquivo '{caminho_arquivo}': {e}. Ignorando.")
         
-        Returns:
-            Dict[str, str]: Dicionário mapeando caminhos para conteúdo dos arquivos
-                encontrados e lidos com sucesso
+        print(f"Leitura filtrada GitLab concluída. {len(arquivos_lidos)} de {total_arquivos} arquivos lidos com sucesso.")
+        return arquivos_lidos
+
+    def _ler_arquivos_especificos(self, repositorio, branch_a_ler: str, arquivos_especificos: List[str]) -> Dict[str, str]:
+        if self._is_gitlab_project(repositorio):
+            return self._ler_arquivos_especificos_gitlab(repositorio, branch_a_ler, arquivos_especificos)
         
-        Note:
-            - Arquivos não encontrados geram warning, não erro fatal
-            - Falhas de leitura individual são tratadas graciosamente
-            - Progresso é logado a cada arquivo processado
-        """
         arquivos_lidos = {}
         total_arquivos = len(arquivos_especificos)
         
@@ -116,10 +80,7 @@ class GitHubRepositoryReader(IRepositoryReader):
             try:
                 print(f"  [{i+1}/{total_arquivos}] Lendo: {caminho_arquivo}")
                 
-                # Obtém conteúdo do arquivo específico
                 file_content = repositorio.get_contents(caminho_arquivo, ref=branch_a_ler)
-                
-                # Decodifica conteúdo base64
                 decoded_content = base64.b64decode(file_content.content).decode('utf-8')
                 arquivos_lidos[caminho_arquivo] = decoded_content
                 
@@ -138,30 +99,6 @@ class GitHubRepositoryReader(IRepositoryReader):
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None
     ) -> Dict[str, str]:
-        """
-        Lê os arquivos do repositório e retorna um dicionário {caminho: conteudo}.
-        
-        Este método implementa tanto leitura completa (filtrada por extensão)
-        quanto leitura filtrada (arquivos específicos). O modo é determinado
-        pela presença do parâmetro arquivos_especificos.
-        
-        Args:
-            nome_repo (str): Nome do repositório no formato 'org/repo'
-            tipo_analise (str): Tipo de análise que determina extensões relevantes
-                (ignorado se arquivos_especificos for fornecido)
-            nome_branch (str, optional): Nome da branch. Se None, usa branch padrão
-            arquivos_especificos (Optional[List[str]], optional): Lista de caminhos
-                específicos de arquivos para ler. Se fornecido, ignora filtro por
-                extensão e lê apenas os arquivos listados. Defaults to None
-        
-        Returns:
-            Dict[str, str]: Dicionário mapeando caminhos de arquivo para conteúdo
-        
-        Note:
-            - Quando arquivos_especificos é fornecido, o filtro por extensão é ignorado
-            - Arquivos não encontrados são tratados com warning, não erro fatal
-            - Modo padrão (arquivos_especificos=None) mantém comportamento original
-        """
         provider_name = type(self.repository_provider).__name__
         print(f"Iniciando leitura do repositório: {nome_repo} via {provider_name}")
 
@@ -174,7 +111,6 @@ class GitHubRepositoryReader(IRepositoryReader):
         else:
             branch_a_ler = nome_branch
         
-        # Determina modo de leitura baseado na presença de arquivos_especificos
         if arquivos_especificos and len(arquivos_especificos) > 0:
             print(f"Modo de leitura filtrada ativado para {len(arquivos_especificos)} arquivos específicos.")
             return self._ler_arquivos_especificos(repositorio, branch_a_ler, arquivos_especificos)
@@ -182,28 +118,47 @@ class GitHubRepositoryReader(IRepositoryReader):
             print("Modo de leitura completa ativado (filtro por extensão).")
             return self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise)
     
+    def _ler_repositorio_completo_gitlab(self, repositorio, branch_a_ler: str, tipo_analise: str, extensoes_alvo: List[str]) -> Dict[str, str]:
+        arquivos_do_repo = {}
+        
+        try:
+            print(f"Obtendo árvore de arquivos GitLab da branch '{branch_a_ler}'...")
+            
+            tree_items = repositorio.repository_tree(ref=branch_a_ler, recursive=True, all=True)
+            print(f"Árvore GitLab obtida. {len(tree_items)} itens totais encontrados.")
+            
+            arquivos_para_ler = [
+                item for item in tree_items
+                if item['type'] == 'blob' and any(item['path'].endswith(ext) for ext in extensoes_alvo)
+            ]
+            
+            print(f"Filtragem GitLab concluída. {len(arquivos_para_ler)} arquivos com as extensões {extensoes_alvo} serão lidos.")
+            
+            for i, item in enumerate(arquivos_para_ler):
+                if (i + 1) % 50 == 0:
+                    print(f"  ...lendo arquivo {i + 1} de {len(arquivos_para_ler)} ({item['path']})")
+                
+                try:
+                    file_content = repositorio.files.get(file_path=item['path'], ref=branch_a_ler)
+                    decoded_content = base64.b64decode(file_content.content).decode('utf-8')
+                    arquivos_do_repo[item['path']] = decoded_content
+                    
+                except Exception as e:
+                    print(f"AVISO: Falha ao ler ou decodificar o conteúdo do arquivo '{item['path']}'. Pulando. Erro: {e}")
+
+        except Exception as e:
+            print(f"ERRO CRÍTICO durante a comunicação com a API GitLab: {e}")
+            raise
+        
+        return arquivos_do_repo
+    
     def _ler_repositorio_completo(self, repositorio, branch_a_ler: str, tipo_analise: str) -> Dict[str, str]:
-        """
-        Implementa leitura completa do repositório filtrada por extensões.
-        
-        Este método mantém o comportamento original de leitura completa,
-        filtrando arquivos baseado nas extensões definidas para o tipo de análise.
-        
-        Args:
-            repositorio: Objeto repositório do provedor
-            branch_a_ler (str): Nome da branch a ser lida
-            tipo_analise (str): Tipo de análise para determinar extensões relevantes
-        
-        Returns:
-            Dict[str, str]: Dicionário mapeando caminhos para conteúdo dos arquivos
-        
-        Raises:
-            ValueError: Se tipo de análise não for encontrado ou não tiver extensões
-            GithubException: Se houver falha na comunicação com a API
-        """
         extensoes_alvo = self._mapeamento_tipo_extensoes.get(tipo_analise.lower())
         if extensoes_alvo is None:
             raise ValueError(f"Tipo de análise '{tipo_analise}' não encontrado ou não possui 'extensions' definidas em workflows.yaml")
+
+        if self._is_gitlab_project(repositorio):
+            return self._ler_repositorio_completo_gitlab(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
 
         arquivos_do_repo = {}
         try:
@@ -220,9 +175,8 @@ class GitHubRepositoryReader(IRepositoryReader):
             print(f"Árvore obtida. {len(tree_elements)} itens totais encontrados.")
 
             if tree_response.truncated:
-                print(f"AVISO: A lista de arquivos do repositório '{nome_repo}' foi truncada pela API.")
+                print(f"AVISO: A lista de arquivos do repositório foi truncada pela API.")
 
-            # Filtra arquivos por extensão
             arquivos_para_ler = [
                 element for element in tree_elements
                 if element.type == 'blob' and any(element.path.endswith(ext) for ext in extensoes_alvo)
@@ -230,14 +184,12 @@ class GitHubRepositoryReader(IRepositoryReader):
             
             print(f"Filtragem concluída. {len(arquivos_para_ler)} arquivos com as extensões {extensoes_alvo} serão lidos.")
             
-            # Lê conteúdo de cada arquivo filtrado
             for i, element in enumerate(arquivos_para_ler):
                 if (i + 1) % 50 == 0:
                     print(f"  ...lendo arquivo {i + 1} de {len(arquivos_para_ler)} ({element.path})")
                 
                 try:
                     blob_content = repositorio.get_git_blob(element.sha).content
-                    
                     decoded_content = base64.b64decode(blob_content).decode('utf-8')
                     arquivos_do_repo[element.path] = decoded_content
                     


### PR DESCRIPTION
Este PR modifica o GitHubConnector para aceitar tanto repositórios do GitHub quanto do GitLab, alterando o tipo de retorno para Union e ajustando a lógica de obtenção de tokens para múltiplos provedores. Esta mudança é essencial para garantir compatibilidade total e deve ser integrada após a base do suporte ao GitLab. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 2, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA