### PR TITLE
Aprimora GitHubConnector com logging detalhado e tratamento específico para GitLab

### DIFF
--- a/tools/github_connector.py
+++ b/tools/github_connector.py
@@ -14,6 +14,7 @@ class GitHubConnector:
     
     def _get_token_for_org(self, org_name: str) -> str:
         provider_type = type(self.repository_provider).__name__.lower()
+        print(f"[GitHub Connector] Detectado provider: {provider_type}")
         
         if 'github' in provider_type:
             token_prefix = 'github-token'
@@ -25,37 +26,67 @@ class GitHubConnector:
             token_prefix = 'repo-token'
         
         token_secret_name = f"{token_prefix}-{org_name}"
+        print(f"[GitHub Connector] Tentando buscar token específico: {token_secret_name}")
         
         try:
-            return self.secret_manager.get_secret(token_secret_name)
+            token = self.secret_manager.get_secret(token_secret_name)
+            print(f"[GitHub Connector] Token específico encontrado para {org_name}")
+            return token
         except ValueError:
-            print(f"AVISO: Segredo '{token_secret_name}' não encontrado. Tentando usar token padrão '{token_prefix}'.")
+            print(f"[GitHub Connector] Token específico '{token_secret_name}' não encontrado. Tentando token padrão '{token_prefix}'.")
             try:
-                return self.secret_manager.get_secret(token_prefix)
+                token = self.secret_manager.get_secret(token_prefix)
+                print(f"[GitHub Connector] Token padrão '{token_prefix}' encontrado")
+                return token
             except ValueError as e:
+                print(f"[GitHub Connector] ERRO CRÍTICO: Nenhum token encontrado para provider {provider_type}")
                 raise ValueError(f"ERRO CRÍTICO: Nenhum token encontrado. Verifique se existe '{token_secret_name}' ou '{token_prefix}' no gerenciador de segredos.") from e
     
     def connection(self, repositorio: str) -> Union[Repository, object]:
+        print(f"[GitHub Connector] Iniciando conexão para repositório: {repositorio}")
+        print(f"[GitHub Connector] Provider utilizado: {type(self.repository_provider).__name__}")
+        
         if repositorio in self._cached_repos:
-            print(f"Retornando o objeto do repositório '{repositorio}' do cache.")
+            print(f"[GitHub Connector] Retornando repositório '{repositorio}' do cache.")
             return self._cached_repos[repositorio]
         
         try:
             org_name = repositorio.split('/')[0]
+            print(f"[GitHub Connector] Organização/namespace extraído: {org_name}")
         except (ValueError, IndexError):
+            print(f"[GitHub Connector] ERRO: Formato inválido do repositório: {repositorio}")
             raise ValueError(f"O nome do repositório '{repositorio}' tem formato inválido. Esperado 'organizacao/repositorio' ou 'org/proj/repo'.")
         
         token = self._get_token_for_org(org_name)
+        print(f"[GitHub Connector] Token obtido: {'***' + token[-4:] if len(token) > 4 else '***'}")
         
         try:
-            print(f"Tentando acessar o repositório '{repositorio}' via {type(self.repository_provider).__name__}...")
+            print(f"[GitHub Connector] Tentando acessar repositório '{repositorio}' via {type(self.repository_provider).__name__}...")
             repo = self.repository_provider.get_repository(repositorio, token)
-            print(f"Repositório '{repositorio}' encontrado com sucesso.")
-        except ValueError:
-            print(f"AVISO: Repositório '{repositorio}' não encontrado. Tentando criá-lo...")
-            repo = self.repository_provider.create_repository(repositorio, token)
-            print(f"SUCESSO: Repositório '{repositorio}' criado.")
+            print(f"[GitHub Connector] Repositório '{repositorio}' encontrado com sucesso.")
+            
+        except ValueError as get_error:
+            print(f"[GitHub Connector] Repositório '{repositorio}' não encontrado. Erro: {get_error}")
+            
+            provider_name = type(self.repository_provider).__name__
+            if 'gitlab' in provider_name.lower():
+                print(f"[GitHub Connector] AVISO: Para repositórios GitLab, verifique se o nome está correto e se o token possui permissões adequadas.")
+                print(f"[GitHub Connector] AVISO: Não tentando criar repositório GitLab automaticamente.")
+                raise ValueError(f"Repositório GitLab '{repositorio}' não encontrado ou inacessível. Verifique o nome e permissões.") from get_error
+            
+            print(f"[GitHub Connector] Tentando criar repositório '{repositorio}'...")
+            try:
+                repo = self.repository_provider.create_repository(repositorio, token)
+                print(f"[GitHub Connector] SUCESSO: Repositório '{repositorio}' criado.")
+            except Exception as create_error:
+                print(f"[GitHub Connector] ERRO: Falha ao criar repositório '{repositorio}': {create_error}")
+                raise ValueError(f"Não foi possível acessar nem criar o repositório '{repositorio}'. Erro original: {get_error}. Erro de criação: {create_error}") from create_error
         
+        except Exception as unexpected_error:
+            print(f"[GitHub Connector] ERRO INESPERADO ao acessar '{repositorio}': {type(unexpected_error).__name__}: {unexpected_error}")
+            raise
+        
+        print(f"[GitHub Connector] Adicionando repositório '{repositorio}' ao cache.")
         self._cached_repos[repositorio] = repo
         return repo
     


### PR DESCRIPTION
Este PR adiciona logging detalhado para rastreabilidade das operações no GitHubConnector, diferencia claramente os providers GitHub e GitLab, e implementa tratamento específico para evitar tentativas automáticas de criação de repositórios GitLab quando não encontrados, alinhando o comportamento com as políticas de acesso. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 2, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA