### PR TITLE
Adiciona suporte a project_id na interface do provider de repositórios

### DIFF
--- a/domain/interfaces/repository_provider_interface.py
+++ b/domain/interfaces/repository_provider_interface.py
@@ -7,13 +7,14 @@ class IRepositoryProvider(ABC):
     Abstrai a implementação específica do provedor (GitHub, GitLab, etc.)
     """
     @abstractmethod
-    def get_repository(self, repository_name: str, token: str) -> Any:
+    def get_repository(self, repository_name: str, token: str, project_id: str = None) -> Any:
         """
         Obtém um objeto de repositório.
         
         Args:
             repository_name: Nome do repositório no formato 'org/repo'
             token: Token de autenticação
+            project_id: ID específico do projeto (usado principalmente para GitLab)
             
         Returns:
             Any: Objeto do repositório específico do provedor
@@ -21,7 +22,7 @@ class IRepositoryProvider(ABC):
         pass
     
     @abstractmethod
-    def create_repository(self, repository_name: str, token: str, description: str = "", private: bool = True) -> Any:
+    def create_repository(self, repository_name: str, token: str, description: str = "", private: bool = True, project_id: str = None) -> Any:
         """
         Cria um novo repositório.
         
@@ -30,6 +31,7 @@ class IRepositoryProvider(ABC):
             token: Token de autenticação
             description: Descrição do repositório
             private: Se o repositório deve ser privado
+            project_id: ID específico do projeto (usado principalmente para GitLab)
             
         Returns:
             Any: Objeto do repositório criado


### PR DESCRIPTION
Este PR modifica a interface IRepositoryProvider para incluir o parâmetro opcional project_id nos métodos get_repository e create_repository. Essa alteração permite a identificação precisa de projetos GitLab via ID sem quebrar a compatibilidade com implementações existentes. Esta base é essencial para as mudanças subsequentes nos providers. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Arquiteto de Software