### PR TITLE
Aprimora extração de org_name e token para GitLab no GitHubConnector com suporte a Project ID e path completo

### DIFF
--- a/tools/github_connector.py
+++ b/tools/github_connector.py
@@ -54,14 +54,19 @@ class GitHubConnector:
         
         if 'gitlab' in provider_type:
             if self._is_gitlab_project_id(repositorio):
-                print(f"[GitHub Connector] GitLab Project ID detectado: {repositorio}. Usando 'gitlab' como org_name para token.")
+                print(f"[GitHub Connector] GitLab Project ID detectado: {repositorio}. Usando 'gitlab' como org_name para busca de token.")
                 return 'gitlab'
             else:
-                print(f"[GitHub Connector] GitLab path detectado: {repositorio}. Extraindo namespace.")
+                print(f"[GitHub Connector] GitLab path detectado: {repositorio}. Extraindo namespace para busca de token.")
                 try:
-                    namespace = repositorio.split('/')[0]
-                    print(f"[GitHub Connector] Namespace GitLab extraído: {namespace}")
-                    return namespace
+                    parts = repositorio.split('/')
+                    if len(parts) >= 2:
+                        namespace = parts[0]
+                        print(f"[GitHub Connector] Namespace GitLab extraído: {namespace}")
+                        return namespace
+                    else:
+                        print(f"[GitHub Connector] Path GitLab inválido. Usando 'gitlab' como fallback.")
+                        return 'gitlab'
                 except (ValueError, IndexError):
                     print(f"[GitHub Connector] Erro ao extrair namespace do path GitLab. Usando 'gitlab' como fallback.")
                     return 'gitlab'

--- a/tools/gitlab_repository_provider.py
+++ b/tools/gitlab_repository_provider.py
@@ -30,6 +30,7 @@ class GitLabRepositoryProvider(IRepositoryProvider):
         try:
             gl = gitlab.Gitlab(url="https://gitlab.com", private_token=token)
             gl.auth()
+            print(f"[GitLab Provider] Autenticação GitLab bem-sucedida.")
         except gitlab.exceptions.GitlabAuthenticationError as e:
             print(f"[GitLab Provider] ERRO: Token de autenticação inválido.")
             raise ValueError("Token de autenticação do GitLab é inválido.") from e
@@ -38,8 +39,9 @@ class GitLabRepositoryProvider(IRepositoryProvider):
     
         try:
             if self._is_project_id(repository_name):
-                print(f"[GitLab Provider] Detectado project ID numérico: {repository_name}")
-                project = gl.projects.get(int(repository_name))
+                project_id = int(repository_name)
+                print(f"[GitLab Provider] Detectado Project ID numérico: {project_id} (formato mais robusto)")
+                project = gl.projects.get(project_id)
                 print(f"[GitLab Provider] Projeto encontrado por ID: '{project.name_with_namespace}' (ID: {project.id}).")
             else:
                 print(f"[GitLab Provider] Detectado path completo: {repository_name}")
@@ -47,7 +49,9 @@ class GitLabRepositoryProvider(IRepositoryProvider):
                 print(f"[GitLab Provider] Projeto '{project.name_with_namespace}' encontrado com sucesso (ID: {project.id}).")
             
             if not hasattr(project, 'default_branch'):
-                project.default_branch = project.attributes.get('default_branch', 'main')
+                default_branch = project.attributes.get('default_branch', 'main')
+                project.default_branch = default_branch
+                print(f"[GitLab Provider] Branch padrão definida: {default_branch}")
             
             return project
             
@@ -87,6 +91,7 @@ class GitLabRepositoryProvider(IRepositoryProvider):
         try:
             gl = gitlab.Gitlab(url="https://gitlab.com", private_token=token)
             gl.auth()
+            print(f"[GitLab Provider] Autenticação para criação bem-sucedida.")
             
             project_data = {
                 'name': project_name,
@@ -114,7 +119,7 @@ class GitLabRepositoryProvider(IRepositoryProvider):
             if not hasattr(project, 'default_branch'):
                 project.default_branch = 'main'
             
-            print(f"[GitLab Provider] Projeto criado com sucesso: {project.web_url}")
+            print(f"[GitLab Provider] Projeto criado com sucesso: {project.web_url} (ID: {project.id})")
             return project
             
         except gitlab.exceptions.GitlabCreateError as e:


### PR DESCRIPTION
Este PR refatora o método _extract_org_name da classe GitHubConnector para tratar corretamente Project ID GitLab usando 'gitlab' como org_name e extrair namespace para paths completos. Inclui logs detalhados para facilitar troubleshooting e fallback robusto. Esta melhoria é essencial para garantir autenticação correta e uso adequado dos tokens para repositórios GitLab, alinhando o comportamento com as práticas recomendadas. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 2, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de Segurança