### PR TITLE
Corrige erro crítico no GitLabRepositoryProvider e melhora tratamento de erros e logs

### DIFF
--- a/tools/gitlab_repository_provider.py
+++ b/tools/gitlab_repository_provider.py
@@ -112,17 +112,18 @@ class GitLabRepositoryProvider(IRepositoryProvider):
             
             print(f"[GitLab Provider] Tentando criar em namespace/grupo: {namespace}")
             try:
-                group = gl.groups.get(namespace, lazy=True)
-                group_info = group.name
+                group = gl.groups.get(namespace)
+                group_name = group.attributes.get('name', namespace)
                 project_data['namespace_id'] = group.id
-                print(f"[GitLab Provider] Grupo encontrado: {group_info}, ID: {group.id}")
+                print(f"[GitLab Provider] Grupo encontrado: {group_name}, ID: {group.id}")
                 project = gl.projects.create(project_data)
                 
             except gitlab.exceptions.GitlabGetError as group_error:
-                print(f"[GitLab Provider] Grupo não encontrado ({group_error.response_code}), criando como projeto pessoal")
+                print(f"[GitLab Provider] Grupo '{namespace}' não encontrado ou sem permissão ({group_error.response_code}), criando como projeto pessoal")
                 if 'namespace_id' in project_data:
                     del project_data['namespace_id']
                 project = gl.projects.create(project_data)
+                print(f"[GitLab Provider] Projeto criado como pessoal devido à falta de acesso ao grupo '{namespace}'")
             
             if not hasattr(project, 'default_branch'):
                 project.default_branch = 'main'


### PR DESCRIPTION
Este PR corrige o erro crítico 'Group' object has no attribute 'name' removendo o uso incorreto de lazy=True e acessando atributos do grupo via 'group.attributes.get'. Além disso, aprimora o tratamento de erros para fallback automático para projeto pessoal quando o grupo não existe ou não há permissão, e adiciona logs detalhados para facilitar o debugging. Esta correção é essencial para a estabilidade e confiabilidade do provedor GitLab, devendo ser revisada com prioridade crítica e integrada imediatamente.