### PR TITLE
Corrige erro NameError no parâmetro de descrição do PR no fluxo de commit

### DIFF
--- a/tools/commit_multiplas_branchs.py
+++ b/tools/commit_multiplas_branchs.py
@@ -409,7 +409,7 @@ def processar_e_subir_mudancas_agrupadas(
                 branch_de_origem=branch_anterior,  # Empilhamento: usa branch anterior como base
                 branch_alvo_do_pr=branch_anterior,  # PR aponta para branch anterior
                 mensagem_pr=resumo_do_pr,
-                descricao_pr=descricao_pr,
+                descricao_pr=descricao_do_pr,
                 conjunto_de_mudancas=conjunto_de_mudancas
             )
             print(f"[DEBUG] Resultado da branch {nome_da_branch_atual}: {resultado_da_branch}")


### PR DESCRIPTION
Este PR corrige um erro crítico de execução (NameError) causado pelo uso incorreto do nome do parâmetro 'descricao_pr' na chamada da função _processar_uma_branch dentro da função processar_e_subir_mudancas_agrupadas. A alteração garante que o parâmetro correto 'descricao_do_pr' seja passado, evitando falhas no processo de commit. Esta correção é essencial para o funcionamento correto do fluxo de commits e deve ser revisada com prioridade ALTA. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA