### PR TITLE
Correções no GitHubConnector e GitHubRepositoryReader para suporte adequado ao Azure DevOps

### DIFF
--- a/tools/commit_multiplas_branchs.py
+++ b/tools/commit_multiplas_branchs.py
@@ -42,7 +42,7 @@ def _processar_uma_branch_azure(
         
         from tools.github_connector import GitHubConnector
         connector = GitHubConnector.create_with_defaults()
-        token = connector._get_token_for_org(organization)
+        token = connector._get_token_for_org(organization, 'azure')
         
         base_url = f"https://dev.azure.com/{organization}/{project}/_apis"
         headers = {
@@ -446,8 +446,14 @@ def processar_e_subir_mudancas_agrupadas(
         print(f"[DEBUG] Criando GitHubConnector com provider: {type(repository_provider).__name__}")
         connector = GitHubConnector(repository_provider=repository_provider)
         
-        print(f"[DEBUG] Estabelecendo conexão com repositório: {nome_repo}")
-        repo = connector.connection(repositorio=nome_repo)
+        repository_type = 'github'
+        if 'GitLab' in provider_name:
+            repository_type = 'gitlab'
+        elif 'Azure' in provider_name:
+            repository_type = 'azure'
+        
+        print(f"[DEBUG] Estabelecendo conexão com repositório: {nome_repo} (tipo: {repository_type})")
+        repo = connector.connection(repositorio=nome_repo, repository_type=repository_type)
         print(f"[DEBUG] Conexão estabelecida. Tipo do objeto repo: {type(repo)}")
         
         repo_type = "Azure DevOps" if _is_azure_repo(repo) else "GitLab" if _is_gitlab_project(repo) else "GitHub"

--- a/tools/github_connector.py
+++ b/tools/github_connector.py
@@ -12,7 +12,7 @@ class GitHubConnector:
         self.repository_provider = repository_provider
         self.secret_manager = secret_manager or AzureSecretManager()
     
-    def _get_token_for_org(self, org_name: str, repository_type: str) -> str:
+    def _get_token_for_org(self, org_name: str, repository_type: str = 'github') -> str:
         print(f"[GitHub Connector] Tipo de repositório explícito: {repository_type}")
         
         if repository_type == 'github':
@@ -91,7 +91,7 @@ class GitHubConnector:
         
         return repositorio.strip()
     
-    def connection(self, repositorio: str, repository_type: str) -> Union[Repository, object]:
+    def connection(self, repositorio: str, repository_type: str = 'github') -> Union[Repository, object]:
         print(f"[GitHub Connector] Iniciando conexão para repositório: {repositorio} (tipo: {repository_type})")
         print(f"[GitHub Connector] Provider utilizado: {type(self.repository_provider).__name__}")
         

--- a/tools/github_reader.py
+++ b/tools/github_reader.py
@@ -55,7 +55,7 @@ class GitHubRepositoryReader(IRepositoryReader):
         from tools.github_connector import GitHubConnector
         connector = GitHubConnector.create_with_defaults()
         organization = repositorio_dict.get('_organization')
-        token = connector._get_token_for_org(organization)
+        token = connector._get_token_for_org(organization, 'azure')
         
         import base64
         credentials = base64.b64encode(f":{token}".encode()).decode()
@@ -213,7 +213,14 @@ class GitHubRepositoryReader(IRepositoryReader):
         print(f"Iniciando leitura do repositório: {nome_repo} via {provider_name}")
 
         connector = GitHubConnector(repository_provider=self.repository_provider)
-        repositorio = connector.connection(repositorio=nome_repo)
+        
+        repository_type = 'github'
+        if 'GitLab' in provider_name:
+            repository_type = 'gitlab'
+        elif 'Azure' in provider_name:
+            repository_type = 'azure'
+        
+        repositorio = connector.connection(repositorio=nome_repo, repository_type=repository_type)
 
         if nome_branch is None:
             if hasattr(repositorio, 'default_branch'):


### PR DESCRIPTION
Este PR corrige a lógica de obtenção de tokens no GitHubConnector para suportar corretamente o Azure DevOps, incluindo a passagem obrigatória do parâmetro 'repository_type' no método connection. Além disso, ajusta o GitHubRepositoryReader para detectar corretamente o tipo de repositório e usar o token correto para autenticação no Azure. Essas mudanças garantem a integração segura e funcional com repositórios Azure DevOps. prioridade_de_revisao: ALTA, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA