### PR TITLE
Atualiza Azure Committer para uso da nova estrutura modular

### DIFF
--- a/tools/repo_committers/azure_committer.py
+++ b/tools/repo_committers/azure_committer.py
@@ -29,9 +29,9 @@ def processar_branch_azure(
         project = repo._project
         repository = repo._repository
         
-        from tools.github_connector import GitHubConnector
-        connector = GitHubConnector.create_with_defaults()
-        token = connector._get_token_for_org(organization, 'azure')
+        from tools.conectores.azure_conector import AzureConector
+        connector = AzureConector.create_with_defaults()
+        token = connector._get_token_for_org(organization)
         
         base_url = f"https://dev.azure.com/{organization}/{project}/_apis"
         headers = {


### PR DESCRIPTION
Este PR atualiza o módulo de committer para Azure DevOps, ajustando o import para utilizar o AzureConector da nova estrutura modular, removendo dependências antigas. Esta mudança é importante para garantir a consistência e integração correta do processo de commit e criação de pull requests na plataforma Azure. Deve ser mesclado após o PR de ajuste dos imports e leitores para garantir que a base esteja atualizada. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 2, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de DevOps/SRE