### PR TITLE
Refatora ReaderGeral e AgenteRevisor para uso explícito do parâmetro repository_type

### DIFF
--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -38,6 +38,7 @@ class AgenteRevisor:
             codigo_para_analise = self.repository_reader.read_repository(
                 nome_repo=repositorio,
                 tipo_analise=tipo_analise,
+                repository_type=repository_type,
                 nome_branch=nome_branch,
                 arquivos_especificos=arquivos_especificos
             )


### PR DESCRIPTION
Este PR altera a assinatura do método read_repository em ReaderGeral para incluir o parâmetro obrigatório repository_type, removendo a inferência automática do tipo de repositório. Além disso, atualiza o agente revisor para passar explicitamente esse parâmetro em suas chamadas, garantindo consistência e clareza na delegação para os readers específicos (GitHub, GitLab, Azure). Essas mudanças melhoram a robustez e a previsibilidade do fluxo de leitura de repositórios. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Qualquer Membro da Equipe