### PR TITLE
Atualiza construtor de caminho do Blob Storage para incluir projeto

### DIFF
--- a/tools/blob_report_path_builder.py
+++ b/tools/blob_report_path_builder.py
@@ -1,6 +1,6 @@
 import re
 
-def build_report_blob_path(analysis_type: str, repository_type: str, repo_name: str, branch_name: str, analysis_name: str) -> str:
+def build_report_blob_path(projeto: str, analysis_type: str, repository_type: str, repo_name: str, branch_name: str, analysis_name: str) -> str:
     def sanitize_path_component(component: str) -> str:
         if not component:
             return "unknown"
@@ -11,10 +11,11 @@ def build_report_blob_path(analysis_type: str, repository_type: str, repo_name: 
         
         return sanitized if sanitized else "unknown"
     
+    projeto_clean = sanitize_path_component(projeto)
     analysis_type_clean = sanitize_path_component(analysis_type)
     repository_type_clean = sanitize_path_component(repository_type)
     repo_name_clean = sanitize_path_component(repo_name)
     branch_name_clean = sanitize_path_component(branch_name)
     analysis_name_clean = sanitize_path_component(analysis_name)
     
-    return f"{analysis_type_clean}/{repository_type_clean}/{repo_name_clean}/{branch_name_clean}/{analysis_name_clean}.md"
+    return f"{projeto_clean}/{analysis_type_clean}/{repository_type_clean}/{repo_name_clean}/{branch_name_clean}/{analysis_name_clean}.md"


### PR DESCRIPTION
Este PR modifica a função build_report_blob_path para incluir o parâmetro 'projeto' como primeiro componente do caminho, organizando os relatórios no Blob Storage por projeto conforme o novo modelo de domínio. Esta mudança é de baixo risco e pode ser integrada após a atualização da API. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 2, revisores_sugeridos: Engenheiro de DevOps/SRE, Desenvolvedor Sênior (Backend)