### PR TITLE
Propaga job_id no Agente Revisor para logging consistente no provider LLM

### DIFF
--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -68,9 +68,12 @@ class AgenteRevisor:
         usar_rag: bool = False,
         model_name: Optional[str] = None,
         max_token_out: int = 15000,
-        arquivos_especificos: Optional[List[str]] = None
+        arquivos_especificos: Optional[List[str]] = None,
+        job_id: Optional[str] = None
     ) -> Dict[str, Any]:
         print(f"[Agente Revisor] Iniciando análise - repositório: {repositorio} (tipo: {repository_type})")
+        if job_id:
+            print(f"[Agente Revisor] Job ID recebido: {job_id}")
         
         codigo_para_analise = self._get_code(
             repositorio=repositorio,
@@ -100,7 +103,8 @@ class AgenteRevisor:
             instrucoes_extras=instrucoes_extras,
             usar_rag=usar_rag,
             model_name=model_name,
-            max_token_out=max_token_out
+            max_token_out=max_token_out,
+            job_id=job_id
         )
 
         print(f"[Agente Revisor] Resposta recebida da IA: {type(resultado_da_ia)}")


### PR DESCRIPTION
Este PR adiciona o parâmetro opcional job_id ao método main do AgenteRevisor e propaga este parâmetro para o método executar_prompt do provider LLM. Essa mudança permite um logging consistente e rastreável dos tokens utilizados durante a execução dos prompts, conforme as observações prioritárias do usuário. Por se tratar de uma melhoria funcional importante para o monitoramento e rastreamento, a revisão deve ser realizada com prioridade normal. prioridade_de_revisao: NORMAL, ordem_de_merge_sugerida: 1, revisores_sugeridos: Desenvolvedor Sênior (Backend), Engenheiro de QA