### PR TITLE
Refatoração SRP: Separação de responsabilidades no WorkflowRegistryService

### DIFF
--- a/services/analysis_type_provider.py
+++ b/services/analysis_type_provider.py
@@ -1,0 +1,13 @@
+import enum
+from typing import Dict, Any
+
+class AnalysisTypeProvider:
+    def __init__(self):
+        self._valid_analysis_types = None
+    
+    def get_valid_analysis_types(self, workflow_registry: Dict[str, Any]):
+        if self._valid_analysis_types is None:
+            valid_analysis_keys = {key: key for key in workflow_registry.keys()}
+            self._valid_analysis_types = enum.Enum('ValidAnalysisTypes', valid_analysis_keys)
+        
+        return self._valid_analysis_types

--- a/services/workflow_registry_loader.py
+++ b/services/workflow_registry_loader.py
@@ -1,0 +1,22 @@
+import yaml
+from typing import Dict, Any
+
+class WorkflowRegistryLoader:
+    def __init__(self, workflow_file_path: str = "workflows.yaml"):
+        self.workflow_file_path = workflow_file_path
+    
+    def load_workflows(self) -> Dict[str, Any]:
+        print(f"Carregando workflows do arquivo: {self.workflow_file_path}")
+        workflows = {}
+        
+        try:
+            with open(self.workflow_file_path, 'r', encoding='utf-8') as f:
+                for document in yaml.safe_load_all(f):
+                    if document:
+                        workflows.update(document)
+        except yaml.YAMLError as e:
+            print(f"Erro ao processar YAML em streaming: {e}")
+            with open(self.workflow_file_path, 'r', encoding='utf-8') as f:
+                workflows = yaml.safe_load(f)
+        
+        return workflows

--- a/services/workflow_registry_service.py
+++ b/services/workflow_registry_service.py
@@ -1,39 +1,22 @@
-import yaml
-import enum
 from typing import Dict, Any
+from services.workflow_registry_loader import WorkflowRegistryLoader
+from services.analysis_type_provider import AnalysisTypeProvider
 
 class WorkflowRegistryService:
     def __init__(self, workflow_file_path: str = "workflows.yaml"):
-        self.workflow_file_path = workflow_file_path
         self._workflow_registry = None
-        self._valid_analysis_types = None
+        self._loader = WorkflowRegistryLoader(workflow_file_path)
+        self._analysis_type_provider = AnalysisTypeProvider()
     
     def load_workflow_registry(self) -> Dict[str, Any]:
         if self._workflow_registry is None:
-            print(f"Carregando workflows do arquivo: {self.workflow_file_path}")
-            workflows = {}
-            
-            try:
-                with open(self.workflow_file_path, 'r', encoding='utf-8') as f:
-                    for document in yaml.safe_load_all(f):
-                        if document:
-                            workflows.update(document)
-            except yaml.YAMLError as e:
-                print(f"Erro ao processar YAML em streaming: {e}")
-                with open(self.workflow_file_path, 'r', encoding='utf-8') as f:
-                    workflows = yaml.safe_load(f)
-            
-            self._workflow_registry = workflows
+            self._workflow_registry = self._loader.load_workflows()
         
         return self._workflow_registry
     
     def get_valid_analysis_types(self):
-        if self._valid_analysis_types is None:
-            workflow_registry = self.load_workflow_registry()
-            valid_analysis_keys = {key: key for key in workflow_registry.keys()}
-            self._valid_analysis_types = enum.Enum('ValidAnalysisTypes', valid_analysis_keys)
-        
-        return self._valid_analysis_types
+        workflow_registry = self.load_workflow_registry()
+        return self._analysis_type_provider.get_valid_analysis_types(workflow_registry)
     
     def get_workflow_registry(self) -> Dict[str, Any]:
         return self.load_workflow_registry()


### PR DESCRIPTION
Este PR realiza uma refatoração importante no WorkflowRegistryService, aplicando o princípio da Responsabilidade Única (SRP). Foram criadas duas novas classes:

- WorkflowRegistryLoader: Responsável exclusivamente pelo parsing e carregamento dos workflows a partir de arquivos YAML.
- AnalysisTypeProvider: Responsável por fornecer e enumerar os tipos de análise válidos a partir do registro de workflows.

O WorkflowRegistryService passa a atuar como fachada, delegando tarefas específicas para essas novas classes, tornando o código mais modular, testável e de fácil manutenção.