### PR TITLE
Suporte à comparação de código original vs modernizado

### DIFF
--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -40,6 +40,73 @@ class AgenteRevisor:
             print(f"[Agente Revisor] ERRO durante leitura do repositório: {e}")
             raise RuntimeError(f"Falha ao ler o repositório: {e}") from e
 
+    def _get_comparison_codes(
+        self,
+        repositorio: str,
+        repository_type: str,
+        codigo_original_branch: Optional[str],
+        codigo_original_arquivos: Optional[List[str]],
+        codigo_modernizado_branch: Optional[str],
+        codigo_modernizado_arquivos: Optional[List[str]]
+    ) -> Dict[str, Dict[str, str]]:
+        comparison_data = {}
+        
+        if codigo_original_branch and codigo_original_arquivos:
+            try:
+                codigo_original = self.repository_reader.read_repository(
+                    nome_repo=repositorio,
+                    tipo_analise="comparacao",
+                    repository_type=repository_type,
+                    nome_branch=codigo_original_branch,
+                    arquivos_especificos=codigo_original_arquivos
+                )
+                comparison_data["codigo_original"] = codigo_original
+                print(f"[Agente Revisor] Código original carregado: {len(codigo_original)} arquivos")
+            except Exception as e:
+                print(f"[Agente Revisor] ERRO ao carregar código original: {e}")
+                comparison_data["codigo_original"] = {}
+        
+        if codigo_modernizado_branch and codigo_modernizado_arquivos:
+            try:
+                codigo_modernizado = self.repository_reader.read_repository(
+                    nome_repo=repositorio,
+                    tipo_analise="comparacao",
+                    repository_type=repository_type,
+                    nome_branch=codigo_modernizado_branch,
+                    arquivos_especificos=codigo_modernizado_arquivos
+                )
+                comparison_data["codigo_modernizado"] = codigo_modernizado
+                print(f"[Agente Revisor] Código modernizado carregado: {len(codigo_modernizado)} arquivos")
+            except Exception as e:
+                print(f"[Agente Revisor] ERRO ao carregar código modernizado: {e}")
+                comparison_data["codigo_modernizado"] = {}
+        
+        return comparison_data
+
+    def _prepare_comparison_prompt(
+        self,
+        comparison_data: Dict[str, Dict[str, str]],
+        instrucoes_comparacao_markdown: str
+    ) -> str:
+        prompt_parts = []
+        
+        if "codigo_original" in comparison_data and comparison_data["codigo_original"]:
+            prompt_parts.append("=== CÓDIGO ORIGINAL ===")
+            prompt_parts.append(json.dumps(comparison_data["codigo_original"], indent=2, ensure_ascii=False))
+            prompt_parts.append("")
+        
+        if "codigo_modernizado" in comparison_data and comparison_data["codigo_modernizado"]:
+            prompt_parts.append("=== CÓDIGO MODERNIZADO ===")
+            prompt_parts.append(json.dumps(comparison_data["codigo_modernizado"], indent=2, ensure_ascii=False))
+            prompt_parts.append("")
+        
+        if instrucoes_comparacao_markdown:
+            prompt_parts.append("=== INSTRUÇÕES DE COMPARAÇÃO ===")
+            prompt_parts.append(instrucoes_comparacao_markdown)
+            prompt_parts.append("")
+        
+        return "\n".join(prompt_parts)
+
     def main(
         self,
         tipo_analise: str,
@@ -53,7 +120,12 @@ class AgenteRevisor:
         arquivos_especificos: Optional[List[str]] = None,
         job_id: Optional[str] = None,
         projeto: Optional[str] = None,
-        status_update: Optional[str] = None
+        status_update: Optional[str] = None,
+        codigo_original_branch: Optional[str] = None,
+        codigo_original_arquivos: Optional[List[str]] = None,
+        codigo_modernizado_branch: Optional[str] = None,
+        codigo_modernizado_arquivos: Optional[List[str]] = None,
+        instrucoes_comparacao_markdown: Optional[str] = None
     ) -> Dict[str, Any]:
 
         log_custom_data(
@@ -67,39 +139,68 @@ class AgenteRevisor:
             model_name=model_name
         )
 
-        codigo_para_analise = self._get_code(
-            repositorio=repositorio,
-            nome_branch=nome_branch,
-            tipo_analise=tipo_analise,
-            repository_type=repository_type,
-            arquivos_especificos=arquivos_especificos
+        is_comparison_mode = (
+            codigo_original_branch or codigo_original_arquivos or 
+            codigo_modernizado_branch or codigo_modernizado_arquivos or 
+            instrucoes_comparacao_markdown
         )
 
-        if not codigo_para_analise:
-            if arquivos_especificos and len(arquivos_especificos) > 0:
-                print(f"[Agente Revisor] AVISO: Nenhum dos arquivos específicos foi encontrado no repositório para a análise '{tipo_analise}'.")
-            else:
-                print(f"[Agente Revisor] AVISO: Nenhum código encontrado no repositório para a análise '{tipo_analise}'.")
+        if is_comparison_mode:
+            print(f"[Agente Revisor] Modo comparação ativado para job {job_id}")
             
-            print(f"[Agente Revisor] Retornando resposta vazia devido à ausência de código")
-            
-            log_custom_data(
-                job_id=job_id,
-                projeto=projeto,
-                status="ERRO_SEM_CODIGO",
+            comparison_data = self._get_comparison_codes(
                 repositorio=repositorio,
-                tipo_analise=tipo_analise,
-                data_hora=datetime.now(timezone.utc).isoformat()
+                repository_type=repository_type,
+                codigo_original_branch=codigo_original_branch,
+                codigo_original_arquivos=codigo_original_arquivos,
+                codigo_modernizado_branch=codigo_modernizado_branch,
+                codigo_modernizado_arquivos=codigo_modernizado_arquivos
             )
             
-            return {"resultado": {"reposta_final": {}}}
+            if not comparison_data:
+                print(f"[Agente Revisor] AVISO: Nenhum código de comparação foi carregado")
+                return {"resultado": {"reposta_final": {}}}
+            
+            prompt_principal = self._prepare_comparison_prompt(
+                comparison_data, instrucoes_comparacao_markdown or ""
+            )
+            
+            instrucoes_extras_completas = f"{instrucoes_extras}\n\nEsta é uma análise de comparação entre código original e modernizado."
+        else:
+            codigo_para_analise = self._get_code(
+                repositorio=repositorio,
+                nome_branch=nome_branch,
+                tipo_analise=tipo_analise,
+                repository_type=repository_type,
+                arquivos_especificos=arquivos_especificos
+            )
 
-        codigo_str = json.dumps(codigo_para_analise, indent=2, ensure_ascii=False)
+            if not codigo_para_analise:
+                if arquivos_especificos and len(arquivos_especificos) > 0:
+                    print(f"[Agente Revisor] AVISO: Nenhum dos arquivos específicos foi encontrado no repositório para a análise '{tipo_analise}'.")
+                else:
+                    print(f"[Agente Revisor] AVISO: Nenhum código encontrado no repositório para a análise '{tipo_analise}'.")
+                
+                print(f"[Agente Revisor] Retornando resposta vazia devido à ausência de código")
+                
+                log_custom_data(
+                    job_id=job_id,
+                    projeto=projeto,
+                    status="ERRO_SEM_CODIGO",
+                    repositorio=repositorio,
+                    tipo_analise=tipo_analise,
+                    data_hora=datetime.now(timezone.utc).isoformat()
+                )
+                
+                return {"resultado": {"reposta_final": {}}}
+
+            prompt_principal = json.dumps(codigo_para_analise, indent=2, ensure_ascii=False)
+            instrucoes_extras_completas = instrucoes_extras
 
         resultado_da_ia = self.llm_provider.executar_prompt(
             tipo_tarefa=tipo_analise,
-            prompt_principal=codigo_str,
-            instrucoes_extras=instrucoes_extras,
+            prompt_principal=prompt_principal,
+            instrucoes_extras=instrucoes_extras_completas,
             usar_rag=usar_rag,
             model_name=model_name,
             max_token_out=max_token_out,

--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -45,6 +45,11 @@ class JobFields:
     SUCCESS = 'success'
     PR_URL = 'pr_url'
     ARQUIVOS_MODIFICADOS = 'arquivos_modificados'
+    CODIGO_ORIGINAL_BRANCH = 'codigo_original_branch'
+    CODIGO_ORIGINAL_ARQUIVOS = 'codigo_original_arquivos'
+    CODIGO_MODERNIZADO_BRANCH = 'codigo_modernizado_branch'
+    CODIGO_MODERNIZADO_ARQUIVOS = 'codigo_modernizado_arquivos'
+    INSTRUCOES_COMPARACAO_MARKDOWN = 'instrucoes_comparacao_markdown'
 
 class JobActions:
     APPROVE = 'approve'
@@ -67,6 +72,11 @@ class StartAnalysisPayload(BaseModel):
     arquivos_especificos: Optional[List[str]] = Field(None, description="Lista opcional de caminhos específicos de arquivos para ler. Se fornecido, apenas esses arquivos serão processados.")
     analysis_name: Optional[str] = Field(None, description="Nome personalizado para identificar a análise.")
     repository_type: Literal['github', 'gitlab', 'azure'] = Field(description="Tipo do repositório: 'github', 'gitlab', 'azure'.")
+    codigo_original_branch: Optional[str] = Field(None, description="Branch do código original para comparação.")
+    codigo_original_arquivos: Optional[List[str]] = Field(None, description="Lista de caminhos dos arquivos do código original para comparação.")
+    codigo_modernizado_branch: Optional[str] = Field(None, description="Branch do código modernizado para comparação.")
+    codigo_modernizado_arquivos: Optional[List[str]] = Field(None, description="Lista de caminhos dos arquivos do código modernizado para comparação.")
+    instrucoes_comparacao_markdown: Optional[str] = Field(None, description="Instruções em markdown sobre como realizar a comparação entre os códigos.")
 
 class StartAnalysisResponse(BaseModel):
     job_id: str
@@ -166,7 +176,12 @@ def _create_initial_job_data(payload: StartAnalysisPayload, normalized_repo_name
             JobFields.GERAR_NOVO_RELATORIO: payload.gerar_novo_relatorio,
             JobFields.ARQUIVOS_ESPECIFICOS: payload.arquivos_especificos,
             JobFields.ANALYSIS_NAME: analysis_name,
-            JobFields.REPOSITORY_TYPE: payload.repository_type
+            JobFields.REPOSITORY_TYPE: payload.repository_type,
+            JobFields.CODIGO_ORIGINAL_BRANCH: payload.codigo_original_branch,
+            JobFields.CODIGO_ORIGINAL_ARQUIVOS: payload.codigo_original_arquivos,
+            JobFields.CODIGO_MODERNIZADO_BRANCH: payload.codigo_modernizado_branch,
+            JobFields.CODIGO_MODERNIZADO_ARQUIVOS: payload.codigo_modernizado_arquivos,
+            JobFields.INSTRUCOES_COMPARACAO_MARKDOWN: payload.instrucoes_comparacao_markdown
         },
         JobFields.ERROR_DETAILS: None
     }

--- a/services/factories/agent_factory.py
+++ b/services/factories/agent_factory.py
@@ -12,7 +12,7 @@ class AgentFactory:
     
     @classmethod
     def create_agent(cls, agent_type: str, repository_reader: ReaderGeral = None, 
-                    llm_provider: ILLMProvider = None):
+                    llm_provider: ILLMProvider = None, **kwargs):
         agent_class = cls._agents.get(agent_type)
         if not agent_class:
             raise ValueError(f"Tipo de agente desconhecido '{agent_type}'.")

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -106,7 +106,12 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
         agent_params.update({
             'usar_rag': job_info.get("data", {}).get("usar_rag", False), 
             'model_name': model_para_etapa,
-            'repository_type': job_info['data']['repository_type']
+            'repository_type': job_info['data']['repository_type'],
+            'codigo_original_branch': job_info['data'].get('codigo_original_branch'),
+            'codigo_original_arquivos': job_info['data'].get('codigo_original_arquivos'),
+            'codigo_modernizado_branch': job_info['data'].get('codigo_modernizado_branch'),
+            'codigo_modernizado_arquivos': job_info['data'].get('codigo_modernizado_arquivos'),
+            'instrucoes_comparacao_markdown': job_info['data'].get('instrucoes_comparacao_markdown')
         })
 
         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)


### PR DESCRIPTION
Este PR implementa a capacidade de fornecer dois conjuntos de código (original e modernizado) para análise comparativa. Foram adicionados campos opcionais no payload StartAnalysisPayload e na classe JobFields, permitindo especificar branches e arquivos para ambos os códigos. O agente revisor foi adaptado para processar os dois conjuntos e gerar prompts de comparação conforme instruções em markdown. O AgentFactory e o WorkflowOrchestrator foram modificados para aceitar e repassar os novos parâmetros durante a execução dos workflows.