### PR TITLE
Modernização do payload e integração do agente comparador

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -59,10 +59,8 @@ workflow_registry_service = container.get_workflow_registry_service()
 ValidAnalysisTypes = workflow_registry_service.get_valid_analysis_types()
 
 class StartAnalysisPayload(BaseModel):
-    repo_name: str
     projeto: str = Field(description="Nome do projeto para agrupar atividades e organizar histórico")
     analysis_type: ValidAnalysisTypes
-    branch_name: Optional[str] = None
     instrucoes_extras: Optional[str] = None
     usar_rag: bool = Field(False)
     gerar_relatorio_apenas: bool = Field(False)
@@ -71,7 +69,7 @@ class StartAnalysisPayload(BaseModel):
     arquivos_especificos: Optional[List[str]] = Field(None, description="Lista opcional de caminhos específicos de arquivos para ler. Se fornecido, apenas esses arquivos serão processados.")
     analysis_name: Optional[str] = Field(None, description="Nome personalizado para identificar a análise.")
     repository_type: Literal['github', 'gitlab', 'azure'] = Field(description="Tipo do repositório: 'github', 'gitlab', 'azure'.")
-    repo_name_modernizado: Optional[str] = Field(None, description="Nome do repositório modernizado para comparação")
+    repo_name_modernizado: str = Field(description="Nome do repositório modernizado")
     branch_name_modernizado: Optional[str] = Field(None, description="Branch do repositório modernizado")
     repo_name_original: Optional[str] = Field(None, description="Nome do repositório original para comparação")
     branch_name_original: Optional[str] = Field(None, description="Branch do repositório original")
@@ -159,13 +157,17 @@ def _generate_analysis_name(provided_name: Optional[str], job_id: str) -> str:
     return analysis_name
 
 def _create_initial_job_data(payload: StartAnalysisPayload, normalized_repo_name: str, analysis_name: str) -> dict:
+    # Para agentes não-comparadores, usar repo_name_modernizado como repo_name principal
+    repo_name = payload.repo_name_modernizado
+    branch_name = payload.branch_name_modernizado
+    
     return {
         JobFields.STATUS: JobStatus.STARTING,
         JobFields.DATA: {
             JobFields.REPO_NAME: normalized_repo_name,
-            JobFields.ORIGINAL_REPO_NAME: payload.repo_name,
+            JobFields.ORIGINAL_REPO_NAME: repo_name,
             JobFields.PROJETO: payload.projeto,
-            JobFields.BRANCH_NAME: payload.branch_name,
+            JobFields.BRANCH_NAME: branch_name,
             JobFields.ORIGINAL_ANALYSIS_TYPE: payload.analysis_type.value,
             JobFields.INSTRUCOES_EXTRAS: payload.instrucoes_extras,
             JobFields.MODEL_NAME: payload.model_name,
@@ -336,7 +338,8 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     job_store = container.get_job_store()
     analysis_service = container.get_analysis_name_service()
     
-    normalized_repo_name = _normalize_repo_name_by_type(payload.repo_name, payload.repository_type)
+    # Para compatibilidade com agentes não-comparadores, usar repo_name_modernizado como repo_name principal
+    normalized_repo_name = _normalize_repo_name_by_type(payload.repo_name_modernizado, payload.repository_type)
 
     job_id = str(uuid.uuid4())
     analysis_name = _generate_analysis_name(payload.analysis_name, job_id)

--- a/services/step_executors/comparador_step_executor.py
+++ b/services/step_executors/comparador_step_executor.py
@@ -25,10 +25,10 @@ class ComparadorStepExecutor(BaseStepExecutor):
 
         agent_params['instrucoes_extras'] = instrucoes_formatadas
         agent_params.update({
-            'repositorio_modernizado': job_info['data'].get('repo_name_modernizado'),
-            'branch_modernizado': job_info['data'].get('branch_name_modernizado'),
-            'repositorio_original': job_info['data'].get('repo_name_original'),
-            'branch_original': job_info['data'].get('branch_name_original'),
+            'repo_name_modernizado': job_info['data']['repo_name_modernizado'],
+            'branch_name_modernizado': job_info['data']['branch_name_modernizado'],
+            'repo_name_original': job_info['data']['repo_name_original'],
+            'branch_name_original': job_info['data']['branch_name_original'],
             'repository_type': job_info['data']['repository_type'],
             'job_id': job_id,
             'projeto': job_info['data']['projeto'],
@@ -39,7 +39,7 @@ class ComparadorStepExecutor(BaseStepExecutor):
         agent_response = agente.main(**agent_params)
         
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):


### PR DESCRIPTION
Este PR realiza a modernização do framework do MCP Server, removendo as variáveis repo_name e branch_name do payload de entrada e utilizando repo_name_modernizado e branch_name_modernizado como referência principal. Também integra o novo agente comparador ao fluxo de steps, permitindo a comparação entre código original e modernizado para garantir que todas as funcionalidades originais sejam mantidas. A lógica de compatibilidade foi implementada para agentes não-comparadores, minimizando o impacto nas demais partes do sistema conforme solicitado.