### PR TITLE
Timeout automático de jobs por inatividade com mensagem amigável

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,30 @@
-# Configuração do Azure Application Insights
-APPLICATIONINSIGHTS_CONNECTION_STRING=
+# Configurações de Banco de Dados
+DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+
+# Configurações de Redis
+REDIS_URL=redis://localhost:6379/0
+
+# Configurações de Azure
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=account;AccountKey=key;EndpointSuffix=core.windows.net
+AZURE_CONTAINER_NAME=reports
+
+# Configurações de LLM
+OPENAI_API_KEY=sk-your-openai-api-key
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-api-key
+
+# Configurações de Repositório
+GITHUB_TOKEN=ghp_your-github-token
+GITLAB_TOKEN=glpat-your-gitlab-token
+AZURE_DEVOPS_PAT=your-azure-devops-pat
+
+# Configurações de Timeout de Job
+# Tempo limite em segundos para jobs sem alteração de status (default: 360 = 6 minutos)
+JOB_TIMEOUT_SECONDS=360
+
+# Configurações de RAG
+AZURE_SEARCH_SERVICE_NAME=your-search-service
+AZURE_SEARCH_API_KEY=your-search-api-key
+AZURE_SEARCH_INDEX_NAME=your-index-name
+
+# Configurações de Logging
+LOG_LEVEL=INFO

--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from services.dependency_container import DependencyContainer
 from services.workflow_registry_service import WorkflowRegistryService
+from services.job_timeout_monitor import monitor_job_timeouts
 
 class JobStatus:
     STARTING = 'starting'
@@ -49,6 +50,7 @@ class JobFields:
     BRANCH_NAME_MODERNIZADO = 'branch_name_modernizado'
     REPO_NAME_ORIGINAL = 'repo_name_original'
     BRANCH_NAME_ORIGINAL = 'branch_name_original'
+    LAST_STATUS_UPDATE = 'last_status_update'
 
 class JobActions:
     APPROVE = 'approve'
@@ -151,8 +153,10 @@ def _generate_analysis_name(provided_name: Optional[str], job_id: str) -> str:
     return analysis_name
 
 def _create_initial_job_data(payload: StartAnalysisPayload, normalized_repo_name: str, analysis_name: str) -> dict:
+    current_time = time.time()
     return {
         JobFields.STATUS: JobStatus.STARTING,
+        JobFields.LAST_STATUS_UPDATE: current_time,
         JobFields.DATA: {
             JobFields.REPO_NAME: normalized_repo_name,
             JobFields.ORIGINAL_REPO_NAME: payload.repo_name_modernizado,
@@ -200,8 +204,10 @@ def _get_report_from_job(job: dict, job_id: str) -> str:
 
 def _create_derived_job_data(original_job: dict, analysis_name: str, normalized_repo_name: str, report: str) -> dict:
     original_data = original_job[JobFields.DATA]
+    current_time = time.time()
     return {
         JobFields.STATUS: JobStatus.STARTING,
+        JobFields.LAST_STATUS_UPDATE: current_time,
         JobFields.DATA: {
             JobFields.REPO_NAME: normalized_repo_name,
             JobFields.ORIGINAL_REPO_NAME: original_data[JobFields.REPO_NAME],
@@ -352,6 +358,11 @@ def run_workflow_task(job_id: str, start_from_step: int = 0):
     workflow_orchestrator = container.get_workflow_orchestrator()
     workflow_orchestrator.execute_workflow(job_id, start_from_step)
 
+@app.on_event("startup")
+async def startup_event():
+    import asyncio
+    asyncio.create_task(monitor_job_timeouts(container.get_job_store(), container.get_job_handler()))
+
 @app.post("/start-analysis", response_model=StartAnalysisResponse, tags=["Jobs"])
 def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTasks):
     job_store = container.get_job_store()
@@ -391,6 +402,7 @@ def update_job_status(payload: UpdateJobPayload, background_tasks: BackgroundTas
             print(f"[{payload.job_id}] Instruções extras de aprovação salvas: {payload.instrucoes_extras[:100]}...")
         
         job[JobFields.STATUS] = JobStatus.WORKFLOW_STARTED
+        job[JobFields.LAST_STATUS_UPDATE] = time.time()
 
         paused_step = job[JobFields.DATA].get(JobFields.PAUSED_AT_STEP, 0)
         start_from_step = paused_step + 1
@@ -403,6 +415,7 @@ def update_job_status(payload: UpdateJobPayload, background_tasks: BackgroundTas
 
     if payload.action == JobActions.REJECT:
         job[JobFields.STATUS] = JobStatus.REJECTED
+        job[JobFields.LAST_STATUS_UPDATE] = time.time()
         job_store.set_job(payload.job_id, job)
         return {"job_id": payload.job_id, JobFields.STATUS: JobStatus.REJECTED, "message": "Processo encerrado."}
 
@@ -484,10 +497,12 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
             return _build_completed_response(job_id, job, blob_url)
         elif status == JobStatus.FAILED:
             logs = job.get(JobFields.DATA, {}).get(JobFields.DIAGNOSTIC_LOGS)
+            error_details = job.get(JobFields.ERROR_DETAILS, "Nenhum detalhe de erro encontrado.")
+            
             return FinalStatusResponse(
                 job_id=job_id,
                 status=status,
-                error_details=job.get(JobFields.ERROR_DETAILS, "Nenhum detalhe de erro encontrado."),
+                error_details=error_details,
                 diagnostic_logs=logs,
                 report_blob_url=blob_url
             )

--- a/services/job_handler.py
+++ b/services/job_handler.py
@@ -1,4 +1,4 @@
-import json
+import time
 from typing import Dict, Any, Optional
 from domain.interfaces.job_manager_interface import IJobManager
 
@@ -9,35 +9,55 @@ class JobHandler:
     def get_job_info(self, job_id: str) -> Dict[str, Any]:
         job_info = self.job_manager.get_job(job_id)
         if not job_info:
-            raise ValueError("Job não encontrado.")
+            raise ValueError(f"Job {job_id} não encontrado")
         return job_info
     
     def update_job_status(self, job_id: str, status: str) -> None:
-        self.job_manager.update_job_status(job_id, status)
+        job_info = self.get_job_info(job_id)
+        job_info['status'] = status
+        job_info['last_status_update'] = time.time()
+        self.job_manager.set_job(job_id, job_info)
+        print(f"[{job_id}] Status atualizado para: {status}")
     
     def update_job(self, job_id: str, job_info: Dict[str, Any]) -> None:
-        self.job_manager.update_job(job_id, job_info)
+        job_info['last_status_update'] = time.time()
+        self.job_manager.set_job(job_id, job_info)
     
-    def handle_job_error(self, job_id: str, error: Exception, context: str) -> None:
-        self.job_manager.handle_job_error(job_id, error, context)
+    def get_step_result(self, job_info: Dict[str, Any], start_from_step: int) -> Optional[Dict[str, Any]]:
+        if start_from_step > 0:
+            step_key = f"step_{start_from_step - 1}_result"
+            return job_info['data'].get(step_key)
+        return None
     
     def save_step_result(self, job_info: Dict[str, Any], step_index: int, step_result: Dict[str, Any]) -> None:
-        job_info['data'][f'step_{step_index}_result'] = step_result
-    
-    def get_step_result(self, job_info: Dict[str, Any], step_index: int) -> Dict[str, Any]:
-        return job_info['data'].get(f'step_{step_index - 1}_result', {})
-    
-    def should_generate_report_only(self, job_info: Dict[str, Any], current_step_index: int) -> bool:
-        return current_step_index == 0 and job_info['data'].get('gerar_relatorio_apenas') is True
-    
-    def set_approval_instructions(self, job_info: Dict[str, Any], instructions: str) -> None:
-        job_info['data']['instrucoes_extras_aprovacao'] = instructions
+        step_key = f"step_{step_index}_result"
+        job_info['data'][step_key] = step_result
     
     def get_approval_instructions(self, job_info: Dict[str, Any]) -> Optional[str]:
         return job_info['data'].get('instrucoes_extras_aprovacao')
     
     def clear_approval_instructions(self, job_info: Dict[str, Any]) -> None:
-        job_info['data']['instrucoes_extras_aprovacao'] = None
+        if 'instrucoes_extras_aprovacao' in job_info['data']:
+            del job_info['data']['instrucoes_extras_aprovacao']
     
     def set_paused_step(self, job_info: Dict[str, Any], step_index: int) -> None:
         job_info['data']['paused_at_step'] = step_index
+    
+    def handle_job_error(self, job_id: str, error: Exception, context: str) -> None:
+        try:
+            job_info = self.get_job_info(job_id)
+            job_info['status'] = 'failed'
+            job_info['last_status_update'] = time.time()
+            job_info['error_details'] = f"Erro em {context}: {str(error)}"
+            self.job_manager.set_job(job_id, job_info)
+            print(f"[{job_id}] Job marcado como failed devido a erro em {context}: {str(error)}")
+        except Exception as e:
+            print(f"[{job_id}] ERRO CRÍTICO ao tratar erro do job: {str(e)}")
+    
+    def abort_job_due_to_timeout(self, job_id: str, job_info: Dict[str, Any]) -> None:
+        job_info['status'] = 'failed'
+        job_info['last_status_update'] = time.time()
+        job_info['error_details'] = "Tempo limite excedido. Considere reduzir o contexto da solicitação e recomeçar a partir do início."
+        
+        self.job_manager.set_job(job_id, job_info)
+        print(f"[{job_id}] Job abortado por timeout - Status definido como 'failed'")

--- a/services/job_timeout_monitor.py
+++ b/services/job_timeout_monitor.py
@@ -1,0 +1,61 @@
+import asyncio
+import time
+import os
+from typing import Dict, Any
+
+JOB_TIMEOUT_SECONDS = int(os.getenv('JOB_TIMEOUT_SECONDS', 360))
+MONITOR_INTERVAL_SECONDS = 60
+
+RUNNING_STATUSES = ['starting', 'pending_approval', 'workflow_started', 'populating_data', 'committing_to_github']
+
+async def monitor_job_timeouts(job_store, job_handler):
+    print(f"[TIMEOUT_MONITOR] Iniciado com timeout de {JOB_TIMEOUT_SECONDS} segundos")
+    
+    while True:
+        try:
+            await asyncio.sleep(MONITOR_INTERVAL_SECONDS)
+            
+            current_time = time.time()
+            all_jobs = job_store.get_all_jobs()
+            
+            if not all_jobs:
+                continue
+            
+            jobs_checked = 0
+            jobs_aborted = 0
+            
+            for job_id, job_data in all_jobs.items():
+                if not isinstance(job_data, dict):
+                    continue
+                
+                status = job_data.get('status')
+                if status not in RUNNING_STATUSES:
+                    continue
+                
+                jobs_checked += 1
+                last_update = job_data.get('last_status_update')
+                
+                if not last_update:
+                    print(f"[TIMEOUT_MONITOR] Job {job_id} sem timestamp, adicionando timestamp atual")
+                    job_data['last_status_update'] = current_time
+                    job_store.set_job(job_id, job_data)
+                    continue
+                
+                time_since_update = current_time - last_update
+                
+                if time_since_update > JOB_TIMEOUT_SECONDS:
+                    print(f"[TIMEOUT_MONITOR] Job {job_id} excedeu timeout ({time_since_update:.1f}s > {JOB_TIMEOUT_SECONDS}s). Abortando...")
+                    
+                    try:
+                        job_handler.abort_job_due_to_timeout(job_id, job_data)
+                        jobs_aborted += 1
+                        print(f"[TIMEOUT_MONITOR] Job {job_id} abortado com sucesso")
+                    except Exception as e:
+                        print(f"[TIMEOUT_MONITOR] ERRO ao abortar job {job_id}: {str(e)}")
+            
+            if jobs_checked > 0:
+                print(f"[TIMEOUT_MONITOR] Verificados {jobs_checked} jobs em execução, {jobs_aborted} abortados por timeout")
+                
+        except Exception as e:
+            print(f"[TIMEOUT_MONITOR] ERRO no monitor de timeout: {str(e)}")
+            await asyncio.sleep(30)

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -1,4 +1,5 @@
 import json
+import time
 from typing import Dict, Any, Optional
 from domain.interfaces.workflow_orchestrator_interface import IWorkflowOrchestrator
 from domain.interfaces.job_manager_interface import IJobManager
@@ -169,6 +170,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             print(f"[{job_id}] gerar_novo_relatorio=False - Não salvando relatório no Blob Storage")
 
         job_info['status'] = 'pending_approval'
+        job_info['last_status_update'] = time.time()
         self.job_handler.set_paused_step(job_info, step_index)
         self.job_handler.update_job(job_id, job_info)
 


### PR DESCRIPTION
Implementa um mecanismo robusto de timeout para jobs que não mudam de status por mais de 6 minutos. Inclui:
- Atualização do campo de timestamp em toda alteração de status.
- Background task que monitora jobs em execução e aborta jobs parados, marcando-os como 'failed' e adicionando mensagem clara ao usuário: 'Tempo limite excedido. Considere reduzir o contexto da solicitação e recomeçar a partir do início.'
- Endpoint de status retorna a mensagem de timeout quando aplicável.
- Configuração do tempo limite via variável de ambiente JOB_TIMEOUT_SECONDS no .env.example.