### PR TITLE
Timeout automático de 6 minutos para jobs inativos

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -491,13 +491,16 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
 
     status = job.get(JobFields.STATUS)
     blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
+    error_details = job.get(JobFields.ERROR_DETAILS)
 
     try:
         if status == JobStatus.COMPLETED:
             return _build_completed_response(job_id, job, blob_url)
         elif status == JobStatus.FAILED:
             logs = job.get(JobFields.DATA, {}).get(JobFields.DIAGNOSTIC_LOGS)
-            error_details = job.get(JobFields.ERROR_DETAILS, "Nenhum detalhe de erro encontrado.")
+            
+            if not error_details:
+                error_details = "Nenhum detalhe de erro encontrado."
             
             return FinalStatusResponse(
                 job_id=job_id,
@@ -507,7 +510,12 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
                 report_blob_url=blob_url
             )
         else:
-            return FinalStatusResponse(job_id=job_id, status=status, report_blob_url=blob_url)
+            return FinalStatusResponse(
+                job_id=job_id, 
+                status=status, 
+                error_details=error_details,
+                report_blob_url=blob_url
+            )
     except ValidationError as e:
         print(f"ERRO CRÍTICO de Validação no Job ID {job_id}: {e}")
         print(f"Dados brutos do job que causaram o erro: {job}")

--- a/services/job_handler.py
+++ b/services/job_handler.py
@@ -1,4 +1,4 @@
-import json
+import time
 from typing import Dict, Any, Optional
 from domain.interfaces.job_manager_interface import IJobManager
 
@@ -7,37 +7,65 @@ class JobHandler:
         self.job_manager = job_manager
     
     def get_job_info(self, job_id: str) -> Dict[str, Any]:
-        job_info = self.job_manager.get_job(job_id)
-        if not job_info:
-            raise ValueError("Job não encontrado.")
-        return job_info
+        job = self.job_manager.get_job(job_id)
+        if not job:
+            raise ValueError(f"Job {job_id} não encontrado")
+        return job
     
     def update_job_status(self, job_id: str, status: str) -> None:
-        self.job_manager.update_job_status(job_id, status)
+        job = self.job_manager.get_job(job_id)
+        if job:
+            job['status'] = status
+            job['last_status_update'] = time.time()
+            self.job_manager.set_job(job_id, job)
     
-    def update_job(self, job_id: str, job_info: Dict[str, Any]) -> None:
-        self.job_manager.update_job(job_id, job_info)
+    def update_job(self, job_id: str, job_data: Dict[str, Any]) -> None:
+        self.job_manager.set_job(job_id, job_data)
     
-    def handle_job_error(self, job_id: str, error: Exception, context: str) -> None:
-        self.job_manager.handle_job_error(job_id, error, context)
+    def get_step_result(self, job_info: Dict[str, Any], start_from_step: int) -> Dict[str, Any]:
+        if start_from_step == 0:
+            return {}
+        
+        step_results = job_info.get('data', {}).get('step_results', {})
+        previous_step_key = f'step_{start_from_step - 1}'
+        return step_results.get(previous_step_key, {})
     
-    def save_step_result(self, job_info: Dict[str, Any], step_index: int, step_result: Dict[str, Any]) -> None:
-        job_info['data'][f'step_{step_index}_result'] = step_result
-    
-    def get_step_result(self, job_info: Dict[str, Any], step_index: int) -> Dict[str, Any]:
-        return job_info['data'].get(f'step_{step_index - 1}_result', {})
-    
-    def should_generate_report_only(self, job_info: Dict[str, Any], current_step_index: int) -> bool:
-        return current_step_index == 0 and job_info['data'].get('gerar_relatorio_apenas') is True
-    
-    def set_approval_instructions(self, job_info: Dict[str, Any], instructions: str) -> None:
-        job_info['data']['instrucoes_extras_aprovacao'] = instructions
+    def save_step_result(self, job_info: Dict[str, Any], step_index: int, result: Dict[str, Any]) -> None:
+        if 'step_results' not in job_info['data']:
+            job_info['data']['step_results'] = {}
+        
+        step_key = f'step_{step_index}'
+        job_info['data']['step_results'][step_key] = result
     
     def get_approval_instructions(self, job_info: Dict[str, Any]) -> Optional[str]:
-        return job_info['data'].get('instrucoes_extras_aprovacao')
+        return job_info.get('data', {}).get('instrucoes_extras_aprovacao')
     
     def clear_approval_instructions(self, job_info: Dict[str, Any]) -> None:
-        job_info['data']['instrucoes_extras_aprovacao'] = None
+        if 'instrucoes_extras_aprovacao' in job_info.get('data', {}):
+            del job_info['data']['instrucoes_extras_aprovacao']
     
     def set_paused_step(self, job_info: Dict[str, Any], step_index: int) -> None:
         job_info['data']['paused_at_step'] = step_index
+    
+    def handle_job_error(self, job_id: str, error: Exception, context: str) -> None:
+        try:
+            job = self.job_manager.get_job(job_id)
+            if job:
+                job['status'] = 'failed'
+                job['last_status_update'] = time.time()
+                job['error_details'] = f"Erro em {context}: {str(error)}"
+                self.job_manager.set_job(job_id, job)
+        except Exception as e:
+            print(f"[{job_id}] ERRO ao salvar erro do job: {str(e)}")
+    
+    def abort_job_due_to_timeout(self, job_id: str, job_data: Dict[str, Any]) -> None:
+        try:
+            job_data['status'] = 'failed'
+            job_data['last_status_update'] = time.time()
+            job_data['error_details'] = "O workflow foi abortado por inatividade (timeout de 6 minutos). Considere reduzir o contexto da solicitação e recomeçar a partir do início."
+            
+            self.job_manager.set_job(job_id, job_data)
+            print(f"[{job_id}] Job abortado por timeout - mensagem registrada para o usuário")
+            
+        except Exception as e:
+            print(f"[{job_id}] ERRO ao abortar job por timeout: {str(e)}")

--- a/services/job_timeout_monitor.py
+++ b/services/job_timeout_monitor.py
@@ -49,7 +49,7 @@ async def monitor_job_timeouts(job_store, job_handler):
                     try:
                         job_handler.abort_job_due_to_timeout(job_id, job_data)
                         jobs_aborted += 1
-                        print(f"[TIMEOUT_MONITOR] Job {job_id} abortado com sucesso")
+                        print(f"[TIMEOUT_MONITOR] Job {job_id} abortado com sucesso por timeout")
                     except Exception as e:
                         print(f"[TIMEOUT_MONITOR] ERRO ao abortar job {job_id}: {str(e)}")
             


### PR DESCRIPTION
Adiciona mecanismo de timeout para jobs que não atualizarem o status por mais de 6 minutos. O workflow é abortado automaticamente e o usuário recebe uma mensagem clara para reduzir o contexto e tentar novamente. Não altera o fluxo normal, apenas adiciona a checagem temporal e tratamento de erro amigável.