### PR TITLE
fix: garantir salvamento e retorno do relatório no modo 'gerar_relatorio_apenas'

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -85,6 +85,17 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 
                 if strategy.should_finalize_workflow(job_info, current_step_index):
                     print(f"[{job_id}] Finalizando workflow em modo 'gerar_relatorio_apenas'")
+                    
+                    report_text = self.report_handler.extract_report_text(step_result)
+                    job_info['data']['analysis_report'] = report_text
+                    
+                    if job_info['data'].get('gerar_novo_relatorio', True):
+                        print(f"[{job_id}] Salvando relatório no Blob Storage em modo 'gerar_relatorio_apenas'")
+                        self.report_handler.save_report_to_blob(job_id, job_info, report_text, report_generated_by_agent=True)
+                    else:
+                        print(f"[{job_id}] gerar_novo_relatorio=False - Não salvando relatório no Blob Storage")
+                    
+                    self.job_handler.update_job(job_id, job_info)
                     self.report_handler.handle_report_only_mode(job_id, job_info, step_result)
                     self.job_handler.update_job_status(job_id, 'completed')
                     return


### PR DESCRIPTION
Este PR corrige o comportamento do fluxo 'gerar_relatorio_apenas' para que, quando ativado, o relatório gerado seja salvo no Blob Storage e também retornado corretamente como output da API. O ajuste foi feito de forma isolada para não impactar os demais fluxos, que já estão funcionando conforme esperado. A lógica garante que o relatório seja atribuído ao job_info e persistido antes da finalização do workflow.