### PR TITLE
Correção do uso de 'gerar_relatorio_apenas' em todos os executores e orquestrador

### DIFF
--- a/services/step_executors/comparador_step_executor.py
+++ b/services/step_executors/comparador_step_executor.py
@@ -24,6 +24,7 @@ class ComparadorStepExecutor(BaseStepExecutor):
             self.job_handler.update_job(job_id, job_info)
 
         agent_params['instrucoes_extras'] = instrucoes_formatadas
+        agent_params['gerar_relatorio_apenas'] = job_info['data'].get('gerar_relatorio_apenas', False)
         agent_params.update({
             'arquivos_especificos': job_info['data'].get('arquivos_especificos'),
             'repository_type': job_info['data']['repository_type'],
@@ -36,7 +37,7 @@ class ComparadorStepExecutor(BaseStepExecutor):
         agent_response = agente.main(**agent_params)
         
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):

--- a/services/step_executors/processador_step_executor.py
+++ b/services/step_executors/processador_step_executor.py
@@ -24,6 +24,7 @@ class ProcessadorStepExecutor(BaseStepExecutor):
             self.job_handler.update_job(job_id, job_info)
 
         agent_params['instrucoes_extras'] = instrucoes_formatadas
+        agent_params['gerar_relatorio_apenas'] = job_info['data'].get('gerar_relatorio_apenas', False)
         agent_params.update({
             'codigo': previous_step_result,
             'repositorio': job_info['data']['repo_name'],
@@ -35,7 +36,7 @@ class ProcessadorStepExecutor(BaseStepExecutor):
         agent_response = agente.main(**agent_params)
         
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):

--- a/services/step_executors/revisor_step_executor.py
+++ b/services/step_executors/revisor_step_executor.py
@@ -24,6 +24,7 @@ class RevisorStepExecutor(BaseStepExecutor):
             self.job_handler.update_job(job_id, job_info)
 
         agent_params['instrucoes_extras'] = instrucoes_formatadas
+        agent_params['gerar_relatorio_apenas'] = job_info['data'].get('gerar_relatorio_apenas', False)
         
         if 'repositorio' not in agent_params:
             agent_params['repositorio'] = job_info['data']['repo_name']
@@ -42,7 +43,7 @@ class RevisorStepExecutor(BaseStepExecutor):
         agent_response = agente.main(**agent_params)
         
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -140,7 +140,8 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
         agent_params.update({
             'usar_rag': job_info.get("data", {}).get("usar_rag", False), 
             'model_name': model_para_etapa,
-            'repository_type': job_info['data']['repository_type']
+            'repository_type': job_info['data']['repository_type'],
+            'gerar_relatorio_apenas': job_info['data'].get('gerar_relatorio_apenas', False)
         })
 
         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)


### PR DESCRIPTION
Este PR corrige o fluxo de passagem do parâmetro 'gerar_relatorio_apenas' em todos os pontos relevantes do código. Agora, o valor é sempre obtido de 'job_info["data"]' e passado explicitamente para os agent_params em todos os step executors (revisor, comparador, processador) e no método _execute_step_with_strategy do WorkflowOrchestrator. Isso garante que o erro de variável não definida não ocorra mais quando gerar_relatorio_apenas=True. A alteração foi feita de forma a não impactar os fluxos atuais, que já funcionam corretamente quando gerar_relatorio_apenas=False.