### PR TITLE
Suporte à flag incluir_lista_arquivos nos readers e interface

### DIFF
--- a/domain/interfaces/repository_reader_interface.py
+++ b/domain/interfaces/repository_reader_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 
 class IRepositoryReader(ABC):
     """
@@ -13,27 +13,35 @@ class IRepositoryReader(ABC):
     def read_repository(
         self, 
         nome_repo: str, 
-        tipo_analise: str, 
+        tipo_analise: str,
+        repository_type: str,
         nome_branch: str = None,
-        arquivos_especificos: Optional[List[str]] = None
-    ) -> Dict[str, str]:
+        arquivos_especificos: Optional[List[str]] = None,
+        incluir_lista_arquivos: bool = False
+    ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         """
         Lê os arquivos do repositório e retorna um dicionário {caminho: conteudo}.
         
         Args:
             nome_repo (str): Nome do repositório no formato 'org/repo'
             tipo_analise (str): Tipo de análise que determina extensões relevantes
+            repository_type (str): Tipo do repositório ('github', 'gitlab', 'azure')
             nome_branch (str, optional): Nome da branch. Se None, usa branch padrão
             arquivos_especificos (Optional[List[str]], optional): Lista de caminhos
                 específicos de arquivos para ler. Se fornecido, ignora filtro por
                 extensão e lê apenas os arquivos listados. Defaults to None
+            incluir_lista_arquivos (bool, optional): Se True, retorna também lista
+                de todos os arquivos do repositório. Defaults to False
         
         Returns:
-            Dict[str, str]: Dicionário mapeando caminhos de arquivo para conteúdo
+            Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]: 
+                Se incluir_lista_arquivos=False: Dicionário mapeando caminhos para conteúdo
+                Se incluir_lista_arquivos=True: {'arquivos': Dict[caminho, conteudo], 'lista_arquivos': List[str]}
         
         Note:
             - Quando arquivos_especificos é fornecido, o filtro por extensão é ignorado
             - Arquivos não encontrados são tratados com warning, não erro fatal
             - Modo padrão (arquivos_especificos=None) mantém comportamento original
+            - incluir_lista_arquivos permite obter lista completa de arquivos do repositório
         """
         pass

--- a/tools/readers/azure_reader.py
+++ b/tools/readers/azure_reader.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 from domain.interfaces.repository_provider_interface import IRepositoryProvider
 from tools.azure_repository_provider import AzureRepositoryProvider
 from tools.conectores.azure_conector import AzureConector
@@ -21,6 +21,35 @@ class AzureReader(BaseReader):
             "Content-Type": "application/json",
             "Authorization": f"Basic {credentials}"
         }
+
+    def _obter_lista_todos_arquivos(self, repositorio_dict: dict, branch_a_ler: str) -> List[str]:
+        organization = repositorio_dict.get('_organization')
+        project = repositorio_dict.get('_project')
+        repository = repositorio_dict.get('_repository')
+        
+        print(f"[Azure Reader] Obtendo lista completa de arquivos: {organization}/{project}/{repository}")
+        
+        headers = self._get_azure_auth_headers(repositorio_dict)
+        base_url = f"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repository}"
+        
+        try:
+            items_url = f"{base_url}/items?recursionLevel=Full&versionDescriptor.version={branch_a_ler}&api-version=7.0"
+            response = requests.get(items_url, headers=headers, timeout=60)
+            response.raise_for_status()
+            
+            all_items = response.json().get('value', [])
+            
+            lista_arquivos = [
+                item.get('path') for item in all_items
+                if not item.get('isFolder') and item.get('path')
+            ]
+            
+            print(f"[Azure Reader] Lista completa obtida: {len(lista_arquivos)} arquivos encontrados.")
+            return lista_arquivos
+            
+        except Exception as e:
+            print(f"[Azure Reader] ERRO ao obter lista completa de arquivos Azure DevOps: {e}")
+            raise
 
     def _ler_repositorio_completo(self, repositorio_dict: dict, branch_a_ler: str, extensoes_alvo: List[str], arquivos_especificos: Optional[List[str]] = None) -> Dict[str, str]:
         arquivos_do_repo = {}
@@ -90,8 +119,9 @@ class AzureReader(BaseReader):
         tipo_analise: str, 
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None,
-        mapeamento_tipo_extensoes: Dict = None
-    ) -> Dict[str, str]:
+        mapeamento_tipo_extensoes: Dict = None,
+        incluir_lista_arquivos: bool = False
+    ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         
         branch_a_ler = nome_branch or repositorio.get('default_branch', 'main')
         
@@ -101,9 +131,19 @@ class AzureReader(BaseReader):
             if extensoes_alvo is None:
                 raise ValueError(f"Tipo de análise '{tipo_analise}' não encontrado no mapeamento")
         
-        return self._ler_repositorio_completo(
+        arquivos_lidos = self._ler_repositorio_completo(
             repositorio_dict=repositorio,
             branch_a_ler=branch_a_ler,
             extensoes_alvo=extensoes_alvo,
             arquivos_especificos=arquivos_especificos
         )
+        
+        if incluir_lista_arquivos:
+            print("Flag incluir_lista_arquivos ativada - obtendo lista completa de arquivos Azure.")
+            lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)
+            return {
+                'arquivos': arquivos_lidos,
+                'lista_arquivos': lista_todos_arquivos
+            }
+        else:
+            return arquivos_lidos

--- a/tools/readers/github_reader.py
+++ b/tools/readers/github_reader.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 from github import GithubException, UnknownObjectException
 from domain.interfaces.repository_provider_interface import IRepositoryProvider
 from tools.github_repository_provider import GitHubRepositoryProvider
@@ -18,6 +18,31 @@ class GitHubReader(BaseReader):
         return self._ler_arquivos_especificos_base(
             repositorio, branch_a_ler, arquivos_especificos, "GitHub", self._read_github_file
         )
+
+    def _obter_lista_todos_arquivos(self, repositorio, branch_a_ler: str) -> List[str]:
+        try:
+            print(f"Obtendo lista completa de arquivos GitHub da branch '{branch_a_ler}'...")
+            
+            try:
+                ref = repositorio.get_git_ref(f"heads/{branch_a_ler}")
+                tree_sha = ref.object.sha
+            except UnknownObjectException:
+                raise ValueError(f"Branch '{branch_a_ler}' não encontrada.")
+
+            tree_response = repositorio.get_git_tree(tree_sha, recursive=True)
+            tree_elements = tree_response.tree
+            
+            lista_arquivos = [
+                element.path for element in tree_elements
+                if element.type == 'blob'
+            ]
+            
+            print(f"Lista completa GitHub obtida: {len(lista_arquivos)} arquivos encontrados.")
+            return lista_arquivos
+            
+        except GithubException as e:
+            print(f"ERRO ao obter lista completa de arquivos GitHub: {e}")
+            raise
 
     def _ler_repositorio_completo(self, repositorio, branch_a_ler: str, tipo_analise: str, extensoes_alvo: List[str]) -> Dict[str, str]:
         arquivos_do_repo = {}
@@ -69,14 +94,25 @@ class GitHubReader(BaseReader):
         tipo_analise: str, 
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None,
-        mapeamento_tipo_extensoes: Dict = None
-    ) -> Dict[str, str]:
+        mapeamento_tipo_extensoes: Dict = None,
+        incluir_lista_arquivos: bool = False
+    ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         branch_a_ler = self._validar_parametros_leitura(repositorio, nome_branch, "GitHub")
         
         if arquivos_especificos and len(arquivos_especificos) > 0:
             print(f"Modo de leitura filtrada GitHub ativado para {len(arquivos_especificos)} arquivos específicos.")
-            return self._ler_arquivos_especificos(repositorio, branch_a_ler, arquivos_especificos)
+            arquivos_lidos = self._ler_arquivos_especificos(repositorio, branch_a_ler, arquivos_especificos)
         else:
             print("Modo de leitura completa GitHub ativado (filtro por extensão).")
             extensoes_alvo = self._validar_extensoes_alvo(tipo_analise, mapeamento_tipo_extensoes)
-            return self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
+            arquivos_lidos = self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
+        
+        if incluir_lista_arquivos:
+            print("Flag incluir_lista_arquivos ativada - obtendo lista completa de arquivos GitHub.")
+            lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)
+            return {
+                'arquivos': arquivos_lidos,
+                'lista_arquivos': lista_todos_arquivos
+            }
+        else:
+            return arquivos_lidos

--- a/tools/readers/gitlab_reader.py
+++ b/tools/readers/gitlab_reader.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 from domain.interfaces.repository_provider_interface import IRepositoryProvider
 from tools.gitlab_repository_provider import GitLabRepositoryProvider
 from tools.readers.base_reader import BaseReader
@@ -35,6 +35,51 @@ class GitLabReader(BaseReader):
         return self._ler_arquivos_especificos_base(
             repositorio, branch_a_ler, arquivos_especificos, "GitLab", self._read_gitlab_file
         )
+
+    def _obter_lista_todos_arquivos(self, repositorio, branch_a_ler: str) -> List[str]:
+        try:
+            print(f"Obtendo lista completa de arquivos GitLab da branch '{branch_a_ler}' do repositório '{repositorio.path_with_namespace}'...")
+            
+            try:
+                tree_items = repositorio.repository_tree(ref=branch_a_ler, recursive=True, all=True)
+            except Exception as e:
+                if "404" in str(e) or "not found" in str(e).lower():
+                    if "branch" in str(e).lower() or "ref" in str(e).lower():
+                        raise ValueError(
+                            f"Branch '{branch_a_ler}' não encontrada no repositório GitLab "
+                            f"'{repositorio.path_with_namespace}'. Verifique se a branch existe."
+                        ) from e
+                    else:
+                        raise ValueError(
+                            f"Repositório GitLab '{repositorio.path_with_namespace}' não encontrado "
+                            f"ou sem permissão de acesso."
+                        ) from e
+                elif "403" in str(e) or "forbidden" in str(e).lower():
+                    raise PermissionError(
+                        f"Sem permissão para acessar a árvore do repositório GitLab "
+                        f"'{repositorio.path_with_namespace}'. Verifique as permissões do token."
+                    ) from e
+                else:
+                    raise RuntimeError(
+                        f"Erro inesperado ao obter árvore do repositório GitLab "
+                        f"'{repositorio.path_with_namespace}': {e}"
+                    ) from e
+            
+            lista_arquivos = [
+                item['path'] for item in tree_items
+                if item['type'] == 'blob'
+            ]
+            
+            print(f"Lista completa GitLab obtida: {len(lista_arquivos)} arquivos encontrados.")
+            return lista_arquivos
+            
+        except (ValueError, PermissionError, RuntimeError):
+            raise
+        except Exception as e:
+            raise RuntimeError(
+                f"ERRO CRÍTICO ao obter lista completa de arquivos GitLab "
+                f"para o repositório '{repositorio.path_with_namespace}': {e}"
+            ) from e
 
     def _ler_repositorio_completo(self, repositorio, branch_a_ler: str, tipo_analise: str, extensoes_alvo: List[str]) -> Dict[str, str]:
         arquivos_do_repo = {}
@@ -108,18 +153,29 @@ class GitLabReader(BaseReader):
         tipo_analise: str, 
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None,
-        mapeamento_tipo_extensoes: Dict = None
-    ) -> Dict[str, str]:
+        mapeamento_tipo_extensoes: Dict = None,
+        incluir_lista_arquivos: bool = False
+    ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         try:
             branch_a_ler = self._validar_parametros_leitura(repositorio, nome_branch, "GitLab")
             
             if arquivos_especificos and len(arquivos_especificos) > 0:
                 print(f"Modo de leitura filtrada GitLab ativado para {len(arquivos_especificos)} arquivos específicos no repositório '{repositorio.path_with_namespace}'.")
-                return self._ler_arquivos_especificos(repositorio, branch_a_ler, arquivos_especificos)
+                arquivos_lidos = self._ler_arquivos_especificos(repositorio, branch_a_ler, arquivos_especificos)
             else:
                 print(f"Modo de leitura completa GitLab ativado (filtro por extensão) para o repositório '{repositorio.path_with_namespace}'.")
                 extensoes_alvo = self._validar_extensoes_alvo(tipo_analise, mapeamento_tipo_extensoes)
-                return self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
+                arquivos_lidos = self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
+            
+            if incluir_lista_arquivos:
+                print("Flag incluir_lista_arquivos ativada - obtendo lista completa de arquivos GitLab.")
+                lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)
+                return {
+                    'arquivos': arquivos_lidos,
+                    'lista_arquivos': lista_todos_arquivos
+                }
+            else:
+                return arquivos_lidos
                 
         except (ValueError, PermissionError, RuntimeError, FileNotFoundError):
             raise


### PR DESCRIPTION
Este PR adiciona o parâmetro opcional 'incluir_lista_arquivos' à interface IRepositoryReader e implementa o suporte nos readers GitHubReader, GitLabReader e AzureReader. Quando a flag é ativada, o retorno inclui tanto os conteúdos lidos quanto uma lista com o nome de todos os arquivos presentes no repositório. Isso permite que os agentes recebam, de forma opcional, o inventário completo de arquivos do repo junto ao conteúdo solicitado.