### PR TITLE
Suporte à flag opcional para retornar lista de arquivos em leitores de repositório

### DIFF
--- a/domain/interfaces/repository_reader_interface.py
+++ b/domain/interfaces/repository_reader_interface.py
@@ -17,7 +17,7 @@ class IRepositoryReader(ABC):
         repository_type: str,
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None,
-        incluir_lista_arquivos: bool = False
+        retornar_lista_arquivos: bool = False
     ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         """
         Lê os arquivos do repositório e retorna um dicionário {caminho: conteudo}.
@@ -30,18 +30,18 @@ class IRepositoryReader(ABC):
             arquivos_especificos (Optional[List[str]], optional): Lista de caminhos
                 específicos de arquivos para ler. Se fornecido, ignora filtro por
                 extensão e lê apenas os arquivos listados. Defaults to None
-            incluir_lista_arquivos (bool, optional): Se True, retorna também lista
+            retornar_lista_arquivos (bool, optional): Se True, retorna também lista
                 de todos os arquivos do repositório. Defaults to False
         
         Returns:
             Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]: 
-                Se incluir_lista_arquivos=False: Dicionário mapeando caminhos para conteúdo
-                Se incluir_lista_arquivos=True: {'arquivos': Dict[caminho, conteudo], 'lista_arquivos': List[str]}
+                Se retornar_lista_arquivos=False: Dicionário mapeando caminhos para conteúdo
+                Se retornar_lista_arquivos=True: {'codigo': Dict[caminho, conteudo], 'lista_arquivos': List[str]}
         
         Note:
             - Quando arquivos_especificos é fornecido, o filtro por extensão é ignorado
             - Arquivos não encontrados são tratados com warning, não erro fatal
             - Modo padrão (arquivos_especificos=None) mantém comportamento original
-            - incluir_lista_arquivos permite obter lista completa de arquivos do repositório
+            - retornar_lista_arquivos permite obter lista completa de arquivos do repositório
         """
         pass

--- a/tools/readers/azure_reader.py
+++ b/tools/readers/azure_reader.py
@@ -120,7 +120,7 @@ class AzureReader(BaseReader):
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None,
         mapeamento_tipo_extensoes: Dict = None,
-        incluir_lista_arquivos: bool = False
+        retornar_lista_arquivos: bool = False
     ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         
         branch_a_ler = nome_branch or repositorio.get('default_branch', 'main')
@@ -138,11 +138,11 @@ class AzureReader(BaseReader):
             arquivos_especificos=arquivos_especificos
         )
         
-        if incluir_lista_arquivos:
-            print("Flag incluir_lista_arquivos ativada - obtendo lista completa de arquivos Azure.")
+        if retornar_lista_arquivos:
+            print("Flag retornar_lista_arquivos ativada - obtendo lista completa de arquivos Azure.")
             lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)
             return {
-                'arquivos': arquivos_lidos,
+                'codigo': arquivos_lidos,
                 'lista_arquivos': lista_todos_arquivos
             }
         else:

--- a/tools/readers/github_reader.py
+++ b/tools/readers/github_reader.py
@@ -95,7 +95,7 @@ class GitHubReader(BaseReader):
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None,
         mapeamento_tipo_extensoes: Dict = None,
-        incluir_lista_arquivos: bool = False
+        retornar_lista_arquivos: bool = False
     ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         branch_a_ler = self._validar_parametros_leitura(repositorio, nome_branch, "GitHub")
         
@@ -107,11 +107,11 @@ class GitHubReader(BaseReader):
             extensoes_alvo = self._validar_extensoes_alvo(tipo_analise, mapeamento_tipo_extensoes)
             arquivos_lidos = self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
         
-        if incluir_lista_arquivos:
-            print("Flag incluir_lista_arquivos ativada - obtendo lista completa de arquivos GitHub.")
+        if retornar_lista_arquivos:
+            print("Flag retornar_lista_arquivos ativada - obtendo lista completa de arquivos GitHub.")
             lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)
             return {
-                'arquivos': arquivos_lidos,
+                'codigo': arquivos_lidos,
                 'lista_arquivos': lista_todos_arquivos
             }
         else:

--- a/tools/readers/gitlab_reader.py
+++ b/tools/readers/gitlab_reader.py
@@ -154,7 +154,7 @@ class GitLabReader(BaseReader):
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None,
         mapeamento_tipo_extensoes: Dict = None,
-        incluir_lista_arquivos: bool = False
+        retornar_lista_arquivos: bool = False
     ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         try:
             branch_a_ler = self._validar_parametros_leitura(repositorio, nome_branch, "GitLab")
@@ -167,11 +167,11 @@ class GitLabReader(BaseReader):
                 extensoes_alvo = self._validar_extensoes_alvo(tipo_analise, mapeamento_tipo_extensoes)
                 arquivos_lidos = self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
             
-            if incluir_lista_arquivos:
-                print("Flag incluir_lista_arquivos ativada - obtendo lista completa de arquivos GitLab.")
+            if retornar_lista_arquivos:
+                print("Flag retornar_lista_arquivos ativada - obtendo lista completa de arquivos GitLab.")
                 lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)
                 return {
-                    'arquivos': arquivos_lidos,
+                    'codigo': arquivos_lidos,
                     'lista_arquivos': lista_todos_arquivos
                 }
             else:

--- a/tools/readers/reader_geral.py
+++ b/tools/readers/reader_geral.py
@@ -1,7 +1,7 @@
 import time
 import yaml
 import os
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 from domain.interfaces.repository_reader_interface import IRepositoryReader
 from domain.interfaces.repository_provider_interface import IRepositoryProvider
 from tools.github_repository_provider import GitHubRepositoryProvider
@@ -55,11 +55,13 @@ class ReaderGeral(IRepositoryReader):
         tipo_analise: str,
         repository_type: str,
         nome_branch: str = None,
-        arquivos_especificos: Optional[List[str]] = None
-    ) -> Dict[str, str]:
+        arquivos_especificos: Optional[List[str]] = None,
+        retornar_lista_arquivos: bool = False
+    ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         provider_name = type(self.repository_provider).__name__
         print(f"[Reader Geral] Iniciando leitura do repositório: {nome_repo} via {provider_name}")
         print(f"[Reader Geral] Tipo de repositório explícito: {repository_type}")
+        print(f"[Reader Geral] Flag retornar_lista_arquivos: {retornar_lista_arquivos}")
 
         conexao_geral = ConexaoGeral.create_with_defaults()
         
@@ -74,25 +76,32 @@ class ReaderGeral(IRepositoryReader):
         if repository_type == 'azure':
             print(f"[Reader Geral] Delegando para Azure Reader")
             resultado = self.azure_reader.read_repository_internal(
-                repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes
+                repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes, retornar_lista_arquivos
             )
         elif repository_type == 'gitlab':
             print(f"[Reader Geral] Delegando para GitLab Reader")
             resultado = self.gitlab_reader.read_repository_internal(
-                repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes
+                repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes, retornar_lista_arquivos
             )
         else:
             print(f"[Reader Geral] Delegando para GitHub Reader")
             resultado = self.github_reader.read_repository_internal(
-                repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes
+                repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes, retornar_lista_arquivos
             )
         
-        print(f"[Reader Geral] Resultado da leitura: {len(resultado) if resultado else 0} arquivos")
+        if retornar_lista_arquivos and isinstance(resultado, dict) and 'codigo' in resultado:
+            print(f"[Reader Geral] Resultado da leitura: {len(resultado['codigo']) if resultado['codigo'] else 0} arquivos de código, {len(resultado['lista_arquivos']) if resultado.get('lista_arquivos') else 0} arquivos totais")
+        else:
+            print(f"[Reader Geral] Resultado da leitura: {len(resultado) if resultado else 0} arquivos")
         
         if not resultado:
             print(f"[Reader Geral] AVISO CRÍTICO: Leitura retornou vazia para repositório {nome_repo} (tipo: {repository_type})")
             print(f"[Reader Geral] Parâmetros: tipo_analise={tipo_analise}, branch={nome_branch}, arquivos_especificos={arquivos_especificos}")
         else:
-            print(f"[Reader Geral] Arquivos lidos com sucesso: {list(resultado.keys())[:5]}{'...' if len(resultado) > 5 else ''}")
+            if retornar_lista_arquivos and isinstance(resultado, dict) and 'codigo' in resultado:
+                arquivos_lidos = resultado['codigo']
+                print(f"[Reader Geral] Arquivos lidos com sucesso: {list(arquivos_lidos.keys())[:5]}{'...' if len(arquivos_lidos) > 5 else ''}")
+            else:
+                print(f"[Reader Geral] Arquivos lidos com sucesso: {list(resultado.keys())[:5]}{'...' if len(resultado) > 5 else ''}")
         
         return resultado


### PR DESCRIPTION
Este PR implementa a funcionalidade que permite, de forma opcional, que os agentes recebam uma lista com os nomes de todos os arquivos presentes no repositório, além dos conteúdos dos arquivos lidos. Para isso, foi adicionada a flag booleana 'retornar_lista_arquivos' nos métodos de leitura de repositório, e todos os readers (GitHub, GitLab, Azure) foram adaptados para suportar e retornar essa lista quando solicitado.