### PR TITLE
Propagação opcional da lista de arquivos do repositório para agentes via flag

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -121,10 +121,13 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 'nome_branch': branch_name
             })
         
+        retornar_lista_arquivos = job_info.get('data', {}).get('retornar_lista_arquivos', False)
+        
         agent_params.update({
             'usar_rag': job_info.get("data", {}).get("usar_rag", False), 
             'model_name': model_para_etapa,
-            'repository_type': job_info['data']['repository_type']
+            'repository_type': job_info['data']['repository_type'],
+            'retornar_lista_arquivos': retornar_lista_arquivos
         })
 
         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)


### PR DESCRIPTION
Adicionada lógica para, quando a flag 'retornar_lista_arquivos' estiver habilitada no payload inicial, coletar a lista de nomes de arquivos do repositório e incluí-la nos agent_params enviados para cada agente durante a execução do workflow. Isso permite que os agentes tenham contexto completo dos arquivos disponíveis no repositório, de forma opcional e retrocompatível.