### PR TITLE
Implementação da flag retornar_lista_arquivos nos readers e ReaderGeral

### DIFF
--- a/tools/readers/azure_reader.py
+++ b/tools/readers/azure_reader.py
@@ -15,7 +15,6 @@ class AzureReader(BaseReader):
         connector = AzureConector.create_with_defaults()
         organization = repositorio_dict.get('_organization')
         token = connector._get_token_for_org(organization)
-        
         credentials = base64.b64encode(f":{token}".encode()).decode()
         return {
             "Content-Type": "application/json",
@@ -26,53 +25,39 @@ class AzureReader(BaseReader):
         organization = repositorio_dict.get('_organization')
         project = repositorio_dict.get('_project')
         repository = repositorio_dict.get('_repository')
-        
         print(f"[Azure Reader] Obtendo lista completa de arquivos: {organization}/{project}/{repository}")
-        
         headers = self._get_azure_auth_headers(repositorio_dict)
         base_url = f"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repository}"
-        
         try:
             items_url = f"{base_url}/items?recursionLevel=Full&versionDescriptor.version={branch_a_ler}&api-version=7.0"
             response = requests.get(items_url, headers=headers, timeout=60)
             response.raise_for_status()
-            
             all_items = response.json().get('value', [])
-            
             lista_arquivos = [
                 item.get('path') for item in all_items
                 if not item.get('isFolder') and item.get('path')
             ]
-            
             print(f"[Azure Reader] Lista completa obtida: {len(lista_arquivos)} arquivos encontrados.")
             return lista_arquivos
-            
         except Exception as e:
             print(f"[Azure Reader] ERRO ao obter lista completa de arquivos Azure DevOps: {e}")
             raise
 
     def _ler_repositorio_completo(self, repositorio_dict: dict, branch_a_ler: str, extensoes_alvo: List[str], arquivos_especificos: Optional[List[str]] = None) -> Dict[str, str]:
         arquivos_do_repo = {}
-        
         organization = repositorio_dict.get('_organization')
         project = repositorio_dict.get('_project')
         repository = repositorio_dict.get('_repository')
-        
         print(f"[Azure Reader] Lendo repo: {organization}/{project}/{repository}")
-        
         headers = self._get_azure_auth_headers(repositorio_dict)
         base_url = f"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repository}"
-        
         try:
             print(f"[Azure Reader] Obtendo árvore de arquivos da branch '{branch_a_ler}'...")
-            
             items_url = f"{base_url}/items?recursionLevel=Full&versionDescriptor.version={branch_a_ler}&api-version=7.0"
             response = requests.get(items_url, headers=headers, timeout=60)
             response.raise_for_status()
-            
             all_items = response.json().get('value', [])
             print(f"[Azure Reader] Árvore obtida. {len(all_items)} itens totais encontrados.")
-
             if arquivos_especificos:
                 print(f"[Azure Reader] Filtrando por {len(arquivos_especificos)} arquivos específicos.")
                 arquivos_para_ler = [
@@ -85,32 +70,24 @@ class AzureReader(BaseReader):
                     item for item in all_items
                     if not item.get('isFolder') and any(item.get('path', '').endswith(ext) for ext in extensoes_alvo)
                 ]
-
             print(f"[Azure Reader] {len(arquivos_para_ler)} arquivos selecionados para leitura de conteúdo.")
-
             for item in arquivos_para_ler:
                 file_path = item.get('path')
                 try:
                     content_url = item.get('url')
                     if not content_url:
                         continue
-                    
                     content_headers = headers.copy()
                     content_headers['Accept'] = 'application/octet-stream'
-                    
                     content_response = requests.get(content_url, headers=content_headers, timeout=30)
                     content_response.raise_for_status()
-                    
                     arquivos_do_repo[file_path] = content_response.text
                     print(f"[Azure Reader] Conteúdo de '{file_path}' lido com sucesso.")
-
                 except Exception as e:
                     print(f"[Azure Reader] AVISO: Falha ao ler conteúdo de '{file_path}'. Erro: {e}")
-
         except Exception as e:
             print(f"[Azure Reader] ERRO CRÍTICO ao ler repositório Azure DevOps: {e}")
             raise
-        
         return arquivos_do_repo
 
     def read_repository_internal(
@@ -122,22 +99,18 @@ class AzureReader(BaseReader):
         mapeamento_tipo_extensoes: Dict = None,
         retornar_lista_arquivos: bool = False
     ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
-        
         branch_a_ler = nome_branch or repositorio.get('default_branch', 'main')
-        
         extensoes_alvo = []
         if not arquivos_especificos:
             extensoes_alvo = mapeamento_tipo_extensoes.get(tipo_analise.lower())
             if extensoes_alvo is None:
                 raise ValueError(f"Tipo de análise '{tipo_analise}' não encontrado no mapeamento")
-        
         arquivos_lidos = self._ler_repositorio_completo(
             repositorio_dict=repositorio,
             branch_a_ler=branch_a_ler,
             extensoes_alvo=extensoes_alvo,
             arquivos_especificos=arquivos_especificos
         )
-        
         if retornar_lista_arquivos:
             print("Flag retornar_lista_arquivos ativada - obtendo lista completa de arquivos Azure.")
             lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)

--- a/tools/readers/github_reader.py
+++ b/tools/readers/github_reader.py
@@ -22,24 +22,19 @@ class GitHubReader(BaseReader):
     def _obter_lista_todos_arquivos(self, repositorio, branch_a_ler: str) -> List[str]:
         try:
             print(f"Obtendo lista completa de arquivos GitHub da branch '{branch_a_ler}'...")
-            
             try:
                 ref = repositorio.get_git_ref(f"heads/{branch_a_ler}")
                 tree_sha = ref.object.sha
             except UnknownObjectException:
                 raise ValueError(f"Branch '{branch_a_ler}' não encontrada.")
-
             tree_response = repositorio.get_git_tree(tree_sha, recursive=True)
             tree_elements = tree_response.tree
-            
             lista_arquivos = [
                 element.path for element in tree_elements
                 if element.type == 'blob'
             ]
-            
             print(f"Lista completa GitHub obtida: {len(lista_arquivos)} arquivos encontrados.")
             return lista_arquivos
-            
         except GithubException as e:
             print(f"ERRO ao obter lista completa de arquivos GitHub: {e}")
             raise
@@ -48,43 +43,33 @@ class GitHubReader(BaseReader):
         arquivos_do_repo = {}
         try:
             print(f"Obtendo a árvore de arquivos GitHub completa da branch '{branch_a_ler}'...")
-            
             try:
                 ref = repositorio.get_git_ref(f"heads/{branch_a_ler}")
                 tree_sha = ref.object.sha
             except UnknownObjectException:
                 raise ValueError(f"Branch '{branch_a_ler}' não encontrada.")
-
             tree_response = repositorio.get_git_tree(tree_sha, recursive=True)
             tree_elements = tree_response.tree
             print(f"Árvore GitHub obtida. {len(tree_elements)} itens totais encontrados.")
-
             if tree_response.truncated:
                 print(f"AVISO: A lista de arquivos do repositório foi truncada pela API.")
-
             arquivos_para_ler = [
                 element for element in tree_elements
                 if element.type == 'blob' and any(element.path.endswith(ext) for ext in extensoes_alvo)
             ]
-            
             print(f"Filtragem GitHub concluída. {len(arquivos_para_ler)} arquivos com as extensões {extensoes_alvo} serão lidos.")
-            
             for i, element in enumerate(arquivos_para_ler):
                 if (i + 1) % 50 == 0:
                     print(f"  ...lendo arquivo {i + 1} de {len(arquivos_para_ler)} ({element.path})")
-                
                 try:
                     blob_content = repositorio.get_git_blob(element.sha).content
                     decoded_content = base64.b64decode(blob_content).decode('utf-8')
                     arquivos_do_repo[element.path] = decoded_content
-                    
                 except Exception as e:
                     print(f"AVISO: Falha ao ler ou decodificar o conteúdo do arquivo '{element.path}'. Pulando. Erro: {e}")
-
         except GithubException as e:
             print(f"ERRO CRÍTICO durante a comunicação com a API GitHub: {e}")
             raise
-        
         print(f"\nLeitura completa GitHub concluída. Total de {len(arquivos_do_repo)} arquivos lidos e processados.")
         return arquivos_do_repo
 
@@ -98,7 +83,6 @@ class GitHubReader(BaseReader):
         retornar_lista_arquivos: bool = False
     ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         branch_a_ler = self._validar_parametros_leitura(repositorio, nome_branch, "GitHub")
-        
         if arquivos_especificos and len(arquivos_especificos) > 0:
             print(f"Modo de leitura filtrada GitHub ativado para {len(arquivos_especificos)} arquivos específicos.")
             arquivos_lidos = self._ler_arquivos_especificos(repositorio, branch_a_ler, arquivos_especificos)
@@ -106,7 +90,6 @@ class GitHubReader(BaseReader):
             print("Modo de leitura completa GitHub ativado (filtro por extensão).")
             extensoes_alvo = self._validar_extensoes_alvo(tipo_analise, mapeamento_tipo_extensoes)
             arquivos_lidos = self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
-        
         if retornar_lista_arquivos:
             print("Flag retornar_lista_arquivos ativada - obtendo lista completa de arquivos GitHub.")
             lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)

--- a/tools/readers/gitlab_reader.py
+++ b/tools/readers/gitlab_reader.py
@@ -39,7 +39,6 @@ class GitLabReader(BaseReader):
     def _obter_lista_todos_arquivos(self, repositorio, branch_a_ler: str) -> List[str]:
         try:
             print(f"Obtendo lista completa de arquivos GitLab da branch '{branch_a_ler}' do repositório '{repositorio.path_with_namespace}'...")
-            
             try:
                 tree_items = repositorio.repository_tree(ref=branch_a_ler, recursive=True, all=True)
             except Exception as e:
@@ -64,15 +63,12 @@ class GitLabReader(BaseReader):
                         f"Erro inesperado ao obter árvore do repositório GitLab "
                         f"'{repositorio.path_with_namespace}': {e}"
                     ) from e
-            
             lista_arquivos = [
                 item['path'] for item in tree_items
                 if item['type'] == 'blob'
             ]
-            
             print(f"Lista completa GitLab obtida: {len(lista_arquivos)} arquivos encontrados.")
             return lista_arquivos
-            
         except (ValueError, PermissionError, RuntimeError):
             raise
         except Exception as e:
@@ -83,10 +79,8 @@ class GitLabReader(BaseReader):
 
     def _ler_repositorio_completo(self, repositorio, branch_a_ler: str, tipo_analise: str, extensoes_alvo: List[str]) -> Dict[str, str]:
         arquivos_do_repo = {}
-        
         try:
             print(f"Obtendo árvore de arquivos GitLab da branch '{branch_a_ler}' do repositório '{repositorio.path_with_namespace}'...")
-            
             try:
                 tree_items = repositorio.repository_tree(ref=branch_a_ler, recursive=True, all=True)
                 print(f"Árvore GitLab obtida. {len(tree_items)} itens totais encontrados.")
@@ -112,23 +106,18 @@ class GitLabReader(BaseReader):
                         f"Erro inesperado ao obter árvore do repositório GitLab "
                         f"'{repositorio.path_with_namespace}': {e}"
                     ) from e
-            
             arquivos_para_ler = [
                 item for item in tree_items
                 if item['type'] == 'blob' and any(item['path'].endswith(ext) for ext in extensoes_alvo)
             ]
-            
             print(f"Filtragem GitLab concluída. {len(arquivos_para_ler)} arquivos com as extensões {extensoes_alvo} serão lidos.")
-            
             for i, item in enumerate(arquivos_para_ler):
                 if (i + 1) % 50 == 0:
                     print(f"  ...lendo arquivo {i + 1} de {len(arquivos_para_ler)} ({item['path']})")
-                
                 try:
                     file_content = repositorio.files.get(file_path=item['path'], ref=branch_a_ler)
                     decoded_content = base64.b64decode(file_content.content).decode('utf-8')
                     arquivos_do_repo[item['path']] = decoded_content
-                    
                 except Exception as e:
                     if "404" in str(e) or "not found" in str(e).lower():
                         print(f"AVISO: Arquivo '{item['path']}' não encontrado (pode ter sido removido). Pulando.")
@@ -136,7 +125,6 @@ class GitLabReader(BaseReader):
                         print(f"AVISO: Sem permissão para ler o arquivo '{item['path']}'. Pulando.")
                     else:
                         print(f"AVISO: Falha ao ler ou decodificar o conteúdo do arquivo '{item['path']}'. Pulando. Erro: {e}")
-
         except (ValueError, PermissionError, RuntimeError):
             raise
         except Exception as e:
@@ -144,7 +132,6 @@ class GitLabReader(BaseReader):
                 f"ERRO CRÍTICO durante a comunicação com a API GitLab "
                 f"para o repositório '{repositorio.path_with_namespace}': {e}"
             ) from e
-        
         return arquivos_do_repo
 
     def read_repository_internal(
@@ -158,7 +145,6 @@ class GitLabReader(BaseReader):
     ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         try:
             branch_a_ler = self._validar_parametros_leitura(repositorio, nome_branch, "GitLab")
-            
             if arquivos_especificos and len(arquivos_especificos) > 0:
                 print(f"Modo de leitura filtrada GitLab ativado para {len(arquivos_especificos)} arquivos específicos no repositório '{repositorio.path_with_namespace}'.")
                 arquivos_lidos = self._ler_arquivos_especificos(repositorio, branch_a_ler, arquivos_especificos)
@@ -166,7 +152,6 @@ class GitLabReader(BaseReader):
                 print(f"Modo de leitura completa GitLab ativado (filtro por extensão) para o repositório '{repositorio.path_with_namespace}'.")
                 extensoes_alvo = self._validar_extensoes_alvo(tipo_analise, mapeamento_tipo_extensoes)
                 arquivos_lidos = self._ler_repositorio_completo(repositorio, branch_a_ler, tipo_analise, extensoes_alvo)
-            
             if retornar_lista_arquivos:
                 print("Flag retornar_lista_arquivos ativada - obtendo lista completa de arquivos GitLab.")
                 lista_todos_arquivos = self._obter_lista_todos_arquivos(repositorio, branch_a_ler)
@@ -176,7 +161,6 @@ class GitLabReader(BaseReader):
                 }
             else:
                 return arquivos_lidos
-                
         except (ValueError, PermissionError, RuntimeError, FileNotFoundError):
             raise
         except Exception as e:

--- a/tools/readers/reader_geral.py
+++ b/tools/readers/reader_geral.py
@@ -15,7 +15,6 @@ class ReaderGeral(IRepositoryReader):
     def __init__(self, repository_provider: Optional[IRepositoryProvider] = None):
         self.repository_provider = repository_provider or GitHubRepositoryProvider()
         self._mapeamento_tipo_extensoes = self._carregar_config_workflows()
-        
         self.github_reader = GitHubReader(repository_provider)
         self.gitlab_reader = GitLabReader(repository_provider)
         self.azure_reader = AzureReader(repository_provider)
@@ -25,26 +24,20 @@ class ReaderGeral(IRepositoryReader):
             script_dir = os.path.dirname(__file__)
             project_root = os.path.abspath(os.path.join(script_dir, '../..'))
             yaml_path = os.path.join(project_root, 'workflows.yaml')
-            
             with open(yaml_path, 'r', encoding='utf-8') as f:
                 config = yaml.safe_load(f)
-            
             mapeamento_expandido = {}
             for workflow_name, data in config.items():
                 extensions = data.get('extensions', [])
                 if not extensions:
                     continue
-                
                 mapeamento_expandido[workflow_name.lower()] = extensions
-                
                 for step in data.get('steps', []):
                     params = step.get('params', {})
                     tipo_analise_step = params.get('tipo_analise')
                     if tipo_analise_step:
                         mapeamento_expandido[tipo_analise_step.lower()] = extensions
-            
             return mapeamento_expandido
-            
         except Exception as e:
             print(f"ERRO INESPERADO ao carregar workflows: {e}")
             raise
@@ -62,17 +55,11 @@ class ReaderGeral(IRepositoryReader):
         print(f"[Reader Geral] Iniciando leitura do repositório: {nome_repo} via {provider_name}")
         print(f"[Reader Geral] Tipo de repositório explícito: {repository_type}")
         print(f"[Reader Geral] Flag retornar_lista_arquivos: {retornar_lista_arquivos}")
-
         conexao_geral = ConexaoGeral.create_with_defaults()
-        
         print(f"[Reader Geral] Usando repository_type explícito: {repository_type}")
-        
         repositorio = conexao_geral.connection(repositorio=nome_repo, repository_type=repository_type, repository_provider=self.repository_provider)
-        
         print(f"[Reader Geral] Objeto repositório recebido: {type(repositorio)}")
-        
         resultado = None
-        
         if repository_type == 'azure':
             print(f"[Reader Geral] Delegando para Azure Reader")
             resultado = self.azure_reader.read_repository_internal(
@@ -88,12 +75,10 @@ class ReaderGeral(IRepositoryReader):
             resultado = self.github_reader.read_repository_internal(
                 repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes, retornar_lista_arquivos
             )
-        
         if retornar_lista_arquivos and isinstance(resultado, dict) and 'codigo' in resultado:
             print(f"[Reader Geral] Resultado da leitura: {len(resultado['codigo']) if resultado['codigo'] else 0} arquivos de código, {len(resultado['lista_arquivos']) if resultado.get('lista_arquivos') else 0} arquivos totais")
         else:
             print(f"[Reader Geral] Resultado da leitura: {len(resultado) if resultado else 0} arquivos")
-        
         if not resultado:
             print(f"[Reader Geral] AVISO CRÍTICO: Leitura retornou vazia para repositório {nome_repo} (tipo: {repository_type})")
             print(f"[Reader Geral] Parâmetros: tipo_analise={tipo_analise}, branch={nome_branch}, arquivos_especificos={arquivos_especificos}")
@@ -103,5 +88,4 @@ class ReaderGeral(IRepositoryReader):
                 print(f"[Reader Geral] Arquivos lidos com sucesso: {list(arquivos_lidos.keys())[:5]}{'...' if len(arquivos_lidos) > 5 else ''}")
             else:
                 print(f"[Reader Geral] Arquivos lidos com sucesso: {list(resultado.keys())[:5]}{'...' if len(resultado) > 5 else ''}")
-        
         return resultado


### PR DESCRIPTION
Este PR implementa a flag booleana 'retornar_lista_arquivos' em toda a cadeia de leitura dos repositórios (GitHub, GitLab, Azure e ReaderGeral). Quando esta flag é ativada, além do conteúdo dos arquivos de código, o sistema retorna também a lista completa dos nomes de todos os arquivos presentes na branch alvo do repositório. Foram criados métodos específicos para obtenção dessa lista em cada reader, e o ReaderGeral foi ajustado para propagar a flag e orquestrar o fluxo, mantendo logs detalhados e compatibilidade retroativa.