### PR TITLE
Propagação da flag retornar_lista_arquivos nos step executors

### DIFF
--- a/services/step_executors/processador_step_executor.py
+++ b/services/step_executors/processador_step_executor.py
@@ -31,11 +31,17 @@ class ProcessadorStepExecutor(BaseStepExecutor):
             'repository_type': job_info['data']['repository_type']
         })
         
+        # Passo 11: Propagar retornar_lista_arquivos
+        agent_params['retornar_lista_arquivos'] = agent_params.get('retornar_lista_arquivos', False)
+        # Se previous_step_result contém lista_arquivos, propagar também
+        if isinstance(previous_step_result, dict) and 'lista_arquivos' in previous_step_result:
+            agent_params['lista_arquivos'] = previous_step_result['lista_arquivos']
+        
         agente = AgentFactory.create_agent("processador", None, llm_provider)
         agent_response = agente.main(**agent_params)
         
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):

--- a/services/step_executors/revisor_step_executor.py
+++ b/services/step_executors/revisor_step_executor.py
@@ -38,11 +38,14 @@ class RevisorStepExecutor(BaseStepExecutor):
             'status_update': step['status_update']
         })
         
+        # Passo 10: Propagar retornar_lista_arquivos
+        agent_params['retornar_lista_arquivos'] = agent_params.get('retornar_lista_arquivos', False)
+        
         agente = AgentFactory.create_agent("revisor", repo_reader, llm_provider)
         agent_response = agente.main(**agent_params)
         
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):


### PR DESCRIPTION
Este PR implementa a propagação da flag booleana retornar_lista_arquivos nos step executors Revisor e Processador. Com isso, os agentes podem receber opcionalmente a lista de nomes de todos os arquivos do repositório, conforme solicitado. No Processador, a lista de arquivos também é repassada quando disponível. Não foram criados testes nem modificados requisitos.