### PR TITLE
Implementa lógica de adição incremental de conteúdo em arquivos existentes

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -50,6 +50,7 @@ class JobFields:
     REPO_NAME_ORIGINAL = 'repo_name_original'
     BRANCH_NAME_ORIGINAL = 'branch_name_original'
     RETORNAR_LISTA_ARQUIVOS = 'retornar_lista_arquivos'
+    MODO_ADICAO_INCREMENTAL = 'modo_adicao_incremental'
 
 class JobActions:
     APPROVE = 'approve'
@@ -75,6 +76,7 @@ class StartAnalysisPayload(BaseModel):
     repo_name_original: Optional[str] = Field(None, description="Nome do repositório original para comparação")
     branch_name_original: Optional[str] = Field(None, description="Branch do repositório original")
     retornar_lista_arquivos: bool = Field(False, description="Se True, além do código filtrado, retorna lista completa de todos os arquivos do repositório")
+    modo_adicao_incremental: bool = Field(False, description="Se True, o novo conteúdo será ADICIONADO ao final dos arquivos existentes, ao invés de substituí-los. Útil para migrações de frameworks.")
 
 class StartAnalysisResponse(BaseModel):
     job_id: str
@@ -173,7 +175,8 @@ def _create_initial_job_data(payload: StartAnalysisPayload, normalized_repo_name
             JobFields.BRANCH_NAME_MODERNIZADO: payload.branch_name_modernizado,
             JobFields.REPO_NAME_ORIGINAL: payload.repo_name_original,
             JobFields.BRANCH_NAME_ORIGINAL: payload.branch_name_original,
-            JobFields.RETORNAR_LISTA_ARQUIVOS: payload.retornar_lista_arquivos
+            JobFields.RETORNAR_LISTA_ARQUIVOS: payload.retornar_lista_arquivos,
+            JobFields.MODO_ADICAO_INCREMENTAL: payload.modo_adicao_incremental
         },
         JobFields.ERROR_DETAILS: None
     }
@@ -219,7 +222,8 @@ def _create_derived_job_data(original_job: dict, analysis_name: str, normalized_
             JobFields.ARQUIVOS_ESPECIFICOS: original_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
             JobFields.ANALYSIS_NAME: f"{analysis_name}-implementation",
             JobFields.REPOSITORY_TYPE: original_data[JobFields.REPOSITORY_TYPE],
-            JobFields.RETORNAR_LISTA_ARQUIVOS: original_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS, False)
+            JobFields.RETORNAR_LISTA_ARQUIVOS: original_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS, False),
+            JobFields.MODO_ADICAO_INCREMENTAL: original_data.get(JobFields.MODO_ADICAO_INCREMENTAL, False)
         },
         JobFields.ERROR_DETAILS: None
     }


### PR DESCRIPTION
Este PR ajusta a lógica de manipulação de arquivos para suportar o modo de adição incremental. Quando o campo 'modo_adicao_incremental' está ativado no payload, o sistema irá adicionar o novo conteúdo ao final dos arquivos já existentes, ao invés de sobrescrevê-los. Isso permite que, durante migrações de frameworks em repositórios grandes, múltiplos agentes possam contribuir com incrementos em arquivos sem perda de dados anteriores. A escolha desse comportamento é controlada pelo usuário na chamada da API.