### PR TITLE
Permitir mescla de códigos em arquivos modificados durante migração de frameworks

### DIFF
--- a/domain/interfaces/repository_reader_interface.py
+++ b/domain/interfaces/repository_reader_interface.py
@@ -10,6 +10,7 @@ class IRepositoryReader(ABC):
         repository_type: str,
         nome_branch: str = None,
         arquivos_especificos: Optional[List[str]] = None,
-        retornar_lista_arquivos: bool = False
+        retornar_lista_arquivos: bool = False,
+        modo_adicao_incremental: bool = False
     ) -> Union[Dict[str, str], Dict[str, Union[Dict[str, str], List[str]]]]:
         pass

--- a/services/commit_handler.py
+++ b/services/commit_handler.py
@@ -52,6 +52,8 @@ class CommitHandler:
                 print(f"[{job_id}] BLINDAGEM: Sem grupos para commit, commit_details definido")
                 return
             
+            modo_adicao_incremental = job_info.get('data', {}).get('modo_adicao_incremental', False)
+            
             for i, grupo in enumerate(grupos):
                 grupo_titulo = grupo.get('titulo_pr', f'Grupo {i+1}')
                 print(f"[{job_id}] Processando grupo {i+1}/{len(grupos)}: {grupo_titulo}")
@@ -65,7 +67,8 @@ class CommitHandler:
                         mensagem_pr=grupo.get("titulo_pr", f"PR Grupo {i+1}"),
                         descricao_pr=grupo.get("resumo_do_pr", f"Mudanças do grupo {i+1}"),
                         conjunto_de_mudancas=grupo.get("conjunto_de_mudancas", []),
-                        repository_type=repository_type
+                        repository_type=repository_type,
+                        modo_adicao_incremental=modo_adicao_incremental
                     )
                     
                     resultado_branch = self._validate_and_fix_pr_url(job_id, resultado_branch, i+1)


### PR DESCRIPTION
Implementa e documenta o parâmetro modo_adicao_incremental para permitir, sob escolha do usuário, a mescla de códigos em arquivos já existentes ao invés de sobrescrevê-los. Esse comportamento é essencial para cenários de migração de grandes bases de código, onde múltiplos módulos podem depender de um mesmo arquivo e diferentes versões podem ser geradas em etapas distintas. Com isso, evita-se a perda de funcionalidades e garante-se que todos os trechos relevantes sejam preservados. O parâmetro é propagado por todo o fluxo de commit e leitura de repositório, ficando sob controle do usuário ativá-lo apenas quando necessário.