### PR TITLE
Propagação do campo usuario_executor até os agentes e registro nos logs

### DIFF
--- a/agents/agente_revisor.py
+++ b/agents/agente_revisor.py
@@ -61,7 +61,8 @@ class AgenteRevisor:
         projeto: Optional[str] = None,
         status_update: Optional[str] = None,
         retornar_lista_arquivos: bool = False,
-        modo_adicao_incremental: bool = False
+        modo_adicao_incremental: bool = False,
+        usuario_executor: Optional[str] = None
     ) -> Dict[str, Any]:
 
         log_custom_data(
@@ -73,7 +74,8 @@ class AgenteRevisor:
             nome_repositorio=repositorio,
             tipo_analise=tipo_analise,
             model_name=model_name,
-            modo_adicao_incremental=modo_adicao_incremental
+            modo_adicao_incremental=modo_adicao_incremental,
+            usuario_executor=usuario_executor
         )
 
         resultado_leitura = self._get_code(
@@ -101,7 +103,8 @@ class AgenteRevisor:
                 repositorio=repositorio,
                 tipo_analise=tipo_analise,
                 data_hora=datetime.now(timezone.utc).isoformat(),
-                modo_adicao_incremental=modo_adicao_incremental
+                modo_adicao_incremental=modo_adicao_incremental,
+                usuario_executor=usuario_executor
             )
             return {"resultado": {"reposta_final": {}}}
 
@@ -134,7 +137,8 @@ class AgenteRevisor:
             nome_repositorio=repositorio,
             tipo_analise=tipo_analise,
             model_name=model_name,
-            modo_adicao_incremental=modo_adicao_incremental
+            modo_adicao_incremental=modo_adicao_incremental,
+            usuario_executor=usuario_executor
         )
 
         return {

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -129,7 +129,8 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             'model_name': model_para_etapa,
             'repository_type': job_info['data']['repository_type'],
             'retornar_lista_arquivos': retornar_lista_arquivos,
-            'modo_adicao_incremental': job_info.get('data', {}).get('modo_adicao_incremental', False)
+            'modo_adicao_incremental': job_info.get('data', {}).get('modo_adicao_incremental', False),
+            'usuario_executor': job_info.get('data', {}).get('usuario_executor')
         })
 
         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)


### PR DESCRIPTION
Este PR garante que o nome do usuário executor (usuario_executor) seja informado no payload inicial, propagado pelo workflow_orchestrator até os agentes e registrado nos logs customizados dos agentes via log_custom_data. Assim, todas as tarefas executadas terão o usuário responsável devidamente registrado nos logs para rastreabilidade.