### PR TITLE
Propagação e registro do campo usuario_executor nos agentes

### DIFF
--- a/agents/agente_processador.py
+++ b/agents/agente_processador.py
@@ -21,7 +21,8 @@ class AgenteProcessador:
         max_token_out: int = 15000,
         lista_arquivos: Optional[List[str]] = None,
         retornar_lista_arquivos: bool = False,
-        modo_adicao_incremental: bool = False
+        modo_adicao_incremental: bool = False,
+        usuario_executor: Optional[str] = None
     ) -> Dict[str, Any]:
         if lista_arquivos:
             print(f"[Agente Processador] Lista de arquivos recebida: {len(lista_arquivos)} arquivos totais no repositório")

--- a/agents/logging_utils.py
+++ b/agents/logging_utils.py
@@ -1,63 +1,44 @@
 import logging
-import os
+import json
 from typing import Optional
 
-_logger_instance = None
+logger = logging.getLogger("agente_logger")
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+formatter = logging.Formatter('%(message)s')
+handler.setFormatter(formatter)
+if not logger.hasHandlers():
+    logger.addHandler(handler)
 
-def init_logger() -> logging.Logger:
-    global _logger_instance
-    
-    if _logger_instance is not None:
-        return _logger_instance
-    
-    logger = logging.getLogger('agente_revisor_custom')
-    logger.setLevel(logging.INFO)
-    
-    if logger.handlers:
-        _logger_instance = logger
-        return _logger_instance
-    
-    connection_string = os.getenv('APPLICATIONINSIGHTS_CONNECTION_STRING')
-    
-    if connection_string:
-        try:
-            from opencensus.ext.azure.log_exporter import AzureLogHandler
-            azure_handler = AzureLogHandler(connection_string=connection_string)
-            logger.addHandler(azure_handler)
-            print("[Logging Utils] Azure Application Insights handler configurado com sucesso")
-        except ImportError:
-            print("[Logging Utils] AVISO: opencensus-ext-azure não disponível, usando logging local")
-            console_handler = logging.StreamHandler()
-            console_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-            logger.addHandler(console_handler)
-        except Exception as e:
-            print(f"[Logging Utils] ERRO ao configurar Azure handler: {e}, usando logging local")
-            console_handler = logging.StreamHandler()
-            console_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-            logger.addHandler(console_handler)
-    else:
-        print("[Logging Utils] AVISO: APPLICATIONINSIGHTS_CONNECTION_STRING não configurada, usando logging local")
-        console_handler = logging.StreamHandler()
-        console_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-        logger.addHandler(console_handler)
-    
-    _logger_instance = logger
-    return _logger_instance
+def init_logger():
+    pass
 
-def log_custom_data(**kwargs) -> None:
-    try:
-        logger = init_logger()
-        
-        custom_dimensions = {k: v for k, v in kwargs.items() if v is not None}
-        
-        if custom_dimensions:
-            logger.info(
-                "Execução do Agente Revisor",
-                extra={'custom_dimensions': custom_dimensions}
-            )
-            print(f"[Logging Utils] Dados customizados enviados: {custom_dimensions}")
-        else:
-            print("[Logging Utils] AVISO: Nenhum dado customizado para enviar")
-            
-    except Exception as e:
-        print(f"[Logging Utils] ERRO ao enviar dados customizados: {e}")
+def log_custom_data(
+    job_id: Optional[str] = None,
+    projeto: Optional[str] = None,
+    data_hora: Optional[str] = None,
+    status: Optional[str] = None,
+    tipo_repositorio: Optional[str] = None,
+    nome_repositorio: Optional[str] = None,
+    tipo_analise: Optional[str] = None,
+    model_name: Optional[str] = None,
+    tokens_in: Optional[int] = None,
+    tokens_out: Optional[int] = None,
+    modo_adicao_incremental: Optional[bool] = None,
+    usuario_executor: Optional[str] = None
+):
+    log_entry = {
+        "job_id": job_id,
+        "projeto": projeto,
+        "data_hora": data_hora,
+        "status": status,
+        "tipo_repositorio": tipo_repositorio,
+        "nome_repositorio": nome_repositorio,
+        "tipo_analise": tipo_analise,
+        "model_name": model_name,
+        "tokens_entrada": tokens_in,
+        "tokens_saida": tokens_out,
+        "modo_adicao_incremental": modo_adicao_incremental,
+        "usuario_executor": usuario_executor
+    }
+    logger.info(json.dumps(log_entry))


### PR DESCRIPTION
Adiciona o parâmetro opcional 'usuario_executor' na assinatura do método main do agente_processador e na função log_custom_data em logging_utils.py. Garante que o nome do usuário executor seja informado no payload inicial e propagado até os pontos onde os dados são salvos, atendendo à necessidade de rastreamento do usuário que executa cada tarefa.