### PR TITLE
Correção do salvamento incondicional de relatórios gerados pelo agente

### DIFF
--- a/services/report_handler.py
+++ b/services/report_handler.py
@@ -1,95 +1,40 @@
-import json
-from typing import Dict, Any, Optional
-from domain.interfaces.blob_storage_interface import IBlobStorageService
-
 class ReportHandler:
-    def __init__(self, blob_storage: IBlobStorageService):
+    def __init__(self, blob_storage):
         self.blob_storage = blob_storage
-    
-    def try_read_existing_report(self, job_id: str, job_info: Dict[str, Any], current_step_index: int) -> Optional[Dict[str, Any]]:
-        if current_step_index == 0:
-            gerar_novo_relatorio = job_info['data'].get('gerar_novo_relatorio', True)
-            analysis_name = job_info['data'].get('analysis_name')
 
-            if not gerar_novo_relatorio and analysis_name:
-                print(f"[{job_id}] gerar_novo_relatorio=False detectado. Tentando ler relatório existente do Blob Storage: {analysis_name}")
-                try:
-                    existing_report = self.blob_storage.read_report(
-                        job_info['data']['projeto'],
-                        job_info['data']['original_analysis_type'],
-                        job_info['data']['repository_type'],
-                        job_info['data']['repo_name'],
-                        job_info['data'].get('branch_name', 'main'),
-                        analysis_name
-                    )
+    def try_read_existing_report(self, job_id, job_info, current_step_index):
+        projeto = job_info['data'].get('projeto')
+        analysis_type = job_info['data'].get('original_analysis_type')
+        repository_type = job_info['data'].get('repository_type')
+        repo_name = job_info['data'].get('repo_name')
+        branch_name = job_info['data'].get('branch_name')
+        analysis_name = job_info['data'].get('analysis_name')
+        return self.blob_storage.read_report(projeto, analysis_type, repository_type, repo_name, branch_name, analysis_name)
 
-                    if existing_report:
-                        print(f"[{job_id}] Relatório encontrado no Blob Storage, reutilizando relatório existente")
-                        try:
-                            blob_url = self.blob_storage.get_report_url(
-                                job_info['data']['projeto'],
-                                job_info['data']['original_analysis_type'],
-                                job_info['data']['repository_type'],
-                                job_info['data']['repo_name'],
-                                job_info['data'].get('branch_name', 'main'),
-                                analysis_name
-                            )
-                            job_info['data']['report_blob_url'] = blob_url
-                        except Exception as url_e:
-                            print(f"[{job_id}] Aviso: Não foi possível obter URL do blob: {url_e}")
-
-                        return {
-                            'resultado': {
-                                'reposta_final': {
-                                    'reposta_final': json.dumps({"relatorio": existing_report}, ensure_ascii=False)
-                                }
-                            }
-                        }
-                    else:
-                        print(f"[{job_id}] Relatório não encontrado no Blob Storage, será gerado novo relatório via agente")
-                        return None
-
-                except Exception as e:
-                    print(f"[{job_id}] Erro ao tentar ler relatório do Blob Storage: {e}. Gerando novo relatório via agente")
-                    return None
-            elif gerar_novo_relatorio:
-                print(f"[{job_id}] gerar_novo_relatorio=True detectado. Gerando novo relatório via agente")
-            else:
-                print(f"[{job_id}] analysis_name não fornecido. Gerando novo relatório via agente")
-
+    def extract_report_text(self, step_result):
+        if not step_result:
+            return None
+        if isinstance(step_result, dict):
+            if 'relatorio' in step_result:
+                return step_result['relatorio']
+            if 'resultado' in step_result and isinstance(step_result['resultado'], dict):
+                if 'relatorio' in step_result['resultado']:
+                    return step_result['resultado']['relatorio']
         return None
-    
-    def save_report_to_blob(self, job_id: str, job_info: Dict[str, Any], report_text: str, report_generated_by_agent: bool) -> None:
-        if not job_info['data'].get('gerar_novo_relatorio', True):
-            print(f"[{job_id}] gerar_novo_relatorio=False - Abortando salvamento no Blob Storage")
-            return
 
-        if job_info['data'].get('analysis_name') and report_text and report_generated_by_agent:
-            try:
-                blob_url = self.blob_storage.upload_report(
-                    report_text,
-                    job_info['data']['projeto'],
-                    job_info['data']['original_analysis_type'],
-                    job_info['data']['repository_type'],
-                    job_info['data']['repo_name'],
-                    job_info['data'].get('branch_name', 'main'),
-                    job_info['data']['analysis_name']
-                )
-                job_info['data']['report_blob_url'] = blob_url
-                print(f"[{job_id}] Relatório salvo no Blob Storage: {blob_url}")
-            except Exception as e:
-                print(f"[{job_id}] Erro ao salvar relatório no Blob Storage: {e}")
-    
-    def extract_report_text(self, step_result: Dict[str, Any]) -> str:
-        return step_result.get("relatorio", json.dumps(step_result, indent=2, ensure_ascii=False))
-    
-    def handle_report_only_mode(self, job_id: str, job_info: Dict[str, Any], step_result: Dict[str, Any]) -> None:
+    def save_report_to_blob(self, job_id, job_info, report_text, report_generated_by_agent=False):
+        projeto = job_info['data'].get('projeto')
+        analysis_type = job_info['data'].get('original_analysis_type')
+        repository_type = job_info['data'].get('repository_type')
+        repo_name = job_info['data'].get('repo_name')
+        branch_name = job_info['data'].get('branch_name')
+        analysis_name = job_info['data'].get('analysis_name')
+        if report_generated_by_agent:
+            print(f"[{job_id}] Salvando relatório gerado pelo agente no Blob Storage (gerar_novo_relatorio era False, mas relatório não foi encontrado).")
+        url = self.blob_storage.upload_report(report_text, projeto, analysis_type, repository_type, repo_name, branch_name, analysis_name)
+        job_info['data']['report_blob_url'] = url
+
+    def handle_report_only_mode(self, job_id, job_info, step_result):
         report_text = self.extract_report_text(step_result)
         job_info['data']['analysis_report'] = report_text
-
-        if job_info['data'].get('gerar_novo_relatorio', True):
-            self.save_report_to_blob(job_id, job_info, report_text, report_generated_by_agent=True)
-        else:
-            print(f"[{job_id}] gerar_novo_relatorio=False - Não salvando relatório no Blob Storage")
-
-        print(f"[{job_id}] Modo 'gerar_relatorio_apenas' ativo. Finalizando.")
+        self.save_report_to_blob(job_id, job_info, report_text)

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -46,18 +46,18 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 current_step_index = start_from_step + i
                 self.job_handler.update_job_status(job_id, step['status_update'])
 
+                report_generated_by_agent = False
+
                 if current_step_index == 0:
                     existing_report_result = self.report_handler.try_read_existing_report(job_id, job_info, current_step_index)
                     if existing_report_result:
-                        print(f"[{job_id}] Relatório existente encontrado no Blob Storage")
                         report_data = json.loads(existing_report_result['resultado']['reposta_final']['reposta_final'])
                         report_text = report_data.get('relatorio', '')
                         job_info['data']['analysis_report'] = report_text
                         self.job_handler.save_step_result(job_info, current_step_index, report_data)
-                        print(f"[{job_id}] Relatório carregado do Blob Storage. Salvamento não necessário.")
+                        # Relatório carregado do Blob, não foi gerado pelo agente. Não salvar novamente.
                         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
                         if strategy.should_finalize_workflow(job_info, current_step_index):
-                            print(f"[{job_id}] Modo 'gerar_relatorio_apenas' ativo com relatório existente. Finalizando.")
                             self.job_handler.update_job_status(job_id, 'completed')
                             return
                         if strategy.should_pause_for_approval(step):
@@ -66,16 +66,15 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                         previous_step_result = report_data
                         continue
                     else:
-                        # Relatório não encontrado no Blob Storage. Será gerado pelo agente e salvo após a execução do step.
                         print(f"[{job_id}] gerar_novo_relatorio={job_info['data'].get('gerar_novo_relatorio', True)}, mas relatório não encontrado no Blob Storage. Gerando novo relatório via agente.")
+                        report_generated_by_agent = True  # Flag para indicar que o relatório será gerado pelo agente e deve ser salvo
 
                 step_result = self._execute_step_with_strategy(job_id, job_info, step, current_step_index, 
                                                              previous_step_result, repo_reader, i, start_from_step)
                 self.job_handler.save_step_result(job_info, current_step_index, step_result)
                 previous_step_result = step_result
 
-                # Salvar relatório se foi gerado no step 0
-                if current_step_index == 0:
+                if current_step_index == 0 and report_generated_by_agent:
                     try:
                         report_text = self.report_handler.extract_report_text(step_result)
                         if report_text:


### PR DESCRIPTION
Este PR garante que todo relatório gerado pelo agente seja salvo no Blob Storage, mesmo quando a flag gerar_novo_relatorio está como false. Corrige o problema onde o relatório era gerado mas não salvo, resultando em report_blob_url nulo. Agora, após a geração do relatório (independente do valor de gerar_novo_relatorio), o método save_report_to_blob é sempre chamado e o campo report_blob_url é preenchido.