### PR TITLE
Expansão e integração do sistema de logging customizado

### DIFF
--- a/agents/logging_utils.py
+++ b/agents/logging_utils.py
@@ -1,6 +1,6 @@
 import logging
 import json
-from typing import Optional
+from typing import Optional, List
 
 logger = logging.getLogger("agente_logger")
 logger.setLevel(logging.INFO)
@@ -25,7 +25,14 @@ def log_custom_data(
     tokens_in: Optional[int] = None,
     tokens_out: Optional[int] = None,
     modo_adicao_incremental: Optional[bool] = None,
-    usuario_executor: Optional[str] = None
+    usuario_executor: Optional[str] = None,
+    analysis_type: Optional[str] = None,
+    branch_name: Optional[str] = None,
+    analysis_name: Optional[str] = None,
+    arquivos_especificos: Optional[List[str]] = None,
+    pr_url: Optional[str] = None,
+    arquivos_modificados: Optional[List[str]] = None,
+    retornar_lista_arquivos: Optional[bool] = None
 ):
     log_entry = {
         "job_id": job_id,
@@ -39,6 +46,13 @@ def log_custom_data(
         "tokens_entrada": tokens_in,
         "tokens_saida": tokens_out,
         "modo_adicao_incremental": modo_adicao_incremental,
-        "usuario_executor": usuario_executor
+        "usuario_executor": usuario_executor,
+        "analysis_type": analysis_type,
+        "branch_name": branch_name,
+        "analysis_name": analysis_name,
+        "arquivos_especificos": arquivos_especificos,
+        "pr_url": pr_url,
+        "arquivos_modificados": arquivos_modificados,
+        "retornar_lista_arquivos": retornar_lista_arquivos
     }
     logger.info(json.dumps(log_entry))

--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from services.dependency_container import DependencyContainer
 from services.workflow_registry_service import WorkflowRegistryService
+from agents.logging_utils import log_custom_data
 
 class JobStatus:
     STARTING = 'starting'
@@ -349,6 +350,26 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
             print(f"[{job_id}] DIAGNÓSTICO FINAL - PR {i+1}: url='{pr_summary.pull_request_url}', branch='{pr_summary.branch_name}', arquivos={len(pr_summary.arquivos_modificados)}")
         
         logs = job_data.get(JobFields.DIAGNOSTIC_LOGS)
+
+        # Logging de cada PR criado
+        for pr_summary in summary_list:
+            log_custom_data(
+                job_id=job_id,
+                projeto=job_data.get(JobFields.PROJETO),
+                data_hora=time.strftime('%Y-%m-%d %H:%M:%S'),
+                status=JobStatus.COMPLETED,
+                tipo_repositorio=job_data.get(JobFields.REPOSITORY_TYPE),
+                nome_repositorio=job_data.get(JobFields.REPO_NAME),
+                tipo_analise=job_data.get(JobFields.ORIGINAL_ANALYSIS_TYPE),
+                branch_name=pr_summary.branch_name,
+                analysis_name=job_data.get(JobFields.ANALYSIS_NAME),
+                arquivos_especificos=job_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
+                pr_url=pr_summary.pull_request_url,
+                arquivos_modificados=pr_summary.arquivos_modificados,
+                retornar_lista_arquivos=job_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS),
+                modo_adicao_incremental=job_data.get(JobFields.MODO_ADICAO_INCREMENTAL),
+                usuario_executor=job_data.get(JobFields.USUARIO_EXECUTOR)
+            )
         return FinalStatusResponse(
             job_id=job_id, 
             status=JobStatus.COMPLETED, 
@@ -384,6 +405,23 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     initial_job_data = _create_initial_job_data(payload, normalized_repo_name, analysis_name)
 
     job_store.set_job(job_id, initial_job_data)
+
+    # Logging do início da análise
+    log_custom_data(
+        job_id=job_id,
+        projeto=payload.projeto,
+        data_hora=time.strftime('%Y-%m-%d %H:%M:%S'),
+        status=JobStatus.STARTING,
+        tipo_repositorio=payload.repository_type,
+        nome_repositorio=normalized_repo_name,
+        tipo_analise=payload.analysis_type.value,
+        branch_name=payload.branch_name_modernizado,
+        analysis_name=analysis_name,
+        arquivos_especificos=payload.arquivos_especificos,
+        retornar_lista_arquivos=payload.retornar_lista_arquivos,
+        modo_adicao_incremental=payload.modo_adicao_incremental,
+        usuario_executor=payload.usuario_executor
+    )
 
     if analysis_name:
         analysis_service.register_analysis(analysis_name, job_id)
@@ -499,7 +537,24 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
         if status == JobStatus.COMPLETED:
             return _build_completed_response(job_id, job, blob_url)
         elif status == JobStatus.FAILED:
-            logs = job.get(JobFields.DATA, {}).get(JobFields.DIAGNOSTIC_LOGS)
+            job_data = job.get(JobFields.DATA, {})
+            logs = job_data.get(JobFields.DIAGNOSTIC_LOGS)
+            # Logging de falha do job
+            log_custom_data(
+                job_id=job_id,
+                projeto=job_data.get(JobFields.PROJETO),
+                data_hora=time.strftime('%Y-%m-%d %H:%M:%S'),
+                status=JobStatus.FAILED,
+                tipo_repositorio=job_data.get(JobFields.REPOSITORY_TYPE),
+                nome_repositorio=job_data.get(JobFields.REPO_NAME),
+                tipo_analise=job_data.get(JobFields.ORIGINAL_ANALYSIS_TYPE),
+                branch_name=job_data.get(JobFields.BRANCH_NAME),
+                analysis_name=job_data.get(JobFields.ANALYSIS_NAME),
+                arquivos_especificos=job_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
+                retornar_lista_arquivos=job_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS),
+                modo_adicao_incremental=job_data.get(JobFields.MODO_ADICAO_INCREMENTAL),
+                usuario_executor=job_data.get(JobFields.USUARIO_EXECUTOR)
+            )
             return FinalStatusResponse(
                 job_id=job_id,
                 status=status,


### PR DESCRIPTION
Este PR expande a função log_custom_data em agents/logging_utils.py para aceitar todos os campos solicitados pelo usuário e integra as chamadas de logging no ciclo de vida do job em mcp_server_fastapi.py. Agora, a cada criação de job e conclusão de PR, são registrados: projeto, analysis_type, repository_type, repo_name, branch_name, analysis_name, arquivos_especificos, url do PR, arquivos_modificados no PR e retornar_lista_arquivos. Isso garante rastreabilidade detalhada e aderência total às instruções de logging.