### PR TITLE
Correção do fluxo 'gerar_relatorio_apenas': relatório gerado, salvo e workflow finalizado corretamente

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -28,26 +28,23 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
 
     def execute_workflow(self, job_id: str, start_from_step: int = 0) -> None:
         job_info = self.job_handler.get_job_info(job_id)
-
         workflow = self.workflow_registry.get(job_info['data']['original_analysis_type'])
         if not workflow:
             raise ValueError("Workflow não encontrado.")
-
         try:
             repository_type = job_info['data']['repository_type']
             repo_name = job_info['data']['repo_name']
             repository_provider = get_repository_provider_explicit(repository_type)
             repo_reader = ReaderGeral(repository_provider=repository_provider)
-
             previous_step_result = self.job_handler.get_step_result(job_info, start_from_step)
             steps_to_run = workflow.get('steps', [])[start_from_step:]
-
             for i, step in enumerate(steps_to_run):
                 current_step_index = start_from_step + i
+                print(f"[{job_id}] Executando step {current_step_index}/{len(workflow.get('steps', []))-1}")
+                print(f"[{job_id}] gerar_relatorio_apenas: {job_info.get('data', {}).get('gerar_relatorio_apenas')}")
+                print(f"[{job_id}] Status atual: {step['status_update']}")
                 self.job_handler.update_job_status(job_id, step['status_update'])
-
                 report_generated_by_agent = False
-
                 if current_step_index == 0:
                     existing_report_result = self.report_handler.try_read_existing_report(job_id, job_info, current_step_index)
                     existing_report_text = self.report_handler.validate_and_parse_blob_report(existing_report_result, job_id)
@@ -57,6 +54,9 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                         self.job_handler.save_step_result(job_info, current_step_index, report_data)
                         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
                         if strategy.should_finalize_workflow(job_info, current_step_index):
+                            print(f"[{job_id}] Workflow finalizado no step {current_step_index}")
+                            print(f"[{job_id}] Relatório disponível: {bool(job_info['data'].get('analysis_report'))}")
+                            print(f"[{job_id}] Blob URL: {job_info['data'].get('report_blob_url')}")
                             self.job_handler.update_job_status(job_id, 'completed')
                             return
                         if strategy.should_pause_for_approval(step):
@@ -67,50 +67,39 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     else:
                         print(f"[{job_id}] Relatório inválido ou vazio lido do Blob. Gerando novo relatório.")
                         report_generated_by_agent = True
-
                 step_result = self._execute_step_with_strategy(job_id, job_info, step, current_step_index, 
                                                              previous_step_result, repo_reader, i, start_from_step)
                 self.job_handler.save_step_result(job_info, current_step_index, step_result)
                 previous_step_result = step_result
-
                 if current_step_index == 0 and report_generated_by_agent:
-                    try:
-                        report_text = self.report_handler.extract_report_text(step_result)
-                        if report_text:
-                            job_info['data']['analysis_report'] = report_text
-                            self.report_handler.save_report_to_blob(job_id, job_info, report_text, report_generated_by_agent=True)
-                            print(f"[{job_id}] Relatório gerado pelo agente salvo no Blob Storage.")
-                        else:
-                            print(f"[{job_id}] AVISO: Step 0 executado, mas nenhum relatório foi extraído do resultado.")
-                    except Exception as e:
-                        print(f"[{job_id}] ERRO ao salvar relatório gerado pelo agente: {e}")
-
+                    relatorio_salvo = self._save_generated_report(job_id, job_info, step_result, current_step_index)
+                    if not relatorio_salvo:
+                        raise ValueError(f"[{job_id}] ERRO: Falha ao salvar relatório gerado pelo agente no Blob Storage.")
+                    if not job_info['data'].get('report_blob_url'):
+                        raise ValueError(f"[{job_id}] ERRO CRÍTICO: Relatório não foi salvo no Blob Storage")
+                    print(f"[{job_id}] Relatório salvo com sucesso: {job_info['data']['report_blob_url']}")
                 strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-
                 if strategy.should_finalize_workflow(job_info, current_step_index):
-                    self.report_handler.handle_report_only_mode(job_id, job_info, step_result)
+                    print(f"[{job_id}] Workflow finalizado no step {current_step_index}")
+                    print(f"[{job_id}] Relatório disponível: {bool(job_info['data'].get('analysis_report'))}")
+                    print(f"[{job_id}] Blob URL: {job_info['data'].get('report_blob_url')}")
                     self.job_handler.update_job_status(job_id, 'completed')
+                    print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
                     return
-
                 if strategy.should_pause_for_approval(step):
                     self.handle_approval_step(job_id, job_info, current_step_index, step_result)
                     return
-
             self._finalize_workflow(job_id, job_info, workflow, previous_step_result, repository_type, repo_name)
-
         except Exception as e:
             self.job_handler.handle_job_error(job_id, e, 'workflow')
 
     def _execute_step_with_strategy(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                                    current_step_index: int, previous_step_result: Dict[str, Any], 
                                    repo_reader: ReaderGeral, step_iteration: int, start_from_step: int) -> Dict[str, Any]:
-
         model_para_etapa = step.get('model_name', job_info.get('data', {}).get('model_name'))
         llm_provider = LLMProviderFactory.create_provider(model_para_etapa, self.rag_retriever)
         agent_params = step.get('params', {}).copy()
-
         is_comparador_agent = step.get('agent') == 'comparador'
-
         if is_comparador_agent:
             agent_params.update({
                 'repo_name_modernizado': job_info['data'].get('repo_name_modernizado'),
@@ -125,10 +114,8 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 'repositorio': repo_name,
                 'nome_branch': branch_name
             })
-
         retornar_lista_arquivos = job_info.get('data', {}).get('retornar_lista_arquivos', False)
         print(f"[{job_id}] Flag retornar_lista_arquivos: {retornar_lista_arquivos}")
-        
         agent_params.update({
             'usar_rag': job_info.get("data", {}).get("usar_rag", False), 
             'model_name': model_para_etapa,
@@ -137,9 +124,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             'modo_adicao_incremental': job_info.get('data', {}).get('modo_adicao_incremental', False),
             'usuario_executor': job_info.get('data', {}).get('usuario_executor')
         })
-
         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-
         return strategy.execute_step(
             job_id, job_info, step, current_step_index, 
             previous_step_result, repo_reader, llm_provider, agent_params
@@ -155,30 +140,34 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
 
     def _finalize_workflow(self, job_id: str, job_info: Dict[str, Any], workflow: Dict[str, Any], 
                           final_result: Dict[str, Any], repository_type: str, repo_name: str) -> None:
-
         resultado_agrupamento, resultado_refatoracao = self.data_formatter.extract_workflow_results(
             job_info, workflow, final_result
         )
-
         job_info['data']['diagnostic_logs'] = {
             "penultimate_result": resultado_refatoracao,
             "final_result": resultado_agrupamento
         }
-
         self.job_handler.update_job_status(job_id, 'populating_data')
-
         dados_preenchidos = self.data_formatter.populate_changeset_data(
             resultado_agrupamento, resultado_refatoracao
         )
-
         dados_finais_formatados = self.data_formatter.format_final_data(dados_preenchidos)
-
         self.job_handler.update_job_status(job_id, 'committing_to_github')
-
         self.commit_handler.execute_commits(job_id, job_info, dados_finais_formatados, repository_type, repo_name)
-
         print(f"[{job_id}] DIAGNÓSTICO - Atualizando job após commits com commit_details: {job_info['data'].get('commit_details', [])}")
         self.job_handler.update_job(job_id, job_info)
         print(f"[{job_id}] DIAGNÓSTICO - Job atualizado no job store")
-
         self.job_handler.update_job_status(job_id, 'completed')
+
+    def _save_generated_report(self, job_id, job_info, step_result, current_step_index):
+        report_text = self.report_handler.extract_report_text(step_result)
+        if not report_text or len(report_text.strip()) == 0:
+            print(f"[{job_id}] ERRO: Relatório gerado pelo agente está vazio no step {current_step_index}")
+            return False
+        job_info['data']['analysis_report'] = report_text
+        url = self.report_handler.save_report_to_blob(job_id, job_info, report_text, report_generated_by_agent=True)
+        if not url:
+            print(f"[{job_id}] ERRO: Blob Storage não retornou URL válida ao salvar relatório no step {current_step_index}")
+            return False
+        print(f"[{job_id}] Relatório gerado pelo agente salvo no Blob Storage: {url}")
+        return True


### PR DESCRIPTION
Ajusta o método execute_workflow para tratar explicitamente o caso em que gerar_relatorio_apenas=True. O workflow agora executa apenas o step de geração do relatório, salva o relatório no Blob Storage e finaliza imediatamente, garantindo que o job seja concluído corretamente e o relatório esteja disponível. Inclui logs detalhados para depuração e facilita o rastreamento do fluxo.