### PR TITLE
Correção do fluxo e referência da flag gerar_relatorio_apenas

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -402,6 +402,8 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     job_id = str(uuid.uuid4())
     analysis_name = _generate_analysis_name(payload.analysis_name, job_id)
 
+    print(f"[{job_id}] Configuração validada - gerar_relatorio_apenas: {payload.gerar_relatorio_apenas}, gerar_novo_relatorio: {payload.gerar_novo_relatorio}, analysis_type: {payload.analysis_type.value}")
+
     initial_job_data = _create_initial_job_data(payload, normalized_repo_name, analysis_name)
 
     job_store.set_job(job_id, initial_job_data)

--- a/services/report_handler.py
+++ b/services/report_handler.py
@@ -57,5 +57,8 @@ class ReportHandler:
         if len(report_text.strip()) == 0:
             print(f"[{job_id}] ERRO: Relatório lido do Blob está vazio.")
             return None
+        if len(report_text.strip()) < 50:
+            print(f"[{job_id}] AVISO: Relatório muito curto ({len(report_text)} chars), considerado inválido")
+            return None
         print(f"[{job_id}] Relatório válido lido do Blob Storage ({len(report_text)} chars).")
         return report_text

--- a/services/step_strategies/default_step_strategy.py
+++ b/services/step_strategies/default_step_strategy.py
@@ -23,7 +23,17 @@ class DefaultStepStrategy:
         )
     
     def should_finalize_workflow(self, job_info: Dict[str, Any], current_step_index: int) -> bool:
-        return job_info.get('data', {}).get(JobFields.GERAR_RELATORIO_APENAS, False) and current_step_index == 0
+        gerar_relatorio_apenas = job_info.get('data', {}).get(JobFields.GERAR_RELATORIO_APENAS, False)
+        analysis_report = job_info.get('data', {}).get(JobFields.ANALYSIS_REPORT)
+        blob_url = job_info.get('data', {}).get(JobFields.REPORT_BLOB_URL)
+        print(f"[STRATEGY] Verificando finalização - gerar_relatorio_apenas: {gerar_relatorio_apenas}, current_step: {current_step_index}, report_exists: {bool(analysis_report)}, blob_url_exists: {bool(blob_url)}")
+        if gerar_relatorio_apenas and current_step_index == 0:
+            if analysis_report and blob_url:
+                return True
+            else:
+                print(f"[STRATEGY] Não pode finalizar: relatório não existe ainda")
+                return False
+        return False
     
     def should_pause_for_approval(self, step: Dict[str, Any]) -> bool:
         return step.get('requires_approval', False)

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -84,16 +84,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
                         previous_step_result = report_data
                         # Só finaliza se for report_only e relatório válido
-                        if job_info.get('data', {}).get(JobFields.GERAR_RELATORIO_APENAS):
-                            if strategy.should_finalize_workflow(job_info, current_step_index):
-                                if not job_info['data'].get(JobFields.REPORT_BLOB_URL) or not job_info['data'].get(JobFields.ANALYSIS_REPORT):
-                                    raise ValueError(f"[{job_id}] ERRO: Tentativa de finalizar sem relatório completo. Blob URL: {job_info['data'].get(JobFields.REPORT_BLOB_URL)}, Report exists: {bool(job_info['data'].get(JobFields.ANALYSIS_REPORT))}")
-                                print(f"[{job_id}] Workflow finalizado no step {current_step_index}")
-                                print(f"[{job_id}] Relatório disponível: {bool(job_info['data'].get(JobFields.ANALYSIS_REPORT))}")
-                                print(f"[{job_id}] Blob URL: {job_info['data'].get(JobFields.REPORT_BLOB_URL)}")
-                                self.job_handler.update_job_status(job_id, 'completed')
-                                print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
-                                return
+                        # Não deve finalizar aqui! A finalização deve ocorrer após a execução do step e salvamento do relatório
                         continue
                     else:
                         print(f"[{job_id}] Relatório inválido ou vazio lido do Blob. Gerando novo relatório.")
@@ -121,6 +112,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 # Passo 9: Log detalhado já está implementado na strategy
                 # Passo 3: Finalização só se relatório existir
                 if strategy.should_finalize_workflow(job_info, current_step_index):
+                    print(f"[{job_id}] [FINALIZAÇÃO] Checando artefatos antes de finalizar...")
                     if not job_info['data'].get(JobFields.REPORT_BLOB_URL) or not job_info['data'].get(JobFields.ANALYSIS_REPORT):
                         raise ValueError(f"[{job_id}] ERRO: Tentativa de finalizar sem relatório completo. Blob URL: {job_info['data'].get(JobFields.REPORT_BLOB_URL)}, Report exists: {bool(job_info['data'].get(JobFields.ANALYSIS_REPORT))}")
                     print(f"[{job_id}] Workflow finalizado no step {current_step_index}")


### PR DESCRIPTION
Corrige o erro de referência à flag GERAR_RELATORIO_APENAS, garantindo uso consistente de JobFields.GERAR_RELATORIO_APENAS. Ajusta o fluxo para que, ao usar gerar_relatorio_apenas=True, o sistema sempre execute a análise do repositório e gere o relatório antes de finalizar. Adiciona logs e validações para rastreabilidade e robustez. Garante que o status 'analisando o repositório' seja corretamente emitido e que nenhuma etapa essencial seja pulada.