### PR TITLE
Correção e robustez no fluxo das flags de relatório (step 0)

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -41,29 +41,44 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
         print(f"[{job_id}] [STEP_0] Iniciando - gerar_novo_relatorio={gerar_novo}, gerar_relatorio_apenas={report_only}")
         report_text = None
         step_result = None
+        report_source = None
+        # ETAPA 1: Tentar ler do blob (se aplicável)
         if not gerar_novo:
-            print(f"[{job_id}] [STEP_0] Tentando ler relatório existente do blob - Flags: gerar_relatorio_apenas={report_only}, gerar_novo_relatorio={gerar_novo}")
+            print(f"[{job_id}] [STEP_0] Tentando ler relatório existente do blob")
             existing_report = self.report_handler.try_read_existing_report(job_id, job_info, 0)
-            report_text = self.report_handler.validate_and_parse_blob_report(existing_report, job_id, gerar_novo)
-        if not report_text:
-            print(f"[{job_id}] [STEP_0] Executando agente para gerar relatório - Flags: gerar_relatorio_apenas={report_only}, gerar_novo_relatorio={gerar_novo}")
+            if existing_report and self.report_handler.is_valid_report(existing_report):
+                report_text = existing_report
+                report_source = 'blob'
+                print(f"[{job_id}] Relatório válido lido do blob")
+            else:
+                print(f"[{job_id}] Blob não encontrado ou inválido, gerando via agente")
+        # ETAPA 2: Gerar via agente (se necessário)
+        if report_text is None:
+            print(f"[{job_id}] Executando agente para gerar relatório")
             strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
             step_result = strategy.execute_step(
                 job_id, job_info, step, 0, None, repo_reader, llm_provider, agent_params
             )
             report_text = self.report_handler.extract_report_text(step_result)
-            if not report_text:
+            if not self.report_handler.is_valid_report(report_text):
                 raise ValueError(f"[{job_id}] Agente não gerou relatório válido")
+            report_source = 'agent'
         else:
-            print(f"[{job_id}] [STEP_0] Usando relatório existente do blob - Flags: gerar_relatorio_apenas={report_only}, gerar_novo_relatorio={gerar_novo}")
             step_result = {'relatorio': report_text}
+        # ETAPA 3: Salvar no job e blob
         job_info['data'][JobFields.ANALYSIS_REPORT] = report_text
-        url = self.report_handler.save_report_to_blob(job_id, job_info, report_text)
-        print(f"[{job_id}] [STEP_0] Relatório salvo: {url} - Flags: gerar_relatorio_apenas={report_only}, gerar_novo_relatorio={gerar_novo}")
+        url = self.report_handler.save_report_to_blob(job_id, job_info, report_text, report_generated_by_agent=(report_source == 'agent'))
         self._validate_report_artifacts(job_id, job_info)
-        should_stop = report_only
-        print(f"[{job_id}] [STEP_0] Decisão: should_stop={should_stop} - Flags: gerar_relatorio_apenas={report_only}, gerar_novo_relatorio={gerar_novo}")
-        return {'should_stop': should_stop, 'step_result': step_result}
+        # ETAPA 4: DECISÃO DE FLUXO (Tabela de Verdade)
+        if report_only:
+            should_stop = True
+            requires_approval = False
+            print(f"[{job_id}] Finalizando (gerar_relatorio_apenas=True, fonte={report_source})")
+        else:
+            should_stop = False
+            requires_approval = True
+            print(f"[{job_id}] Pausando para aprovação (gerar_relatorio_apenas=False, fonte={report_source})")
+        return {'should_stop': should_stop, 'step_result': step_result, 'requires_approval': requires_approval}
 
     def execute_workflow(self, job_id: str, start_from_step: int = 0) -> None:
         job_info = self.job_handler.get_job_info(job_id)
@@ -120,6 +135,9 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     )
                     self.job_handler.save_step_result(job_info, current_step_index, result_step_zero['step_result'])
                     previous_step_result = result_step_zero['step_result']
+                    if result_step_zero['requires_approval']:
+                        self.handle_approval_step(job_id, job_info, current_step_index, result_step_zero['step_result'])
+                        return
                     if result_step_zero['should_stop']:
                         self.job_handler.update_job_status(job_id, 'completed')
                         print(f"[{job_id}] [DECISAO] Workflow finalizado após step 0 - Flags: gerar_relatorio_apenas={gerar_relatorio_apenas}, gerar_novo_relatorio={gerar_novo_relatorio}")


### PR DESCRIPTION
Este PR ajusta o fluxo de decisão do step 0 no orchestrator para garantir aderência total à tabela de verdade das flags 'gerar_relatorio_apenas' e 'gerar_novo_relatorio'. Agora, quando 'gerar_relatorio_apenas' está True, o workflow é finalizado imediatamente após o relatório ser salvo, com status 'completed', independentemente da origem do relatório (blob ou agente). Quando 'gerar_relatorio_apenas' está False, o relatório é salvo e o workflow pausa para aprovação, também respeitando a origem do relatório. O código foi revisado para garantir que não haja caminhos ambíguos ou inconsistentes, e os logs foram melhorados para facilitar o diagnóstico.