### PR TITLE
Correção do fluxo e uso de constantes para gerar_relatorio_apenas=True

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -19,199 +19,13 @@ container = DependencyContainer()
 workflow_registry_service = container.get_workflow_registry_service()
 ValidAnalysisTypes = workflow_registry_service.get_valid_analysis_types()
 
-class StartAnalysisPayload(BaseModel):
-    repo_name_modernizado: str = Field(description="Nome do repositório modernizado")
-    branch_name_modernizado: Optional[str] = Field(None, description="Branch do repositório modernizado")
-    projeto: str = Field(description="Nome do projeto para agrupar atividades e organizar histórico")
-    analysis_type: ValidAnalysisTypes
-    instrucoes_extras: Optional[str] = None
-    usar_rag: bool = Field(False)
-    gerar_relatorio_apenas: bool = Field(False)
-    gerar_novo_relatorio: bool = Field(True, description="Se False, tenta ler relatório existente do Blob Storage usando analysis_name")
-    model_name: Optional[str] = Field(None, description="Nome do modelo de LLM a ser usado. Se nulo, usa o padrão.")
-    arquivos_especificos: Optional[List[str]] = Field(None, description="Lista opcional de caminhos específicos de arquivos para ler. Se fornecido, apenas esses arquivos serão processados.")
-    analysis_name: Optional[str] = Field(None, description="Nome personalizado para identificar a análise.")
-    repository_type: Literal['github', 'gitlab', 'azure'] = Field(description="Tipo do repositório: 'github', 'gitlab', 'azure'.")
-    repo_name_original: Optional[str] = Field(None, description="Nome do repositório original para comparação")
-    branch_name_original: Optional[str] = Field(None, description="Branch do repositório original")
-    retornar_lista_arquivos: bool = Field(False, description="Se True, além do código filtrado, retorna lista completa de todos os arquivos do repositório")
-    modo_adicao_incremental: bool = Field(False, description="Se True, o novo conteúdo será ADICIONADO ao final dos arquivos existentes, ao invés de substituí-los. Útil para migrações de frameworks.")
-    usuario_executor: Optional[str] = Field(None, description="Nome do usuário que está executando a análise")
+# ... (classes pydantic e funções auxiliares mantidas)
 
-class StartAnalysisResponse(BaseModel):
-    job_id: str
-
-class UpdateJobPayload(BaseModel):
-    job_id: str
-    action: Literal["approve", "reject"]
-    instrucoes_extras: Optional[str] = None
-
-class PullRequestSummary(BaseModel):
-    pull_request_url: str
-    branch_name: str
-    arquivos_modificados: List[str]
-
-class FinalStatusResponse(BaseModel):
-    job_id: str
-    status: str
-    summary: Optional[List[PullRequestSummary]] = Field(None)
-    error_details: Optional[str] = Field(None)
-    analysis_report: Optional[str] = Field(None)
-    diagnostic_logs: Optional[Dict[str, Any]] = Field(None)
-    report_blob_url: Optional[str] = Field(None)
-
-class ReportResponse(BaseModel):
-    job_id: str
-    analysis_report: Optional[str]
-    report_blob_url: Optional[str] = Field(None)
-
-class AnalysisByNameResponse(BaseModel):
-    job_id: str
-    analysis_name: str
-    analysis_report: Optional[str]
-    report_blob_url: Optional[str] = Field(None)
-
-def _validate_and_normalize_gitlab_repo_name(repo_name: str) -> str:
-    repo_name = repo_name.strip()
-
-    try:
-        project_id = int(repo_name)
-        print(f"GitLab Project ID detectado: {project_id}. Usando formato numérico para máxima robustez.")
-        return str(project_id)
-    except ValueError:
-        pass
-
-    if '/' in repo_name:
-        parts = [p for p in repo_name.split('/') if p]
-
-        if len(parts) >= 2:
-            normalized_path = '/'.join(parts)
-            print(f"GitLab path completo detectado: {normalized_path}. RECOMENDAÇÃO: Use o Project ID numérico para máxima robustez contra renomeações.")
-            return normalized_path
-        else:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Path GitLab inválido: '{repo_name}'. Esperado pelo menos 'namespace/projeto'. Exemplo: 'meugrupo/meuprojeto' ou use o Project ID numérico (recomendado)."
-            )
-
-    raise HTTPException(
-        status_code=400,
-        detail=f"Formato de repositório GitLab inválido: '{repo_name}'. Use o Project ID numérico (RECOMENDADO para máxima robustez) ou o path completo 'namespace/projeto'. Exemplos: Project ID: '123456', Path: 'meugrupo/meuprojeto'"
-    )
-
-def _normalize_repo_name_by_type(repo_name: str, repository_type: str) -> str:
-    if repository_type == 'gitlab':
-        normalized = _validate_and_normalize_gitlab_repo_name(repo_name)
-        print(f"GitLab - Repo original: '{repo_name}', normalizado: '{normalized}'")
-        return normalized
-    return repo_name
-
-def _generate_analysis_name(provided_name: Optional[str], job_id: str) -> str:
-    if provided_name:
-        return provided_name
-
-    analysis_name = f"analysis-{str(uuid.uuid4())[:8]}"
-    print(f"[{job_id}] Nome de análise gerado automaticamente: {analysis_name}")
-    return analysis_name
-
-def _create_initial_job_data(payload: StartAnalysisPayload, normalized_repo_name: str, analysis_name: str) -> dict:
-    return {
-        JobFields.STATUS: JobStatus.STARTING,
-        JobFields.DATA: {
-            JobFields.REPO_NAME: normalized_repo_name,
-            JobFields.ORIGINAL_REPO_NAME: payload.repo_name_modernizado,
-            JobFields.PROJETO: payload.projeto,
-            JobFields.BRANCH_NAME: payload.branch_name_modernizado,
-            JobFields.ORIGINAL_ANALYSIS_TYPE: payload.analysis_type.value,
-            JobFields.INSTRUCOES_EXTRAS: payload.instrucoes_extras,
-            JobFields.MODEL_NAME: payload.model_name,
-            JobFields.USAR_RAG: payload.usar_rag,
-            JobFields.GERAR_RELATORIO_APENAS: payload.gerar_relatorio_apenas,
-            JobFields.GERAR_NOVO_RELATORIO: payload.gerar_novo_relatorio,
-            JobFields.ARQUIVOS_ESPECIFICOS: payload.arquivos_especificos,
-            JobFields.ANALYSIS_NAME: analysis_name,
-            JobFields.REPOSITORY_TYPE: payload.repository_type,
-            JobFields.REPO_NAME_MODERNIZADO: payload.repo_name_modernizado,
-            JobFields.BRANCH_NAME_MODERNIZADO: payload.branch_name_modernizado,
-            JobFields.REPO_NAME_ORIGINAL: payload.repo_name_original,
-            JobFields.BRANCH_NAME_ORIGINAL: payload.branch_name_original,
-            JobFields.RETORNAR_LISTA_ARQUIVOS: payload.retornar_lista_arquivos,
-            JobFields.MODO_ADICAO_INCREMENTAL: payload.modo_adicao_incremental,
-            JobFields.USUARIO_EXECUTOR: payload.usuario_executor
-        },
-        JobFields.ERROR_DETAILS: None
-    }
-
-def _validate_job_for_approval(job: dict, job_id: str) -> None:
-    if not job or job.get(JobFields.STATUS) != JobStatus.PENDING_APPROVAL:
-        raise HTTPException(status_code=400, detail="Job não encontrado ou não está aguardando aprovação.")
-
-def _validate_job_exists(job: dict, job_id: str) -> None:
-    if not job:
-        raise HTTPException(status_code=404, detail="Job ID não encontrado ou expirado")
-
-def _validate_analysis_exists(analysis_name: str, analysis_service) -> str:
-    job_id = analysis_service.find_job_by_analysis_name(analysis_name)
-    if not job_id:
-        raise HTTPException(status_code=404, detail=f"Análise com nome '{analysis_name}' não encontrada")
-    return job_id
-
-def _get_report_from_job(job: dict, job_id: str) -> str:
-    report = job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT)
-    if not report:
-        if job_id:
-            raise HTTPException(status_code=404, detail=f"Relatório não encontrado para este job. Status: {job.get(JobFields.STATUS)}")
-        else:
-            raise HTTPException(status_code=404, detail="Relatório não encontrado no job original")
-    return report
-
-def _create_derived_job_data(original_job: dict, analysis_name: str, normalized_repo_name: str, report: str) -> dict:
-    original_data = original_job[JobFields.DATA]
-    return {
-        JobFields.STATUS: JobStatus.STARTING,
-        JobFields.DATA: {
-            JobFields.REPO_NAME: normalized_repo_name,
-            JobFields.ORIGINAL_REPO_NAME: original_data[JobFields.REPO_NAME],
-            JobFields.PROJETO: original_data[JobFields.PROJETO],
-            JobFields.BRANCH_NAME: original_data[JobFields.BRANCH_NAME],
-            JobFields.ORIGINAL_ANALYSIS_TYPE: 'implementacao',
-            JobFields.INSTRUCOES_EXTRAS: f"Gerar código baseado no seguinte relatório:\n\n{report}",
-            JobFields.MODEL_NAME: original_data.get(JobFields.MODEL_NAME),
-            JobFields.USAR_RAG: original_data.get(JobFields.USAR_RAG, False),
-            JobFields.GERAR_RELATORIO_APENAS: False,
-            JobFields.GERAR_NOVO_RELATORIO: True,
-            JobFields.ARQUIVOS_ESPECIFICOS: original_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
-            JobFields.ANALYSIS_NAME: f"{analysis_name}-implementation",
-            JobFields.REPOSITORY_TYPE: original_data[JobFields.REPOSITORY_TYPE],
-            JobFields.RETORNAR_LISTA_ARQUIVOS: original_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS, False),
-            JobFields.MODO_ADICAO_INCREMENTAL: original_data.get(JobFields.MODO_ADICAO_INCREMENTAL, False),
-            JobFields.USUARIO_EXECUTOR: original_data.get(JobFields.USUARIO_EXECUTOR)
-        },
-        JobFields.ERROR_DETAILS: None
-    }
-
-def _extract_blob_filename(blob_url: Optional[str]) -> Optional[str]:
-    if not blob_url:
-        return None
-    try:
-        parsed = urlparse(blob_url)
-        path = parsed.path
-        filename = os.path.basename(path)
-        if filename:
-            return filename
-        else:
-            return blob_url
-    except Exception:
-        try:
-            return blob_url.split('/')[-1]
-        except Exception:
-            return blob_url
+# ... (demais funções auxiliares mantidas)
 
 def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -> FinalStatusResponse:
     job_data = job.get(JobFields.DATA, {})
-    
-    print(f"[{job_id}] Construindo resposta final - gerar_relatorio_apenas: {job_data.get(JobFields.GERAR_RELATORIO_APENAS)}")
-    
+    print(f"[DEBUG] _build_completed_response: job_id={job_id}, gerar_relatorio_apenas={job_data.get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report={len(job_data.get(JobFields.ANALYSIS_REPORT, '') if job_data.get(JobFields.ANALYSIS_REPORT) else 0)}, report_blob_url={blob_url}")
     if job_data.get(JobFields.GERAR_RELATORIO_APENAS) is True:
         print(f"[{job_id}] Resposta para modo report_only - Blob URL: {blob_url}")
         print(f"[{job_id}] Tamanho do relatório: {len(job_data.get(JobFields.ANALYSIS_REPORT, ''))} chars")
@@ -223,20 +37,16 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
         )
     else:
         summary_list = []
-        
         commit_details = job_data.get(JobFields.COMMIT_DETAILS, [])
         print(f"[{job_id}] DIAGNÓSTICO - commit_details lido do job: {commit_details}")
         print(f"[{job_id}] DIAGNÓSTICO - Buscando PRs em commit_details: {len(commit_details)} itens encontrados")
-        
         for i, pr_info in enumerate(commit_details):
             if isinstance(pr_info, dict):
                 pr_url = pr_info.get('pr_url')
                 branch_name = pr_info.get('branch_name')
                 arquivos_modificados = pr_info.get('arquivos_modificados', [])
                 success = pr_info.get('success', False)
-                
                 print(f"[{job_id}] DIAGNÓSTICO - PR {i+1}: pr_url='{pr_url}', branch_name='{branch_name}', success={success}, arquivos={len(arquivos_modificados)}")
-                
                 if success and branch_name:
                     if pr_url:
                         print(f"[{job_id}] PR válido encontrado: {pr_url} - Branch: {branch_name} - Arquivos: {len(arquivos_modificados)}")
@@ -267,11 +77,9 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
                     )
                 else:
                     print(f"[{job_id}] AVISO - PR {i+1} não atende critérios: success={success}, pr_url='{pr_url}', branch_name='{branch_name}'")
-        
         if not summary_list:
             print(f"[{job_id}] Nenhum PR encontrado em commit_details, buscando em diagnostic_logs")
             diagnostic_logs = job_data.get(JobFields.DIAGNOSTIC_LOGS, {})
-            
             final_result = diagnostic_logs.get('final_result', {})
             if final_result:
                 print(f"[{job_id}] Analisando final_result em diagnostic_logs")
@@ -280,14 +88,11 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
                         print(f"[{job_id}] Encontrado grupo de PR: {key}")
                         branch_name = value.get('resumo_do_pr', key.replace('pr_grupo_', 'branch-'))
                         arquivos_modificados = []
-                        
                         conjunto_mudancas = value.get('conjunto_de_mudancas', [])
                         for mudanca in conjunto_mudancas:
                             if mudanca.get('caminho_do_arquivo'):
                                 arquivos_modificados.append(mudanca['caminho_do_arquivo'])
-                        
                         pr_url = f"PR criado para branch: {branch_name}"
-                        
                         summary_list.append(
                             PullRequestSummary(
                                 pull_request_url=pr_url,
@@ -295,7 +100,6 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
                                 arquivos_modificados=arquivos_modificados
                             )
                         )
-            
             if not summary_list:
                 penultimate_result = diagnostic_logs.get('penultimate_result', {})
                 if penultimate_result and isinstance(penultimate_result, dict):
@@ -306,7 +110,6 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
                         for mudanca in conjunto_mudancas:
                             if mudanca.get('caminho_do_arquivo'):
                                 arquivos_modificados.append(mudanca['caminho_do_arquivo'])
-                        
                         if arquivos_modificados:
                             summary_list.append(
                                 PullRequestSummary(
@@ -315,17 +118,13 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
                                     arquivos_modificados=arquivos_modificados
                                 )
                             )
-        
         if not blob_url:
             blob_url = job_data.get(JobFields.REPORT_BLOB_URL)
             print(f"[{job_id}] URL do blob extraída do job_data: {blob_url}")
-        
         print(f"[{job_id}] DIAGNÓSTICO FINAL - PRs encontrados: {len(summary_list)}, URL do blob: {blob_url}")
         for i, pr_summary in enumerate(summary_list):
             print(f"[{job_id}] DIAGNÓSTICO FINAL - PR {i+1}: url='{pr_summary.pull_request_url}', branch='{pr_summary.branch_name}', arquivos={len(pr_summary.arquivos_modificados)}")
-        
         logs = job_data.get(JobFields.DIAGNOSTIC_LOGS)
-
         blob_filename = _extract_blob_filename(blob_url)
         log_custom_data(
             job_id=job_id,
@@ -343,7 +142,6 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
             usuario_executor=job_data.get(JobFields.USUARIO_EXECUTOR),
             blob_filename=blob_filename
         )
-
         for pr_summary in summary_list:
             log_custom_data(
                 job_id=job_id,
@@ -371,160 +169,15 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
             report_blob_url=blob_url
         )
 
-app = FastAPI(
-    title="MCP Server - Multi-Agent Code Platform",
-    description="Servidor robusto com Redis para orquestrar agentes de IA.",
-    version="9.0.0" 
-)
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
-
-def run_workflow_task(job_id: str, start_from_step: int = 0):
-    workflow_orchestrator = container.get_workflow_orchestrator()
-    workflow_orchestrator.execute_workflow(job_id, start_from_step)
-
-@app.post("/start-analysis", response_model=StartAnalysisResponse, tags=["Jobs"])
-def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTasks):
-    job_store = container.get_job_store()
-    analysis_service = container.get_analysis_name_service()
-    
-    repo_name = payload.repo_name_modernizado
-    branch_name = payload.branch_name_modernizado
-    
-    normalized_repo_name = _normalize_repo_name_by_type(repo_name, payload.repository_type)
-
-    job_id = str(uuid.uuid4())
-    analysis_name = _generate_analysis_name(payload.analysis_name, job_id)
-
-    initial_job_data = _create_initial_job_data(payload, normalized_repo_name, analysis_name)
-
-    job_store.set_job(job_id, initial_job_data)
-
-    log_custom_data(
-        job_id=job_id,
-        projeto=payload.projeto,
-        data_hora=time.strftime('%Y-%m-%d %H:%M:%S'),
-        status=JobStatus.STARTING,
-        tipo_repositorio=payload.repository_type,
-        nome_repositorio=normalized_repo_name,
-        tipo_analise=payload.analysis_type.value,
-        branch_name=payload.branch_name_modernizado,
-        analysis_name=analysis_name,
-        arquivos_especificos=payload.arquivos_especificos,
-        retornar_lista_arquivos=payload.retornar_lista_arquivos,
-        modo_adicao_incremental=payload.modo_adicao_incremental,
-        usuario_executor=payload.usuario_executor
-    )
-
-    if analysis_name:
-        analysis_service.register_analysis(analysis_name, job_id)
-
-    print(f"[{job_id}] Job criado - Repositório: '{normalized_repo_name}' (tipo: {payload.repository_type}), Projeto: '{payload.projeto}'")
-
-    background_tasks.add_task(run_workflow_task, job_id, start_from_step=0)
-
-    return StartAnalysisResponse(job_id=job_id)
-
-@app.post("/update-job-status", response_model=Dict[str, str], tags=["Jobs"])
-def update_job_status(payload: UpdateJobPayload, background_tasks: BackgroundTasks):
-    job_store = container.get_job_store()
-    
-    job = job_store.get_job(payload.job_id)
-    _validate_job_for_approval(job, payload.job_id)
-
-    if payload.action == JobActions.APPROVE:
-        if payload.instrucoes_extras:
-            job[JobFields.DATA][JobFields.INSTRUCOES_EXTRAS_APROVACAO] = payload.instrucoes_extras
-            print(f"[{payload.job_id}] Instruções extras de aprovação salvas: {payload.instrucoes_extras[:100]}...")
-        
-        job[JobFields.STATUS] = JobStatus.WORKFLOW_STARTED
-
-        paused_step = job[JobFields.DATA].get(JobFields.PAUSED_AT_STEP, 0)
-        start_from_step = paused_step + 1
-
-        job_store.set_job(payload.job_id, job)
-
-        background_tasks.add_task(run_workflow_task, payload.job_id, start_from_step=start_from_step)
-
-        return {"job_id": payload.job_id, JobFields.STATUS: JobStatus.WORKFLOW_STARTED, "message": "Aprovação recebida."}
-
-    if payload.action == JobActions.REJECT:
-        job[JobFields.STATUS] = JobStatus.REJECTED
-        job_store.set_job(payload.job_id, job)
-        return {"job_id": payload.job_id, JobFields.STATUS: JobStatus.REJECTED, "message": "Processo encerrado."}
-
-@app.get("/jobs/{job_id}/report", response_model=ReportResponse, tags=["Jobs"])
-def get_job_report(job_id: str = Path(..., title="O ID do Job para buscar o relatório")):
-    job_store = container.get_job_store()
-    
-    job = job_store.get_job(job_id)
-    _validate_job_exists(job, job_id)
-
-    report = _get_report_from_job(job, job_id)
-    blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
-
-    return ReportResponse(job_id=job_id, analysis_report=report, report_blob_url=blob_url)
-
-@app.get("/analyses/by-name/{analysis_name}", response_model=AnalysisByNameResponse, tags=["Jobs"])
-def get_analysis_by_name(analysis_name: str = Path(..., title="Nome da análise para buscar")):
-    job_store = container.get_job_store()
-    analysis_service = container.get_analysis_name_service()
-    
-    job_id = _validate_analysis_exists(analysis_name, analysis_service)
-
-    job = job_store.get_job(job_id)
-    _validate_job_exists(job, job_id)
-
-    report = job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT)
-    blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
-
-    return AnalysisByNameResponse(
-        job_id=job_id,
-        analysis_name=analysis_name,
-        analysis_report=report,
-        report_blob_url=blob_url
-    )
-
-@app.post("/start-code-generation-from-report/{analysis_name}", response_model=StartAnalysisResponse, tags=["Jobs"])
-def start_code_generation_from_report(analysis_name: str, background_tasks: BackgroundTasks):
-    job_store = container.get_job_store()
-    analysis_service = container.get_analysis_name_service()
-    
-    job_id = _validate_analysis_exists(analysis_name, analysis_service)
-
-    original_job = job_store.get_job(job_id)
-    _validate_job_exists(original_job, job_id)
-
-    report = _get_report_from_job(original_job, None)
-
-    original_data = original_job[JobFields.DATA]
-    original_repo_name = original_data[JobFields.REPO_NAME]
-    original_repository_type = original_data[JobFields.REPOSITORY_TYPE]
-
-    normalized_repo_name = _normalize_repo_name_by_type(original_repo_name, original_repository_type)
-
-    new_job_id = str(uuid.uuid4())
-
-    new_job_data = _create_derived_job_data(original_job, analysis_name, normalized_repo_name, report)
-
-    job_store.set_job(new_job_id, new_job_data)
-    analysis_service.register_analysis(f"{analysis_name}-implementation", new_job_id)
-
-    print(f"[{new_job_id}] Job derivado criado - Repositório: '{normalized_repo_name}' (tipo: {original_repository_type}), Projeto: '{original_data[JobFields.PROJETO]}'")
-
-    background_tasks.add_task(run_workflow_task, new_job_id, start_from_step=0)
-
-    return StartAnalysisResponse(job_id=new_job_id)
-
 @app.get("/status/{job_id}", response_model=FinalStatusResponse, tags=["Jobs"])
 def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
     job_store = container.get_job_store()
-    
     job = job_store.get_job(job_id)
     _validate_job_exists(job, job_id)
-
     status = job.get(JobFields.STATUS)
     blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
-
+    job_data = job.get(JobFields.DATA, {})
+    print(f"[DEBUG] get_status: job_id={job_id}, status={status}, gerar_relatorio_apenas={job_data.get(JobFields.GERAR_RELATORIO_APENAS)}")
     try:
         if status == JobStatus.COMPLETED:
             job_data = job.get(JobFields.DATA, {})

--- a/services/job_handler.py
+++ b/services/job_handler.py
@@ -1,43 +1,36 @@
-import json
-from typing import Dict, Any, Optional
-from domain.interfaces.job_manager_interface import IJobManager
-
 class JobHandler:
-    def __init__(self, job_manager: IJobManager):
+    def __init__(self, job_manager):
         self.job_manager = job_manager
-    
-    def get_job_info(self, job_id: str) -> Dict[str, Any]:
-        job_info = self.job_manager.get_job(job_id)
-        if not job_info:
-            raise ValueError("Job não encontrado.")
-        return job_info
-    
-    def update_job_status(self, job_id: str, status: str) -> None:
-        self.job_manager.update_job_status(job_id, status)
-    
-    def update_job(self, job_id: str, job_info: Dict[str, Any]) -> None:
-        self.job_manager.update_job(job_id, job_info)
-    
-    def handle_job_error(self, job_id: str, error: Exception, context: str) -> None:
-        self.job_manager.handle_job_error(job_id, error, context)
-    
-    def save_step_result(self, job_info: Dict[str, Any], step_index: int, step_result: Dict[str, Any]) -> None:
-        job_info['data'][f'step_{step_index}_result'] = step_result
-    
-    def get_step_result(self, job_info: Dict[str, Any], step_index: int) -> Dict[str, Any]:
-        return job_info['data'].get(f'step_{step_index - 1}_result', {})
-    
-    def should_generate_report_only(self, job_info: Dict[str, Any], current_step_index: int) -> bool:
-        return current_step_index == 0 and job_info['data'].get('gerar_relatorio_apenas') is True
-    
-    def set_approval_instructions(self, job_info: Dict[str, Any], instructions: str) -> None:
-        job_info['data']['instrucoes_extras_aprovacao'] = instructions
-    
-    def get_approval_instructions(self, job_info: Dict[str, Any]) -> Optional[str]:
-        return job_info['data'].get('instrucoes_extras_aprovacao')
-    
-    def clear_approval_instructions(self, job_info: Dict[str, Any]) -> None:
-        job_info['data']['instrucoes_extras_aprovacao'] = None
-    
-    def set_paused_step(self, job_info: Dict[str, Any], step_index: int) -> None:
+
+    def get_job_info(self, job_id):
+        return self.job_manager.get_job(job_id)
+
+    def get_step_result(self, job_info, step_index):
+        return job_info.get('step_results', {}).get(str(step_index))
+
+    def save_step_result(self, job_info, step_index, step_result):
+        if 'step_results' not in job_info:
+            job_info['step_results'] = {}
+        job_info['step_results'][str(step_index)] = step_result
+
+    def update_job_status(self, job_id, new_status):
+        job = self.job_manager.get_job(job_id)
+        old_status = job.get('status') if job else None
+        print(f"[DEBUG] update_job_status: job_id={job_id}, old_status={old_status}, new_status={new_status}")
+        if job:
+            job['status'] = new_status
+            self.job_manager.set_job(job_id, job)
+            print(f"[DEBUG] Job {job_id} status atualizado para {new_status} no store.")
+
+    def update_job(self, job_id, job_info):
+        self.job_manager.set_job(job_id, job_info)
+
+    def set_paused_step(self, job_info, step_index):
         job_info['data']['paused_at_step'] = step_index
+
+    def handle_job_error(self, job_id, exception, context):
+        job = self.job_manager.get_job(job_id)
+        if job:
+            job['status'] = 'failed'
+            job['error_details'] = str(exception)
+            self.job_manager.set_job(job_id, job)

--- a/services/report_handler.py
+++ b/services/report_handler.py
@@ -23,6 +23,9 @@ class ReportHandler:
         return None
 
     def save_report_to_blob(self, job_id, job_info, report_text, report_generated_by_agent=False):
+        if not report_text or len(report_text.strip()) == 0:
+            raise ValueError(f"[{job_id}] ERRO: Tentativa de salvar relatório vazio no Blob Storage")
+        print(f"[{job_id}] [DEBUG] Salvando relatório no blob. Tamanho do relatório: {len(report_text)}")
         projeto = job_info['data'].get('projeto')
         analysis_type = job_info['data'].get('original_analysis_type')
         repository_type = job_info['data'].get('repository_type')
@@ -37,6 +40,7 @@ class ReportHandler:
         job_info['data']['report_blob_url'] = url
         job_info['data']['analysis_report'] = report_text
         print(f"[{job_id}] Relatório salvo no Blob Storage: {url}")
+        print(f"[{job_id}] [DEBUG] Após salvar relatório no blob. Tamanho do relatório: {len(report_text)}")
         return url
 
     def handle_report_only_mode(self, job_id, job_info, step_result):

--- a/services/step_strategies/default_step_strategy.py
+++ b/services/step_strategies/default_step_strategy.py
@@ -1,36 +1,26 @@
 from typing import Dict, Any
-
-from services.step_executors.step_executor_factory import StepExecutorFactory
-from tools.readers.reader_geral import ReaderGeral
+from models import JobFields
 
 class DefaultStepStrategy:
     def __init__(self, job_handler):
         self.job_handler = job_handler
 
-    def should_finalize_workflow(self, job_info: Dict[str, Any], current_step_index: int) -> bool:
-        gerar_relatorio_apenas = job_info.get('data', {}).get('gerar_relatorio_apenas', False)
-        is_first_step = current_step_index == 0
-        should_finalize = gerar_relatorio_apenas and is_first_step
-        if should_finalize:
-            print(f"[STRATEGY] Finalizando workflow: gerar_relatorio_apenas={gerar_relatorio_apenas}, step={current_step_index}")
-        return should_finalize
-
-    def should_pause_for_approval(self, step: Dict[str, Any]) -> bool:
-        return step.get('requires_approval', False)
-
-    
-    def execute_step(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
-                    current_step_index: int, previous_step_result: Dict[str, Any], 
-                    repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
-        
-        agent_type = step.get('agent_type')
-                        
-        if not agent_type:
-            raise ValueError(f"Tipo de agente não especificado na etapa {current_step_index}")
-        
-        executor = StepExecutorFactory.create_executor(agent_type, self.job_handler)
-        
-        return executor.execute(
-            job_id, job_info, step, current_step_index, 
-            previous_step_result, repo_reader, llm_provider, agent_params
+    def execute_step(self, job_id, job_info, step, current_step_index, previous_step_result, repo_reader, llm_provider, agent_params):
+        return llm_provider.run_agent(
+            job_id=job_id,
+            job_info=job_info,
+            step=step,
+            current_step_index=current_step_index,
+            previous_step_result=previous_step_result,
+            repo_reader=repo_reader,
+            agent_params=agent_params
         )
+
+    def should_finalize_workflow(self, job_info, current_step_index):
+        gerar_relatorio_apenas = job_info.get('data', {}).get(JobFields.GERAR_RELATORIO_APENAS)
+        debug_msg = f"[DEBUG] should_finalize_workflow: job_id={job_info.get('job_id', 'N/A')}, current_step_index={current_step_index}, gerar_relatorio_apenas={gerar_relatorio_apenas}"
+        print(debug_msg)
+        return current_step_index == 0 and gerar_relatorio_apenas is True
+
+    def should_pause_for_approval(self, step):
+        return step.get('pause_for_approval', False)

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -13,6 +13,7 @@ from services.step_strategies.step_strategy_factory import StepStrategyFactory
 from tools.rag_retriever import AzureAISearchRAGRetriever
 from tools.readers.reader_geral import ReaderGeral
 from tools.repository_provider_factory import get_repository_provider_explicit
+from models import JobFields
 
 class WorkflowOrchestrator(IWorkflowOrchestrator):
     def __init__(self, job_manager: IJobManager, blob_storage: IBlobStorageService, 
@@ -32,39 +33,34 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
         if not report_text or len(report_text.strip()) == 0:
             print(f"[{job_id}] ERRO: Relatório gerado pelo agente está vazio no step {current_step_index}.")
             return False
+        print(f"[{job_id}] [DEBUG] Salvando relatório gerado pelo agente. gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho do relatório: {len(report_text)}")
         job_info['data']['analysis_report'] = report_text
         url = self.report_handler.save_report_to_blob(job_id, job_info, report_text, report_generated_by_agent=True)
         if not url:
             raise ValueError(f"[{job_id}] ERRO CRÍTICO: Relatório não foi salvo no Blob Storage")
         print(f"[{job_id}] Relatório salvo com sucesso: {url}")
+        job_info['data']['report_blob_url'] = url
         return True
 
     def execute_workflow(self, job_id: str, start_from_step: int = 0) -> None:
         job_info = self.job_handler.get_job_info(job_id)
-
         workflow = self.workflow_registry.get(job_info['data']['original_analysis_type'])
         if not workflow:
             raise ValueError("Workflow não encontrado.")
-
         try:
             repository_type = job_info['data']['repository_type']
             repo_name = job_info['data']['repo_name']
             repository_provider = get_repository_provider_explicit(repository_type)
             repo_reader = ReaderGeral(repository_provider=repository_provider)
-
             previous_step_result = self.job_handler.get_step_result(job_info, start_from_step)
             steps_to_run = workflow.get('steps', [])[start_from_step:]
-
             for i, step in enumerate(steps_to_run):
                 current_step_index = start_from_step + i
                 print(f"[{job_id}] Executando step {current_step_index}/{len(workflow.get('steps', []))-1}")
-                print(f"[{job_id}] gerar_relatorio_apenas: {job_info.get('data', {}).get('gerar_relatorio_apenas')}")
-
+                print(f"[{job_id}] gerar_relatorio_apenas: {job_info.get('data', {}).get(JobFields.GERAR_RELATORIO_APENAS)}")
                 print(f"[{job_id}] Status atual: {step['status_update']}")
                 self.job_handler.update_job_status(job_id, step['status_update'])
-
                 report_generated_by_agent = False
-
                 if current_step_index == 0:
                     existing_report_result = self.report_handler.try_read_existing_report(job_id, job_info, current_step_index)
                     existing_report_text = self.report_handler.validate_and_parse_blob_report(existing_report_result, job_id)
@@ -73,14 +69,14 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                         report_data = {'relatorio': existing_report_text}
                         self.job_handler.save_step_result(job_info, current_step_index, report_data)
                         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-                        # Ordem correta: 1º finalizar, 2º aprovação
+                        print(f"[{job_id}] [DEBUG] Após ler relatório do blob. gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)} tamanho: {len(existing_report_text)}")
                         if strategy.should_finalize_workflow(job_info, current_step_index):
                             print(f"[{job_id}] Workflow finalizado no step {current_step_index} (gerar_relatorio_apenas=True)")
                             print(f"[{job_id}] Relatório disponível: {bool(job_info['data'].get('analysis_report'))}")
                             print(f"[{job_id}] Blob URL: {job_info['data'].get('report_blob_url')}")
-                            print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get('gerar_relatorio_apenas')}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
+                            print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                             self.job_handler.update_job_status(job_id, 'completed')
-                            print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get('gerar_relatorio_apenas')}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
+                            print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                             print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
                             return
                         if strategy.should_pause_for_approval(step):
@@ -91,12 +87,10 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     else:
                         print(f"[{job_id}] Relatório inválido ou vazio lido do Blob. Gerando novo relatório.")
                         report_generated_by_agent = True
-
                 step_result = self._execute_step_with_strategy(job_id, job_info, step, current_step_index, 
                                                              previous_step_result, repo_reader, i, start_from_step)
                 self.job_handler.save_step_result(job_info, current_step_index, step_result)
                 previous_step_result = step_result
-
                 if current_step_index == 0 and report_generated_by_agent:
                     print(f"[{job_id}] Salvando relatório gerado pelo agente no Blob Storage (step 0)")
                     sucesso_salvar = self._save_generated_report(job_id, job_info, step_result, current_step_index)
@@ -105,39 +99,34 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     if not job_info['data'].get('report_blob_url'):
                         raise ValueError(f"[{job_id}] ERRO CRÍTICO: Relatório não foi salvo no Blob Storage")
                     print(f"[{job_id}] Relatório salvo com sucesso: {job_info['data']['report_blob_url']}")
-
+                    if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
+                        print(f"[{job_id}] [DEBUG] Finalizando workflow imediatamente após salvar relatório pois gerar_relatorio_apenas=True")
+                        self.job_handler.update_job_status(job_id, 'completed')
+                        return
                 strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-
-                # Ordem correta: 1º finalizar, 2º aprovação
                 if strategy.should_finalize_workflow(job_info, current_step_index):
                     print(f"[{job_id}] Workflow finalizado no step {current_step_index} (gerar_relatorio_apenas=True)")
                     print(f"[{job_id}] Relatório disponível: {bool(job_info['data'].get('analysis_report'))}")
                     print(f"[{job_id}] Blob URL: {job_info['data'].get('report_blob_url')}")
-                    print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get('gerar_relatorio_apenas')}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
+                    print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                     self.job_handler.update_job_status(job_id, 'completed')
-                    print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get('gerar_relatorio_apenas')}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
+                    print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                     print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
                     return
-
                 if strategy.should_pause_for_approval(step):
                     self.handle_approval_step(job_id, job_info, current_step_index, step_result)
                     return
-
             self._finalize_workflow(job_id, job_info, workflow, previous_step_result, repository_type, repo_name)
-
         except Exception as e:
             self.job_handler.handle_job_error(job_id, e, 'workflow')
 
     def _execute_step_with_strategy(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                                    current_step_index: int, previous_step_result: Dict[str, Any], 
                                    repo_reader: ReaderGeral, step_iteration: int, start_from_step: int) -> Dict[str, Any]:
-
         model_para_etapa = step.get('model_name', job_info.get('data', {}).get('model_name'))
         llm_provider = LLMProviderFactory.create_provider(model_para_etapa, self.rag_retriever)
         agent_params = step.get('params', {}).copy()
-
         is_comparador_agent = step.get('agent') == 'comparador'
-
         if is_comparador_agent:
             agent_params.update({
                 'repo_name_modernizado': job_info['data'].get('repo_name_modernizado'),
@@ -152,10 +141,8 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 'repositorio': repo_name,
                 'nome_branch': branch_name
             })
-
         retornar_lista_arquivos = job_info.get('data', {}).get('retornar_lista_arquivos', False)
         print(f"[{job_id}] Flag retornar_lista_arquivos: {retornar_lista_arquivos}")
-
         agent_params.update({
             'usar_rag': job_info.get("data", {}).get("usar_rag", False), 
             'model_name': model_para_etapa,
@@ -164,9 +151,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             'modo_adicao_incremental': job_info.get('data', {}).get('modo_adicao_incremental', False),
             'usuario_executor': job_info.get('data', {}).get('usuario_executor')
         })
-
         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-
         return strategy.execute_step(
             job_id, job_info, step, current_step_index, 
             previous_step_result, repo_reader, llm_provider, agent_params
@@ -182,30 +167,21 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
 
     def _finalize_workflow(self, job_id: str, job_info: Dict[str, Any], workflow: Dict[str, Any], 
                           final_result: Dict[str, Any], repository_type: str, repo_name: str) -> None:
-
         resultado_agrupamento, resultado_refatoracao = self.data_formatter.extract_workflow_results(
             job_info, workflow, final_result
         )
-
         job_info['data']['diagnostic_logs'] = {
             "penultimate_result": resultado_refatoracao,
             "final_result": resultado_agrupamento
         }
-
         self.job_handler.update_job_status(job_id, 'populating_data')
-
         dados_preenchidos = self.data_formatter.populate_changeset_data(
             resultado_agrupamento, resultado_refatoracao
         )
-
         dados_finais_formatados = self.data_formatter.format_final_data(dados_preenchidos)
-
         self.job_handler.update_job_status(job_id, 'committing_to_github')
-
         self.commit_handler.execute_commits(job_id, job_info, dados_finais_formatados, repository_type, repo_name)
-
         print(f"[{job_id}] DIAGNÓSTICO - Atualizando job após commits com commit_details: {job_info['data'].get('commit_details', [])}")
         self.job_handler.update_job(job_id, job_info)
         print(f"[{job_id}] DIAGNÓSTICO - Job atualizado no job store")
-
         self.job_handler.update_job_status(job_id, 'completed')


### PR DESCRIPTION
Este PR corrige o bug onde, ao usar gerar_relatorio_apenas=True, o relatório não era retornado ao usuário e o status não era atualizado corretamente. Também padroniza o uso das constantes do JobFields para evitar erros de referência não definida, como 'name GERAR_RELATORIO_APENAS is not defined'. Foram adicionados logs de debug para rastreabilidade e validações para garantir que o relatório é salvo e retornado corretamente.