### PR TITLE
Correção do fluxo gerar_relatorio_apenas=True: relatório gerado/salvo e retornado corretamente com status 'completed'

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -209,124 +209,153 @@ def _extract_blob_filename(blob_url: Optional[str]) -> Optional[str]:
 
 def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -> FinalStatusResponse:
     job_data = job.get(JobFields.DATA, {})
-    
-    print(f"[{job_id}] Construindo resposta final - gerar_relatorio_apenas: {job_data.get(JobFields.GERAR_RELATORIO_APENAS)}")
-    
-    if job_data.get(JobFields.GERAR_RELATORIO_APENAS) is True:
-        print(f"[{job_id}] Resposta para modo report_only - Blob URL: {blob_url}")
-        print(f"[{job_id}] Tamanho do relatório: {len(job_data.get(JobFields.ANALYSIS_REPORT, ''))} chars")
-        return FinalStatusResponse(
+    gerar_relatorio_apenas = job_data.get(JobFields.GERAR_RELATORIO_APENAS, False)
+
+    print(f"[{job_id}] [_build_completed_response] INÍCIO - gerar_relatorio_apenas: {gerar_relatorio_apenas}")
+    print(f"[{job_id}] [_build_completed_response] blob_url (parâmetro): {blob_url}")
+    print(f"[{job_id}] [_build_completed_response] report_blob_url (job_data): {job_data.get(JobFields.REPORT_BLOB_URL)}")
+    print(f"[{job_id}] [_build_completed_response] Tamanho analysis_report: {len(job_data.get(JobFields.ANALYSIS_REPORT, ''))} chars")
+
+    # PRIORIDADE ABSOLUTA: Modo report_only
+    if gerar_relatorio_apenas is True:
+        analysis_report = job_data.get(JobFields.ANALYSIS_REPORT)
+        final_blob_url = blob_url or job_data.get(JobFields.REPORT_BLOB_URL)
+
+        print(f"[{job_id}] [_build_completed_response] MODO REPORT_ONLY - Construindo resposta")
+        print(f"[{job_id}] [_build_completed_response] analysis_report presente: {bool(analysis_report)}")
+        print(f"[{job_id}] [_build_completed_response] final_blob_url: {final_blob_url}")
+
+        if not analysis_report:
+            print(f"[{job_id}] [_build_completed_response] ERRO: analysis_report está vazio no modo report_only!")
+        if not final_blob_url:
+            print(f"[{job_id}] [_build_completed_response] AVISO: report_blob_url está vazio no modo report_only!")
+
+        response = FinalStatusResponse(
             job_id=job_id,
             status=JobStatus.COMPLETED,
-            analysis_report=job_data.get(JobFields.ANALYSIS_REPORT),
-            report_blob_url=blob_url
+            analysis_report=analysis_report,
+            report_blob_url=final_blob_url
         )
-    else:
-        summary_list = []
-        
-        commit_details = job_data.get(JobFields.COMMIT_DETAILS, [])
-        print(f"[{job_id}] DIAGNÓSTICO - commit_details lido do job: {commit_details}")
-        print(f"[{job_id}] DIAGNÓSTICO - Buscando PRs em commit_details: {len(commit_details)} itens encontrados")
-        
-        for i, pr_info in enumerate(commit_details):
-            if isinstance(pr_info, dict):
-                pr_url = pr_info.get('pr_url')
-                branch_name = pr_info.get('branch_name')
-                arquivos_modificados = pr_info.get('arquivos_modificados', [])
-                success = pr_info.get('success', False)
-                
-                print(f"[{job_id}] DIAGNÓSTICO - PR {i+1}: pr_url='{pr_url}', branch_name='{branch_name}', success={success}, arquivos={len(arquivos_modificados)}")
-                
-                if success and branch_name:
-                    if pr_url:
-                        print(f"[{job_id}] PR válido encontrado: {pr_url} - Branch: {branch_name} - Arquivos: {len(arquivos_modificados)}")
-                        summary_list.append(
-                            PullRequestSummary(
-                                pull_request_url=pr_url,
-                                branch_name=branch_name,
-                                arquivos_modificados=arquivos_modificados
-                            )
-                        )
-                    else:
-                        print(f"[{job_id}] Branch processada sem PR URL: {branch_name} - Arquivos: {len(arquivos_modificados)}")
-                        summary_list.append(
-                            PullRequestSummary(
-                                pull_request_url=f"Branch processada: {branch_name}",
-                                branch_name=branch_name,
-                                arquivos_modificados=arquivos_modificados
-                            )
-                        )
-                elif pr_info.get('message') and branch_name:
-                    print(f"[{job_id}] Branch processada: {branch_name} - Arquivos: {len(arquivos_modificados)}")
+        print(f"[{job_id}] [_build_completed_response] MODO REPORT_ONLY - Resposta construída com sucesso")
+        return response
+
+    # Modo normal: extração de PRs e summary
+    print(f"[{job_id}] [_build_completed_response] MODO NORMAL - Extraindo PRs")
+    summary_list = []
+    commit_details = job_data.get(JobFields.COMMIT_DETAILS, [])
+    print(f"[{job_id}] DIAGNÓSTICO - commit_details lido do job: {commit_details}")
+    print(f"[{job_id}] DIAGNÓSTICO - Buscando PRs em commit_details: {len(commit_details)} itens encontrados")
+
+    for i, pr_info in enumerate(commit_details):
+        if isinstance(pr_info, dict):
+            pr_url = pr_info.get('pr_url')
+            branch_name = pr_info.get('branch_name')
+            arquivos_modificados = pr_info.get('arquivos_modificados', [])
+            success = pr_info.get('success', False)
+
+            print(f"[{job_id}] DIAGNÓSTICO - PR {i+1}: pr_url='{pr_url}', branch_name='{branch_name}', success={success}, arquivos={len(arquivos_modificados)}")
+
+            if success and branch_name:
+                if pr_url:
+                    print(f"[{job_id}] PR válido encontrado: {pr_url} - Branch: {branch_name} - Arquivos: {len(arquivos_modificados)}")
                     summary_list.append(
                         PullRequestSummary(
-                            pull_request_url=pr_info.get('message', f"Branch processada: {branch_name}"),
+                            pull_request_url=pr_url,
                             branch_name=branch_name,
                             arquivos_modificados=arquivos_modificados
                         )
                     )
                 else:
-                    print(f"[{job_id}] AVISO - PR {i+1} não atende critérios: success={success}, pr_url='{pr_url}', branch_name='{branch_name}'")
-        
+                    print(f"[{job_id}] Branch processada sem PR URL: {branch_name} - Arquivos: {len(arquivos_modificados)}")
+                    summary_list.append(
+                        PullRequestSummary(
+                            pull_request_url=f"Branch processada: {branch_name}",
+                            branch_name=branch_name,
+                            arquivos_modificados=arquivos_modificados
+                        )
+                    )
+            elif pr_info.get('message') and branch_name:
+                print(f"[{job_id}] Branch processada: {branch_name} - Arquivos: {len(arquivos_modificados)}")
+                summary_list.append(
+                    PullRequestSummary(
+                        pull_request_url=pr_info.get('message', f"Branch processada: {branch_name}"),
+                        branch_name=branch_name,
+                        arquivos_modificados=arquivos_modificados
+                    )
+                )
+            else:
+                print(f"[{job_id}] AVISO - PR {i+1} não atende critérios: success={success}, pr_url='{pr_url}', branch_name='{branch_name}'")
+
+    if not summary_list:
+        print(f"[{job_id}] Nenhum PR encontrado em commit_details, buscando em diagnostic_logs")
+        diagnostic_logs = job_data.get(JobFields.DIAGNOSTIC_LOGS, {})
+
+        final_result = diagnostic_logs.get('final_result', {})
+        if final_result:
+            print(f"[{job_id}] Analisando final_result em diagnostic_logs")
+            for key, value in final_result.items():
+                if key.startswith('pr_grupo_') and isinstance(value, dict):
+                    print(f"[{job_id}] Encontrado grupo de PR: {key}")
+                    branch_name = value.get('resumo_do_pr', key.replace('pr_grupo_', 'branch-'))
+                    arquivos_modificados = []
+
+                    conjunto_mudancas = value.get('conjunto_de_mudancas', [])
+                    for mudanca in conjunto_mudancas:
+                        if mudanca.get('caminho_do_arquivo'):
+                            arquivos_modificados.append(mudanca['caminho_do_arquivo'])
+
+                    pr_url = f"PR criado para branch: {branch_name}"
+
+                    summary_list.append(
+                        PullRequestSummary(
+                            pull_request_url=pr_url,
+                            branch_name=branch_name,
+                            arquivos_modificados=arquivos_modificados
+                        )
+                    )
+
         if not summary_list:
-            print(f"[{job_id}] Nenhum PR encontrado em commit_details, buscando em diagnostic_logs")
-            diagnostic_logs = job_data.get(JobFields.DIAGNOSTIC_LOGS, {})
-            
-            final_result = diagnostic_logs.get('final_result', {})
-            if final_result:
-                print(f"[{job_id}] Analisando final_result em diagnostic_logs")
-                for key, value in final_result.items():
-                    if key.startswith('pr_grupo_') and isinstance(value, dict):
-                        print(f"[{job_id}] Encontrado grupo de PR: {key}")
-                        branch_name = value.get('resumo_do_pr', key.replace('pr_grupo_', 'branch-'))
-                        arquivos_modificados = []
-                        
-                        conjunto_mudancas = value.get('conjunto_de_mudancas', [])
-                        for mudanca in conjunto_mudancas:
-                            if mudanca.get('caminho_do_arquivo'):
-                                arquivos_modificados.append(mudanca['caminho_do_arquivo'])
-                        
-                        pr_url = f"PR criado para branch: {branch_name}"
-                        
+            penultimate_result = diagnostic_logs.get('penultimate_result', {})
+            if penultimate_result and isinstance(penultimate_result, dict):
+                print(f"[{job_id}] Analisando penultimate_result em diagnostic_logs")
+                conjunto_mudancas = penultimate_result.get('conjunto_de_mudancas', [])
+                if conjunto_mudancas:
+                    arquivos_modificados = []
+                    for mudanca in conjunto_mudancas:
+                        if mudanca.get('caminho_do_arquivo'):
+                            arquivos_modificados.append(mudanca['caminho_do_arquivo'])
+
+                    if arquivos_modificados:
                         summary_list.append(
                             PullRequestSummary(
-                                pull_request_url=pr_url,
-                                branch_name=branch_name,
+                                pull_request_url="PR criado com base no resultado da análise",
+                                branch_name="branch-implementacao",
                                 arquivos_modificados=arquivos_modificados
                             )
                         )
-            
-            if not summary_list:
-                penultimate_result = diagnostic_logs.get('penultimate_result', {})
-                if penultimate_result and isinstance(penultimate_result, dict):
-                    print(f"[{job_id}] Analisando penultimate_result em diagnostic_logs")
-                    conjunto_mudancas = penultimate_result.get('conjunto_de_mudancas', [])
-                    if conjunto_mudancas:
-                        arquivos_modificados = []
-                        for mudanca in conjunto_mudancas:
-                            if mudanca.get('caminho_do_arquivo'):
-                                arquivos_modificados.append(mudanca['caminho_do_arquivo'])
-                        
-                        if arquivos_modificados:
-                            summary_list.append(
-                                PullRequestSummary(
-                                    pull_request_url="PR criado com base no resultado da análise",
-                                    branch_name="branch-implementacao",
-                                    arquivos_modificados=arquivos_modificados
-                                )
-                            )
-        
-        if not blob_url:
-            blob_url = job_data.get(JobFields.REPORT_BLOB_URL)
-            print(f"[{job_id}] URL do blob extraída do job_data: {blob_url}")
-        
-        print(f"[{job_id}] DIAGNÓSTICO FINAL - PRs encontrados: {len(summary_list)}, URL do blob: {blob_url}")
-        for i, pr_summary in enumerate(summary_list):
-            print(f"[{job_id}] DIAGNÓSTICO FINAL - PR {i+1}: url='{pr_summary.pull_request_url}', branch='{pr_summary.branch_name}', arquivos={len(pr_summary.arquivos_modificados)}")
-        
-        logs = job_data.get(JobFields.DIAGNOSTIC_LOGS)
 
-        blob_filename = _extract_blob_filename(blob_url)
+    final_blob_url = blob_url or job_data.get(JobFields.REPORT_BLOB_URL)
+    logs = job_data.get(JobFields.DIAGNOSTIC_LOGS)
+
+    blob_filename = _extract_blob_filename(final_blob_url)
+    log_custom_data(
+        job_id=job_id,
+        projeto=job_data.get(JobFields.PROJETO),
+        data_hora=time.strftime('%Y-%m-%d %H:%M:%S'),
+        status=JobStatus.COMPLETED,
+        tipo_repositorio=job_data.get(JobFields.REPOSITORY_TYPE),
+        nome_repositorio=job_data.get(JobFields.REPO_NAME),
+        tipo_analise=job_data.get(JobFields.ORIGINAL_ANALYSIS_TYPE),
+        branch_name=job_data.get(JobFields.BRANCH_NAME),
+        analysis_name=job_data.get(JobFields.ANALYSIS_NAME),
+        arquivos_especificos=job_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
+        retornar_lista_arquivos=job_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS),
+        modo_adicao_incremental=job_data.get(JobFields.MODO_ADICAO_INCREMENTAL),
+        usuario_executor=job_data.get(JobFields.USUARIO_EXECUTOR),
+        blob_filename=blob_filename
+    )
+
+    for pr_summary in summary_list:
         log_custom_data(
             job_id=job_id,
             projeto=job_data.get(JobFields.PROJETO),
@@ -335,41 +364,26 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
             tipo_repositorio=job_data.get(JobFields.REPOSITORY_TYPE),
             nome_repositorio=job_data.get(JobFields.REPO_NAME),
             tipo_analise=job_data.get(JobFields.ORIGINAL_ANALYSIS_TYPE),
-            branch_name=job_data.get(JobFields.BRANCH_NAME),
+            branch_name=job_data.get(JobFields.BRANCH_NAME_MODERNIZADO),
             analysis_name=job_data.get(JobFields.ANALYSIS_NAME),
             arquivos_especificos=job_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
+            pr_url=pr_summary.pull_request_url,
+            arquivos_modificados=pr_summary.arquivos_modificados,
             retornar_lista_arquivos=job_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS),
             modo_adicao_incremental=job_data.get(JobFields.MODO_ADICAO_INCREMENTAL),
             usuario_executor=job_data.get(JobFields.USUARIO_EXECUTOR),
             blob_filename=blob_filename
         )
-
-        for pr_summary in summary_list:
-            log_custom_data(
-                job_id=job_id,
-                projeto=job_data.get(JobFields.PROJETO),
-                data_hora=time.strftime('%Y-%m-%d %H:%M:%S'),
-                status=JobStatus.COMPLETED,
-                tipo_repositorio=job_data.get(JobFields.REPOSITORY_TYPE),
-                nome_repositorio=job_data.get(JobFields.REPO_NAME),
-                tipo_analise=job_data.get(JobFields.ORIGINAL_ANALYSIS_TYPE),
-                branch_name=job_data.get(JobFields.BRANCH_NAME_MODERNIZADO),
-                analysis_name=job_data.get(JobFields.ANALYSIS_NAME),
-                arquivos_especificos=job_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
-                pr_url=pr_summary.pull_request_url,
-                arquivos_modificados=pr_summary.arquivos_modificados,
-                retornar_lista_arquivos=job_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS),
-                modo_adicao_incremental=job_data.get(JobFields.MODO_ADICAO_INCREMENTAL),
-                usuario_executor=job_data.get(JobFields.USUARIO_EXECUTOR),
-                blob_filename=blob_filename
-            )
-        return FinalStatusResponse(
-            job_id=job_id, 
-            status=JobStatus.COMPLETED, 
-            summary=summary_list,
-            diagnostic_logs=logs,
-            report_blob_url=blob_url
-        )
+    response = FinalStatusResponse(
+        job_id=job_id, 
+        status=JobStatus.COMPLETED, 
+        summary=summary_list,
+        diagnostic_logs=logs,
+        report_blob_url=final_blob_url
+        # NÃO incluir analysis_report aqui (modo normal)
+    )
+    print(f"[{job_id}] [_build_completed_response] MODO NORMAL - Resposta construída com {len(summary_list)} PRs")
+    return response
 
 app = FastAPI(
     title="MCP Server - Multi-Agent Code Platform",
@@ -523,17 +537,20 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
     _validate_job_exists(job, job_id)
 
     status = job.get(JobFields.STATUS)
-    blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
+    job_data = job.get(JobFields.DATA, {})
+    blob_url = job_data.get(JobFields.REPORT_BLOB_URL)
+    gerar_relatorio_apenas = job_data.get(JobFields.GERAR_RELATORIO_APENAS, False)
+    analysis_report = job_data.get(JobFields.ANALYSIS_REPORT, None)
+
+    print(f"[{job_id}] [get_status] status: {status}")
+    print(f"[{job_id}] [get_status] gerar_relatorio_apenas: {gerar_relatorio_apenas}")
+    print(f"[{job_id}] [get_status] Tamanho analysis_report: {len(analysis_report) if analysis_report else 0}")
+    print(f"[{job_id}] [get_status] report_blob_url: {blob_url}")
 
     try:
         if status == JobStatus.COMPLETED:
-            job_data = job.get(JobFields.DATA, {})
-            if job_data.get(JobFields.GERAR_RELATORIO_APENAS) is True:
-                print(f"[{job_id}] Resposta para modo report_only - Blob URL: {blob_url}")
-                print(f"[{job_id}] Tamanho do relatório: {len(job_data.get(JobFields.ANALYSIS_REPORT, ''))} chars")
             return _build_completed_response(job_id, job, blob_url)
         elif status == JobStatus.FAILED:
-            job_data = job.get(JobFields.DATA, {})
             logs = job_data.get(JobFields.DIAGNOSTIC_LOGS)
             blob_filename = _extract_blob_filename(job_data.get(JobFields.REPORT_BLOB_URL))
             log_custom_data(

--- a/services/report_handler.py
+++ b/services/report_handler.py
@@ -36,7 +36,7 @@ class ReportHandler:
             raise ValueError(f"[{job_id}] ERRO: Blob Storage não retornou URL válida")
         job_info['data']['report_blob_url'] = url
         job_info['data']['analysis_report'] = report_text
-        print(f"[{job_id}] Relatório salvo no Blob Storage: {url}")
+        print(f"[{job_id}] Relatório salvo no Blob Storage: {url} (tamanho: {len(report_text)} chars)")
         return url
 
     def handle_report_only_mode(self, job_id, job_info, step_result):

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -110,10 +110,12 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     print(f"[{job_id}] Relatório salvo com sucesso: {job_info['data']['report_blob_url']}")
                     if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
                         print(f"[{job_id}] [DEBUG] Finalizando workflow imediatamente após salvar relatório pois gerar_relatorio_apenas=True")
+                        print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                         self.job_handler.update_job_status(job_id, 'completed')
+                        print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
+                        print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
                         return
                 strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-
 
                 if strategy.should_finalize_workflow(job_info, current_step_index):
                     print(f"[{job_id}] Workflow finalizado no step {current_step_index} (gerar_relatorio_apenas=True)")


### PR DESCRIPTION
Este PR corrige o comportamento do modo gerar_relatorio_apenas=True. Agora, ao ativar esta flag, o sistema executa apenas o step 0 (geração/leitura do relatório), salva o relatório no Blob Storage, atualiza o status para 'completed' e retorna o relatório e a URL ao usuário. O erro de variável não definida foi eliminado e o fluxo está rastreável via logs detalhados. O modo normal (aprovação do relatório antes de seguir) permanece inalterado.