### PR TITLE
Ajuste do fluxo de relatório para gerar_relatorio_apenas=True

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -44,38 +44,40 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
 
     def execute_workflow(self, job_id: str, start_from_step: int = 0) -> None:
         job_info = self.job_handler.get_job_info(job_id)
-
         workflow = self.workflow_registry.get(job_info['data']['original_analysis_type'])
         if not workflow:
             raise ValueError("Workflow não encontrado.")
-
         try:
             repository_type = job_info['data']['repository_type']
             repo_name = job_info['data']['repo_name']
             repository_provider = get_repository_provider_explicit(repository_type)
             repo_reader = ReaderGeral(repository_provider=repository_provider)
-
             previous_step_result = self.job_handler.get_step_result(job_info, start_from_step)
             steps_to_run = workflow.get('steps', [])[start_from_step:]
-
             for i, step in enumerate(steps_to_run):
                 current_step_index = start_from_step + i
                 print(f"[{job_id}] Executando step {current_step_index}/{len(workflow.get('steps', []))-1}")
                 print(f"[{job_id}] gerar_relatorio_apenas: {job_info.get('data', {}).get(JobFields.GERAR_RELATORIO_APENAS)}")
-
                 print(f"[{job_id}] Status atual: {step['status_update']}")
                 self.job_handler.update_job_status(job_id, step['status_update'])
-
                 report_generated_by_agent = False
-
                 if current_step_index == 0:
                     existing_report_result = self.report_handler.try_read_existing_report(job_id, job_info, current_step_index)
                     existing_report_text = self.report_handler.validate_and_parse_blob_report(existing_report_result, job_id)
                     if existing_report_text:
+                        print(f"[{job_id}] [DEBUG] Relatório lido do blob storage, tamanho: {len(existing_report_text)}")
                         job_info['data']['analysis_report'] = existing_report_text
                         report_data = {'relatorio': existing_report_text}
                         self.job_handler.save_step_result(job_info, current_step_index, report_data)
                         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
+                        if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
+                            print(f"[{job_id}] [DEBUG] Validando relatório antes de finalizar workflow (modo report_only, lido do blob)")
+                            analysis_report = job_info['data'].get('analysis_report')
+                            if not analysis_report or len(analysis_report.strip()) < 100:
+                                raise ValueError(f"[{job_id}] ERRO CRÍTICO: Tentativa de finalizar workflow no modo report_only sem relatório válido. analysis_report={'presente' if analysis_report else 'ausente'}, tamanho={len(analysis_report) if analysis_report else 0}")
+                            self.job_handler.update_job_status(job_id, 'completed')
+                            print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only, lido do blob)")
+                            return
                         if strategy.should_pause_for_approval(job_info, step):
                             self.handle_approval_step(job_id, job_info, current_step_index, report_data)
                             return
@@ -93,12 +95,10 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     else:
                         print(f"[{job_id}] Relatório inválido ou vazio lido do Blob. Gerando novo relatório.")
                         report_generated_by_agent = True
-
                 step_result = self._execute_step_with_strategy(job_id, job_info, step, current_step_index, 
                                                              previous_step_result, repo_reader, i, start_from_step)
                 self.job_handler.save_step_result(job_info, current_step_index, step_result)
                 previous_step_result = step_result
-
                 if current_step_index == 0 and report_generated_by_agent:
                     print(f"[{job_id}] Salvando relatório gerado pelo agente no Blob Storage (step 0)")
                     sucesso_salvar = self._save_generated_report(job_id, job_info, step_result, current_step_index)
@@ -108,7 +108,14 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                         raise ValueError(f"[{job_id}] ERRO CRÍTICO: Relatório não foi salvo no Blob Storage")
                     print(f"[{job_id}] Relatório salvo com sucesso: {job_info['data']['report_blob_url']}")
                     strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-                    # ORDEM CORRIGIDA: primeiro pausa para aprovação, depois finaliza workflow
+                    if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
+                        print(f"[{job_id}] [DEBUG] Validando relatório antes de finalizar workflow (modo report_only, gerado pelo agente)")
+                        analysis_report = job_info['data'].get('analysis_report')
+                        if not analysis_report or len(analysis_report.strip()) < 100:
+                            raise ValueError(f"[{job_id}] ERRO CRÍTICO: Tentativa de finalizar workflow no modo report_only sem relatório válido. analysis_report={'presente' if analysis_report else 'ausente'}, tamanho={len(analysis_report) if analysis_report else 0}")
+                        self.job_handler.update_job_status(job_id, 'completed')
+                        print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only, gerado pelo agente)")
+                        return
                     if strategy.should_pause_for_approval(job_info, step):
                         self.handle_approval_step(job_id, job_info, current_step_index, step_result)
                         return
@@ -120,36 +127,34 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                         print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
                         return
                 strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-
                 if strategy.should_finalize_workflow(job_info, current_step_index):
                     print(f"[{job_id}] Workflow finalizado no step {current_step_index} (gerar_relatorio_apenas=True)")
                     print(f"[{job_id}] Relatório disponível: {bool(job_info['data'].get('analysis_report'))}")
                     print(f"[{job_id}] Blob URL: {job_info['data'].get('report_blob_url')}")
                     print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
+                    # Validação final ANTES de finalizar
+                    analysis_report = job_info['data'].get('analysis_report')
+                    if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
+                        if not analysis_report or len(analysis_report.strip()) < 100:
+                            raise ValueError(f"[{job_id}] ERRO CRÍTICO: Tentativa de finalizar workflow no modo report_only sem relatório válido. analysis_report={'presente' if analysis_report else 'ausente'}, tamanho={len(analysis_report) if analysis_report else 0}")
                     self.job_handler.update_job_status(job_id, 'completed')
                     print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                     print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
                     return
-
                 if strategy.should_pause_for_approval(job_info, step):
                     self.handle_approval_step(job_id, job_info, current_step_index, step_result)
                     return
-
             self._finalize_workflow(job_id, job_info, workflow, previous_step_result, repository_type, repo_name)
-
         except Exception as e:
             self.job_handler.handle_job_error(job_id, e, 'workflow')
 
     def _execute_step_with_strategy(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                                    current_step_index: int, previous_step_result: Dict[str, Any], 
                                    repo_reader: ReaderGeral, step_iteration: int, start_from_step: int) -> Dict[str, Any]:
-
         model_para_etapa = step.get('model_name', job_info.get('data', {}).get('model_name'))
         llm_provider = LLMProviderFactory.create_provider(model_para_etapa, self.rag_retriever)
         agent_params = step.get('params', {}).copy()
-
         is_comparador_agent = step.get('agent') == 'comparador'
-
         if is_comparador_agent:
             agent_params.update({
                 'repo_name_modernizado': job_info['data'].get('repo_name_modernizado'),
@@ -164,10 +169,8 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 'repositorio': repo_name,
                 'nome_branch': branch_name
             })
-
         retornar_lista_arquivos = job_info.get('data', {}).get('retornar_lista_arquivos', False)
         print(f"[{job_id}] Flag retornar_lista_arquivos: {retornar_lista_arquivos}")
-
         agent_params.update({
             'usar_rag': job_info.get("data", {}).get("usar_rag", False), 
             'model_name': model_para_etapa,
@@ -176,9 +179,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             'modo_adicao_incremental': job_info.get('data', {}).get('modo_adicao_incremental', False),
             'usuario_executor': job_info.get('data', {}).get('usuario_executor')
         })
-
         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
-
         return strategy.execute_step(
             job_id, job_info, step, current_step_index, 
             previous_step_result, repo_reader, llm_provider, agent_params
@@ -194,30 +195,21 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
 
     def _finalize_workflow(self, job_id: str, job_info: Dict[str, Any], workflow: Dict[str, Any], 
                           final_result: Dict[str, Any], repository_type: str, repo_name: str) -> None:
-
         resultado_agrupamento, resultado_refatoracao = self.data_formatter.extract_workflow_results(
             job_info, workflow, final_result
         )
-
         job_info['data']['diagnostic_logs'] = {
             "penultimate_result": resultado_refatoracao,
             "final_result": resultado_agrupamento
         }
-
         self.job_handler.update_job_status(job_id, 'populating_data')
-
         dados_preenchidos = self.data_formatter.populate_changeset_data(
             resultado_agrupamento, resultado_refatoracao
         )
-
         dados_finais_formatados = self.data_formatter.format_final_data(dados_preenchidos)
-
         self.job_handler.update_job_status(job_id, 'committing_to_github')
-
         self.commit_handler.execute_commits(job_id, job_info, dados_finais_formatados, repository_type, repo_name)
-
         print(f"[{job_id}] DIAGNÓSTICO - Atualizando job após commits com commit_details: {job_info['data'].get('commit_details', [])}")
         self.job_handler.update_job(job_id, job_info)
         print(f"[{job_id}] DIAGNÓSTICO - Job atualizado no job store")
-
         self.job_handler.update_job_status(job_id, 'completed')


### PR DESCRIPTION
Corrige o comportamento do workflow quando gerar_relatorio_apenas=True, garantindo que o relatório seja lido do blob storage ou gerado e salvo, e sempre retornado para o usuário, com status COMPLETED logo após o step 0. O relatório é salvo em job_info['data']['analysis_report'] e job_info['data']['report_blob_url'], e o job é finalizado imediatamente. O código foi refatorado para garantir que o relatório seja retornado corretamente, tanto no caso de leitura do blob quanto de geração nova.