### PR TITLE
Correção do fluxo de persistência e retorno do relatório no modo gerar_relatorio_apenas

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -102,7 +102,7 @@ def _validate_and_normalize_gitlab_repo_name(repo_name: str) -> str:
 def _normalize_repo_name_by_type(repo_name: str, repository_type: str) -> str:
     if repository_type == 'gitlab':
         normalized = _validate_and_normalize_gitlab_repo_name(repo_name)
-        print(f"GitLab - Repo original: '{repo_name}', normalizado: '{normalized}'")
+        print(f"GitLab - Repo original: '{repo_name}', normalizado: {normalized}")
         return normalized
     return repo_name
 
@@ -159,10 +159,7 @@ def _validate_analysis_exists(analysis_name: str, analysis_service) -> str:
 def _get_report_from_job(job: dict, job_id: str) -> str:
     report = job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT)
     if not report:
-        if job_id:
-            raise HTTPException(status_code=404, detail=f"Relatório não encontrado para este job. Status: {job.get(JobFields.STATUS)}")
-        else:
-            raise HTTPException(status_code=404, detail="Relatório não encontrado no job original")
+        raise HTTPException(status_code=404, detail=f"Relatório não encontrado para o job {job_id}. Status do job: {job.get('status')}. Verifique se o job foi executado com 'gerar_relatorio_apenas=True' ou se o relatório foi gerado com sucesso.")
     return report
 
 def _create_derived_job_data(original_job: dict, analysis_name: str, normalized_repo_name: str, report: str) -> dict:
@@ -216,7 +213,6 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
     print(f"[{job_id}] [_build_completed_response] report_blob_url (job_data): {job_data.get(JobFields.REPORT_BLOB_URL)}")
     print(f"[{job_id}] [_build_completed_response] Tamanho analysis_report: {len(job_data.get(JobFields.ANALYSIS_REPORT, ''))} chars")
 
-    # PRIORIDADE ABSOLUTA: Modo report_only
     if gerar_relatorio_apenas is True:
         analysis_report = job_data.get(JobFields.ANALYSIS_REPORT)
         final_blob_url = blob_url or job_data.get(JobFields.REPORT_BLOB_URL)
@@ -226,7 +222,7 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
         print(f"[{job_id}] [_build_completed_response] final_blob_url: {final_blob_url}")
 
         if not analysis_report:
-            print(f"[{job_id}] [_build_completed_response] ERRO: analysis_report está vazio no modo report_only!")
+            raise HTTPException(status_code=500, detail=f"[{job_id}] ERRO INTERNO: Relatório ausente no modo report_only após finalização do workflow.")
         if not final_blob_url:
             print(f"[{job_id}] [_build_completed_response] AVISO: report_blob_url está vazio no modo report_only!")
 
@@ -236,10 +232,9 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
             analysis_report=analysis_report,
             report_blob_url=final_blob_url
         )
-        print(f"[{job_id}] [_build_completed_response] MODO REPORT_ONLY - Resposta construída com sucesso")
+        print(f"[{job_id}] [_build_completed_response] MODO REPORT_ONLY - Resposta FINAL: analysis_report presente: {bool(response.analysis_report)}, tamanho: {len(response.analysis_report) if response.analysis_report else 0}, report_blob_url: {response.report_blob_url}")
         return response
 
-    # Modo normal: extração de PRs e summary
     print(f"[{job_id}] [_build_completed_response] MODO NORMAL - Extraindo PRs")
     summary_list = []
     commit_details = job_data.get(JobFields.COMMIT_DETAILS, [])
@@ -380,7 +375,6 @@ def _build_completed_response(job_id: str, job: dict, blob_url: Optional[str]) -
         summary=summary_list,
         diagnostic_logs=logs,
         report_blob_url=final_blob_url,
-        # analysis_report NÃO é incluído aqui no modo normal, mas está presente no modo report_only acima.
     )
     print(f"[{job_id}] [_build_completed_response] MODO NORMAL - Resposta construída com {len(summary_list)} PRs")
     return response
@@ -471,6 +465,7 @@ def get_job_report(job_id: str = Path(..., title="O ID do Job para buscar o rela
     job_store = container.get_job_store()
     
     job = job_store.get_job(job_id)
+    print(f"[{job_id}] [get_job_report] Buscando relatório. Job status: {job.get('status')}, gerar_relatorio_apenas: {job.get('data', {}).get('gerar_relatorio_apenas')}, analysis_report presente: {bool(job.get('data', {}).get('analysis_report'))}")
     _validate_job_exists(job, job_id)
 
     report = _get_report_from_job(job, job_id)
@@ -546,7 +541,7 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
     print(f"[{job_id}] [get_status] gerar_relatorio_apenas: {gerar_relatorio_apenas}")
     print(f"[{job_id}] [get_status] Tamanho analysis_report: {len(analysis_report) if analysis_report else 0}")
     print(f"[{job_id}] [get_status] report_blob_url: {blob_url}")
-    print(f"[{job_id}] [get_status] ANTES _build_completed_response: gerar_relatorio_apenas={gerar_relatorio_apenas}, analysis_report_size={len(analysis_report) if analysis_report else 0}, blob_url={blob_url}")
+    print(f"[{job_id}] [get_status] CHAMANDO _build_completed_response - gerar_relatorio_apenas: {gerar_relatorio_apenas}, analysis_report presente: {bool(analysis_report)}, tamanho: {len(analysis_report) if analysis_report else 0}, blob_url: {blob_url}")
 
     try:
         if status == JobStatus.COMPLETED:

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -40,6 +40,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             raise ValueError(f"[{job_id}] ERRO CRÍTICO: Relatório não foi salvo no Blob Storage")
         print(f"[{job_id}] Relatório salvo com sucesso: {url}")
         job_info['data']['report_blob_url'] = url
+        self.job_handler.ensure_report_persisted(job_id, job_info)
         return True
 
     def execute_workflow(self, job_id: str, start_from_step: int = 0) -> None:
@@ -69,6 +70,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                         job_info['data']['analysis_report'] = existing_report_text
                         report_data = {'relatorio': existing_report_text}
                         self.job_handler.save_step_result(job_info, current_step_index, report_data)
+                        self.job_handler.ensure_report_persisted(job_id, job_info)
                         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
                         if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
                             print(f"[{job_id}] [DEBUG] Validando relatório antes de finalizar workflow (modo report_only, lido do blob)")
@@ -86,6 +88,10 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                             print(f"[{job_id}] Relatório disponível: {bool(job_info['data'].get('analysis_report'))}")
                             print(f"[{job_id}] Blob URL: {job_info['data'].get('report_blob_url')}")
                             print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
+                            analysis_report = job_info['data'].get('analysis_report')
+                            if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
+                                if not analysis_report or len(analysis_report.strip()) < 100:
+                                    raise ValueError(f"[{job_id}] ERRO CRÍTICO: Tentativa de finalizar workflow no modo report_only sem relatório válido. analysis_report={'presente' if analysis_report else 'ausente'}, tamanho={len(analysis_report) if analysis_report else 0}")
                             self.job_handler.update_job_status(job_id, 'completed')
                             print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                             print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
@@ -122,6 +128,9 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
                         print(f"[{job_id}] [DEBUG] Finalizando workflow imediatamente após salvar relatório pois gerar_relatorio_apenas=True")
                         print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
+                        analysis_report = job_info['data'].get('analysis_report')
+                        if not analysis_report or len(analysis_report.strip()) < 100:
+                            raise ValueError(f"[{job_id}] ERRO CRÍTICO: Tentativa de finalizar workflow no modo report_only sem relatório válido. analysis_report={'presente' if analysis_report else 'ausente'}, tamanho={len(analysis_report) if analysis_report else 0}")
                         self.job_handler.update_job_status(job_id, 'completed')
                         print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                         print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
@@ -132,7 +141,6 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     print(f"[{job_id}] Relatório disponível: {bool(job_info['data'].get('analysis_report'))}")
                     print(f"[{job_id}] Blob URL: {job_info['data'].get('report_blob_url')}")
                     print(f"[{job_id}] [execute_workflow] (ANTES update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
-                    # Validação final ANTES de finalizar
                     analysis_report = job_info['data'].get('analysis_report')
                     if job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS) is True:
                         if not analysis_report or len(analysis_report.strip()) < 100:


### PR DESCRIPTION
Este PR garante que, ao executar workflows com gerar_relatorio_apenas=True, o relatório (seja lido do blob ou gerado pelo agente) é sempre salvo em job['data']['analysis_report'] antes do status ser atualizado para 'completed'. Isso resolve o erro onde o relatório não era retornado ao usuário após a conclusão, mesmo tendo sido salvo no blob. A lógica cobre ambos os casos: gerar_novo_relatorio=True (gera e salva) e gerar_novo_relatorio=False (tenta ler, se não existir gera e salva).