### PR TITLE
Propagação do job_id até o agente_processador para logs no Application Insights

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -187,6 +187,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             'modo_adicao_incremental': job_info.get('data', {}).get('modo_adicao_incremental', False),
             'usuario_executor': job_info.get('data', {}).get('usuario_executor')
         })
+        agent_params['job_id'] = job_id
         strategy = StepStrategyFactory.create_strategy(step, self.job_handler)
         return strategy.execute_step(
             job_id, job_info, step, current_step_index, 


### PR DESCRIPTION
Inclui o parâmetro job_id nos agent_params enviados ao agente_processador.py, garantindo que o identificador do job seja corretamente salvo e logado no Application Insights. Essa alteração é fundamental para rastreabilidade e auditoria dos jobs processados pelo sistema.