### PR TITLE
Adicionada análise de impacto pré-execução e controle de pausa para tarefas de alto impacto no método execute_incremental_changes.

### DIFF
--- a/services/incremental_orchestrator_service.py
+++ b/services/incremental_orchestrator_service.py
@@ -25,34 +25,34 @@ class IncrementalOrchestratorService:
         all_tasks = {task.id: task for task in tasks}
         completed_tasks = {}
         failed_tasks = {}
-        high_impact_tasks = []
         checkpoint_key = f"checkpoint:{job_id}"
+        high_impact_tasks = []
+        execution_order_rationale = {}
         if completed_task_ids:
             for tid in completed_task_ids:
                 result_data = self.context_cache.get_cached_task_context(tid)
                 if result_data:
                     completed_tasks[tid] = result_data
         for level in levels:
-            sorted_level = []
-            for tid in level:
-                task = all_tasks[tid]
-                impacted_files = self.dependency_analyzer.analyze_task_impact(task, codebase)
+            sorted_tasks = list(level)
+            for tid in sorted_tasks:
+                impacted_files = self.dependency_analyzer.analyze_task_impact(all_tasks[tid], codebase)
                 if len(impacted_files) > 10:
-                    print(f"[{job_id}] WARNING: Tarefa {task.id} pode impactar {len(impacted_files)} arquivos. Considere revisão manual.")
-                    high_impact_tasks.append(task.id)
+                    print(f"[{job_id}] WARNING: Tarefa {tid} pode impactar {len(impacted_files)} arquivos. Considere revisão manual.")
+                    high_impact_tasks.append(tid)
                     if pause_on_high_impact:
-                        print(f"[{job_id}] Execução pausada antes da tarefa de alto impacto {task.id} aguardando aprovação manual.")
+                        print(f"[{job_id}] Execução pausada antes da tarefa de alto impacto {tid}.")
                         return {
                             "completed_tasks": list(completed_tasks.keys()),
                             "failed_tasks": list(failed_tasks.keys()),
                             "commits": [],
                             "resumable": True,
-                            "high_impact_tasks": high_impact_tasks
+                            "high_impact_tasks": high_impact_tasks,
+                            "execution_order_rationale": execution_order_rationale
                         }
-                sorted_level.append(tid)
             futures = {}
             with ThreadPoolExecutor(max_workers=3) as executor:
-                for tid in sorted_level:
+                for tid in sorted_tasks:
                     if tid in completed_tasks or tid in failed_tasks:
                         continue
                     task = all_tasks[tid]
@@ -88,7 +88,8 @@ class IncrementalOrchestratorService:
             "failed_tasks": list(failed_tasks.keys()),
             "commits": [],
             "resumable": resumable,
-            "high_impact_tasks": high_impact_tasks
+            "high_impact_tasks": high_impact_tasks,
+            "execution_order_rationale": execution_order_rationale
         }
         return result_summary
 

--- a/services/incremental_orchestrator_service.py
+++ b/services/incremental_orchestrator_service.py
@@ -15,7 +15,7 @@ class IncrementalOrchestratorService:
         self.committer = committer
         self.redis_client = redis_client
 
-    def execute_incremental_changes(self, job_id: str, report_text: str, repo_name: str, branch_name: str, repository_type: str, completed_task_ids: Optional[List[str]] = None) -> Dict[str, Any]:
+    def execute_incremental_changes(self, job_id: str, report_text: str, repo_name: str, branch_name: str, repository_type: str, completed_task_ids: Optional[List[str]] = None, pause_on_high_impact: bool = False) -> Dict[str, Any]:
         tasks = self.report_parser.parse_implementation_plan(report_text)
         codebase = self.repository_reader.read_repository(repo_name, branch_name, repository_type)
         for file_path, content in codebase.items():
@@ -25,6 +25,7 @@ class IncrementalOrchestratorService:
         all_tasks = {task.id: task for task in tasks}
         completed_tasks = {}
         failed_tasks = {}
+        high_impact_tasks = []
         checkpoint_key = f"checkpoint:{job_id}"
         if completed_task_ids:
             for tid in completed_task_ids:
@@ -32,9 +33,26 @@ class IncrementalOrchestratorService:
                 if result_data:
                     completed_tasks[tid] = result_data
         for level in levels:
+            sorted_level = []
+            for tid in level:
+                task = all_tasks[tid]
+                impacted_files = self.dependency_analyzer.analyze_task_impact(task, codebase)
+                if len(impacted_files) > 10:
+                    print(f"[{job_id}] WARNING: Tarefa {task.id} pode impactar {len(impacted_files)} arquivos. Considere revisão manual.")
+                    high_impact_tasks.append(task.id)
+                    if pause_on_high_impact:
+                        print(f"[{job_id}] Execução pausada antes da tarefa de alto impacto {task.id} aguardando aprovação manual.")
+                        return {
+                            "completed_tasks": list(completed_tasks.keys()),
+                            "failed_tasks": list(failed_tasks.keys()),
+                            "commits": [],
+                            "resumable": True,
+                            "high_impact_tasks": high_impact_tasks
+                        }
+                sorted_level.append(tid)
             futures = {}
             with ThreadPoolExecutor(max_workers=3) as executor:
-                for tid in level:
+                for tid in sorted_level:
                     if tid in completed_tasks or tid in failed_tasks:
                         continue
                     task = all_tasks[tid]
@@ -69,7 +87,8 @@ class IncrementalOrchestratorService:
             "completed_tasks": list(completed_tasks.keys()),
             "failed_tasks": list(failed_tasks.keys()),
             "commits": [],
-            "resumable": resumable
+            "resumable": resumable,
+            "high_impact_tasks": high_impact_tasks
         }
         return result_summary
 


### PR DESCRIPTION
O método execute_incremental_changes agora utiliza dependency_analyzer.analyze_task_impact para identificar arquivos impactados antes da execução de cada tarefa. Se o número de arquivos impactados for maior que 10, a tarefa é marcada como de alto impacto, um aviso é logado, e se a flag pause_on_high_impact estiver ativa, a execução é pausada aguardando aprovação manual. O campo high_impact_tasks foi adicionado ao resultado final para reportar essas tarefas.