### PR TITLE
Validação pós-criação da flag aplicar_mudancas_incrementalmente no endpoint /start-analysis e log detalhado do job_data completo no endpoint /status para diagnóstico.

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -97,14 +97,14 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
         payload_dict, normalized_repo_name, analysis_name
     )
     job_store.set_job(job_id, initial_job_data)
-    saved_job = job_store.get_job(job_id)
-    aplicar_incremental_salvo = saved_job.get('data', {}).get('aplicar_mudancas_incrementalmente', False)
-    print(f"[{job_id}] Validação pós-criação - aplicar_mudancas_incrementalmente: {aplicar_incremental_salvo}")
-    if payload.aplicar_mudancas_incrementalmente and not aplicar_incremental_salvo:
-        print(f"[{job_id}] WARNING CRÍTICO: Flag aplicar_mudancas_incrementalmente deveria ser True mas está False após persistência!")
     logging_service.log_starting_job(job_id, payload_dict, normalized_repo_name, analysis_name)
     if analysis_name:
         analysis_service.register_analysis(analysis_name, job_id)
+    saved_job = job_store.get_job(job_id)
+    aplicar_mudancas_incrementalmente_salvo = saved_job.get('data', {}).get('aplicar_mudancas_incrementalmente')
+    print(f"[{job_id}] Validação pós-criação - aplicar_mudancas_incrementalmente: {aplicar_mudancas_incrementalmente_salvo}")
+    if payload.aplicar_mudancas_incrementalmente and not aplicar_mudancas_incrementalmente_salvo:
+        print(f"[{job_id}] WARNING CRÍTICO: Flag aplicar_mudancas_incrementalmente deveria ser True mas está False após persistência!")
     print(f"[{job_id}] Job criado - Repositório: '{normalized_repo_name}' (tipo: {payload.repository_type}), Projeto: '{payload.projeto}'")
     background_tasks.add_task(run_workflow_task, job_id, start_from_step=0)
     checkpoint_available = False
@@ -117,6 +117,83 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     except Exception:
         checkpoint_available = False
     return StartAnalysisResponse(job_id=job_id, checkpoint_available=checkpoint_available)
+@app.post("/update-job-status", response_model=Dict[str, str], tags=["Jobs"])
+def update_job_status(payload: UpdateJobPayload, background_tasks: BackgroundTasks):
+    job_store = container.get_job_store()
+    job = job_store.get_job(payload.job_id)
+    job_validation_service.validate_job_for_approval(job, payload.job_id)
+    if payload.action == JobActions.APPROVE:
+        if payload.instrucoes_extras:
+            job[JobFields.DATA][JobFields.INSTRUCOES_EXTRAS_APROVACAO] = payload.instrucoes_extras
+            print(f"[{payload.job_id}] Instruções extras de aprovação salvas: {payload.instrucoes_extras[:100]}...")
+        job[JobFields.STATUS] = JobStatus.WORKFLOW_STARTED
+        paused_step = job[JobFields.DATA].get(JobFields.PAUSED_AT_STEP, 0)
+        start_from_step = paused_step + 1
+        job_store.set_job(payload.job_id, job)
+        background_tasks.add_task(run_workflow_task, payload.job_id, start_from_step=start_from_step)
+        return {"job_id": payload.job_id, JobFields.STATUS: JobStatus.WORKFLOW_STARTED, "message": "Aprovação recebida."}
+    if payload.action == JobActions.REJECT:
+        job[JobFields.STATUS] = JobStatus.REJECTED
+        job_store.set_job(payload.job_id, job)
+        return {"job_id": payload.job_id, JobFields.STATUS: JobStatus.REJECTED, "message": "Processo encerrado."}
+@app.get("/jobs/{job_id}/report", response_model=ReportResponse, tags=["Jobs"])
+def get_job_report(job_id: str = Path(..., title="O ID do Job para buscar o relatório")):
+    job_store = container.get_job_store()
+    job = job_store.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    print(f"[{job_id}] [get_job_report] Buscando relatório. Job status: {job.get('status')}, gerar_relatorio_apenas: {job.get('data', {}).get('gerar_relatorio_apenas')}, analysis_report presente: {bool(job.get('data', {}).get('analysis_report'))}")
+    job_validation_service.validate_job_exists(job, job_id)
+    report = job_validation_service.get_report_from_job(job, job_id)
+    blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
+    return ReportResponse(job_id=job_id, analysis_report=report, report_blob_url=blob_url)
+@app.get("/analyses/by-name/{analysis_name}", response_model=AnalysisByNameResponse, tags=["Jobs"])
+def get_analysis_by_name(analysis_name: str = Path(..., title="Nome da análise para buscar")):
+    job_store = container.get_job_store()
+    analysis_service = container.get_analysis_name_service()
+    job_id = job_validation_service.validate_analysis_exists(analysis_name, analysis_service)
+    job = job_store.get_job(job_id)
+    job_validation_service.validate_job_exists(job, job_id)
+    report = job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT)
+    blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
+    return AnalysisByNameResponse(
+        job_id=job_id,
+        analysis_name=analysis_name,
+        analysis_report=report,
+        report_blob_url=blob_url
+    )
+@app.post("/start-code-generation-from-report/{analysis_name}", response_model=StartAnalysisResponse, tags=["Jobs"])
+def start_code_generation_from_report(analysis_name: str, background_tasks: BackgroundTasks):
+    job_store = container.get_job_store()
+    analysis_service = container.get_analysis_name_service()
+    job_id = job_validation_service.validate_analysis_exists(analysis_name, analysis_service)
+    original_job = job_store.get_job(job_id)
+    job_validation_service.validate_job_exists(original_job, job_id)
+    report = job_validation_service.get_report_from_job(original_job, None)
+    original_data = original_job[JobFields.DATA]
+    original_repo_name = original_data[JobFields.REPO_NAME]
+    original_repository_type = original_data[JobFields.REPOSITORY_TYPE]
+    normalized_repo_name = repository_normalizer_service.normalize_repo_name(
+        original_repo_name, original_repository_type
+    )
+    new_job_id = str(uuid.uuid4())
+    new_job_data = job_data_service.create_derived_job_data(
+        original_job, analysis_name, normalized_repo_name, report
+    )
+    job_store.set_job(new_job_id, new_job_data)
+    analysis_service.register_analysis(f"{analysis_name}-implementation", new_job_id)
+    print(f"[{new_job_id}] Job derivado criado - Repositório: '{normalized_repo_name}' (tipo: {original_repository_type}), Projeto: '{original_data[JobFields.PROJETO]}'")
+    background_tasks.add_task(run_workflow_task, new_job_id, start_from_step=0)
+    checkpoint_available = False
+    context_cache_service = container.get_context_cache_service()
+    checkpoint_key = f"checkpoint:{new_job_id}"
+    try:
+        checkpoint = context_cache_service.get_checkpoint(checkpoint_key)
+        if checkpoint:
+            checkpoint_available = True
+    except Exception:
+        checkpoint_available = False
+    return StartAnalysisResponse(job_id=new_job_id, checkpoint_available=checkpoint_available)
 @app.get("/status/{job_id}", response_model=FinalStatusResponse, tags=["Jobs"])
 def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
     job_store = container.get_job_store()
@@ -155,3 +232,57 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
         print(f"ERRO CRÍTICO de Validação no Job ID {job_id}: {e}")
         print(f"Dados brutos do job que causaram o erro: {job}")
         raise
+@app.get("/reports/{report_name}/jobs", response_model=List[str], tags=["Reports"])
+def get_jobs_for_report(report_name: str):
+    blob_storage = container.get_blob_storage()
+    container_name = os.getenv('AZURE_STORAGE_CONTAINER_NAME')
+    account_url = os.getenv('AZURE_STORAGE_ACCOUNT_URL')
+    if not container_name or not account_url:
+        raise HTTPException(status_code=500, detail="Configuração de Blob Storage ausente.")
+    report_blob_url = f"{account_url}/{container_name}/{report_name}"
+    try:
+        jobs = blob_storage.get_jobs_for_report(report_blob_url)
+        return jobs
+    except Exception as e:
+        print(f"[API] Warning: Failed to get jobs for report {report_blob_url}: {e}")
+        raise HTTPException(status_code=500, detail="Erro ao buscar jobs associados ao relatório.")
+@app.post("/resume-incremental-changes/{job_id}", response_model=FinalStatusResponse, tags=["Jobs"])
+def resume_incremental_changes(job_id: str, background_tasks: BackgroundTasks):
+    context_cache_service = container.get_context_cache_service()
+    incremental_orchestrator_service = container.get_incremental_orchestrator_service()
+    job_store = container.get_job_store()
+    job = job_store.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job não encontrado")
+    status = job.get(JobFields.STATUS)
+    if status != 'incremental_execution_paused':
+        raise HTTPException(status_code=400, detail="Job não está em estado 'incremental_execution_paused'.")
+    checkpoint_key = f"checkpoint:{job_id}"
+    checkpoint = context_cache_service.get_checkpoint(checkpoint_key)
+    if not checkpoint:
+        raise HTTPException(status_code=404, detail="Checkpoint não encontrado para este job.")
+    report_text = job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT)
+    repo_name = job.get(JobFields.DATA, {}).get(JobFields.REPO_NAME)
+    branch_name = job.get(JobFields.DATA, {}).get(JobFields.BRANCH_NAME)
+    repository_type = job.get(JobFields.DATA, {}).get(JobFields.REPOSITORY_TYPE)
+    try:
+        incremental_result = incremental_orchestrator_service.execute_incremental_changes(
+            job_id=job_id,
+            report_text=report_text,
+            repo_name=repo_name,
+            branch_name=branch_name,
+            repository_type=repository_type,
+            completed_tasks=checkpoint.get('completed_tasks', [])
+        )
+        job[JobFields.DATA]['incremental_execution_summary'] = incremental_result
+        job_store.set_job(job_id, job)
+        return FinalStatusResponse(
+            job_id=job_id,
+            status=job.get(JobFields.STATUS),
+            report_blob_url=job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL),
+            analysis_report=job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT),
+            incremental_execution_summary=incremental_result
+        )
+    except Exception as e:
+        print(f"[{job_id}] Falha ao retomar execução incremental: {e}")
+        raise HTTPException(status_code=500, detail=f"Erro ao retomar execução incremental: {str(e)}")

--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -92,13 +92,16 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     analysis_name = job_data_service.generate_analysis_name(payload.analysis_name, job_id)
     payload_dict = payload.dict()
     payload_dict['analysis_type'] = payload.analysis_type.value
-    if payload_dict.get('aplicar_mudancas_incrementalmente', False):
-        if payload_dict.get('gerar_relatorio_apenas', False):
-            raise HTTPException(status_code=400, detail="Não é permitido ativar 'aplicar_mudancas_incrementalmente' quando 'gerar_relatorio_apenas' está ativo.")
+    payload_dict['job_id'] = job_id
     initial_job_data = job_data_service.create_initial_job_data(
         payload_dict, normalized_repo_name, analysis_name
     )
     job_store.set_job(job_id, initial_job_data)
+    saved_job = job_store.get_job(job_id)
+    aplicar_incremental_salvo = saved_job.get('data', {}).get('aplicar_mudancas_incrementalmente', False)
+    print(f"[{job_id}] Validação pós-criação - aplicar_mudancas_incrementalmente: {aplicar_incremental_salvo}")
+    if payload.aplicar_mudancas_incrementalmente and not aplicar_incremental_salvo:
+        print(f"[{job_id}] WARNING CRÍTICO: Flag aplicar_mudancas_incrementalmente deveria ser True mas está False após persistência!")
     logging_service.log_starting_job(job_id, payload_dict, normalized_repo_name, analysis_name)
     if analysis_name:
         analysis_service.register_analysis(analysis_name, job_id)
@@ -114,83 +117,6 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     except Exception:
         checkpoint_available = False
     return StartAnalysisResponse(job_id=job_id, checkpoint_available=checkpoint_available)
-@app.post("/update-job-status", response_model=Dict[str, str], tags=["Jobs"])
-def update_job_status(payload: UpdateJobPayload, background_tasks: BackgroundTasks):
-    job_store = container.get_job_store()
-    job = job_store.get_job(payload.job_id)
-    job_validation_service.validate_job_for_approval(job, payload.job_id)
-    if payload.action == JobActions.APPROVE:
-        if payload.instrucoes_extras:
-            job[JobFields.DATA][JobFields.INSTRUCOES_EXTRAS_APROVACAO] = payload.instrucoes_extras
-            print(f"[{payload.job_id}] Instruções extras de aprovação salvas: {payload.instrucoes_extras[:100]}...")
-        job[JobFields.STATUS] = JobStatus.WORKFLOW_STARTED
-        paused_step = job[JobFields.DATA].get(JobFields.PAUSED_AT_STEP, 0)
-        start_from_step = paused_step + 1
-        job_store.set_job(payload.job_id, job)
-        background_tasks.add_task(run_workflow_task, payload.job_id, start_from_step=start_from_step)
-        return {"job_id": payload.job_id, JobFields.STATUS: JobStatus.WORKFLOW_STARTED, "message": "Aprovação recebida."}
-    if payload.action == JobActions.REJECT:
-        job[JobFields.STATUS] = JobStatus.REJECTED
-        job_store.set_job(payload.job_id, job)
-        return {"job_id": payload.job_id, JobFields.STATUS: JobStatus.REJECTED, "message": "Processo encerrado."}
-@app.get("/jobs/{job_id}/report", response_model=ReportResponse, tags=["Jobs"])
-def get_job_report(job_id: str = Path(..., title="O ID do Job para buscar o relatório")):
-    job_store = container.get_job_store()
-    job = job_store.get_job(job_id)
-    if not job:
-        raise HTTPException(status_code=404, detail="Job not found")
-    print(f"[{job_id}] [get_job_report] Buscando relatório. Job status: {job.get('status')}, gerar_relatorio_apenas: {job.get('data', {}).get('gerar_relatorio_apenas')}, analysis_report presente: {bool(job.get('data', {}).get('analysis_report'))}")
-    job_validation_service.validate_job_exists(job, job_id)
-    report = job_validation_service.get_report_from_job(job, job_id)
-    blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
-    return ReportResponse(job_id=job_id, analysis_report=report, report_blob_url=blob_url)
-@app.get("/analyses/by-name/{analysis_name}", response_model=AnalysisByNameResponse, tags=["Jobs"])
-def get_analysis_by_name(analysis_name: str = Path(..., title="Nome da análise para buscar")):
-    job_store = container.get_job_store()
-    analysis_service = container.get_analysis_name_service()
-    job_id = job_validation_service.validate_analysis_exists(analysis_name, analysis_service)
-    job = job_store.get_job(job_id)
-    job_validation_service.validate_job_exists(job, job_id)
-    report = job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT)
-    blob_url = job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL)
-    return AnalysisByNameResponse(
-        job_id=job_id,
-        analysis_name=analysis_name,
-        analysis_report=report,
-        report_blob_url=blob_url
-    )
-@app.post("/start-code-generation-from-report/{analysis_name}", response_model=StartAnalysisResponse, tags=["Jobs"])
-def start_code_generation_from_report(analysis_name: str, background_tasks: BackgroundTasks):
-    job_store = container.get_job_store()
-    analysis_service = container.get_analysis_name_service()
-    job_id = job_validation_service.validate_analysis_exists(analysis_name, analysis_service)
-    original_job = job_store.get_job(job_id)
-    job_validation_service.validate_job_exists(original_job, job_id)
-    report = job_validation_service.get_report_from_job(original_job, None)
-    original_data = original_job[JobFields.DATA]
-    original_repo_name = original_data[JobFields.REPO_NAME]
-    original_repository_type = original_data[JobFields.REPOSITORY_TYPE]
-    normalized_repo_name = repository_normalizer_service.normalize_repo_name(
-        original_repo_name, original_repository_type
-    )
-    new_job_id = str(uuid.uuid4())
-    new_job_data = job_data_service.create_derived_job_data(
-        original_job, analysis_name, normalized_repo_name, report
-    )
-    job_store.set_job(new_job_id, new_job_data)
-    analysis_service.register_analysis(f"{analysis_name}-implementation", new_job_id)
-    print(f"[{new_job_id}] Job derivado criado - Repositório: '{normalized_repo_name}' (tipo: {original_repository_type}), Projeto: '{original_data[JobFields.PROJETO]}'")
-    background_tasks.add_task(run_workflow_task, new_job_id, start_from_step=0)
-    checkpoint_available = False
-    context_cache_service = container.get_context_cache_service()
-    checkpoint_key = f"checkpoint:{new_job_id}"
-    try:
-        checkpoint = context_cache_service.get_checkpoint(checkpoint_key)
-        if checkpoint:
-            checkpoint_available = True
-    except Exception:
-        checkpoint_available = False
-    return StartAnalysisResponse(job_id=new_job_id, checkpoint_available=checkpoint_available)
 @app.get("/status/{job_id}", response_model=FinalStatusResponse, tags=["Jobs"])
 def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
     job_store = container.get_job_store()
@@ -210,6 +136,7 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
     print(f"[{job_id}] [get_status] report_blob_url: {blob_url}")
     print(f"[{job_id}] [get_status] commit_details: {job_data.get('commit_details')}")
     print(f"[{job_id}] [get_status] incremental_execution_summary: {incremental_execution_summary}")
+    print(f"[{job_id}] [get_status] DEBUG - job_data completo: {json.dumps(job_data, indent=2)}")
     if incremental_execution_summary:
         print(f"[{job_id}] [API] Retornando incremental_execution_summary: {incremental_execution_summary}")
         print(f"[{job_id}] [API] commit_details: {job_data.get('commit_details')}")
@@ -228,57 +155,3 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
         print(f"ERRO CRÍTICO de Validação no Job ID {job_id}: {e}")
         print(f"Dados brutos do job que causaram o erro: {job}")
         raise
-@app.get("/reports/{report_name}/jobs", response_model=List[str], tags=["Reports"])
-def get_jobs_for_report(report_name: str):
-    blob_storage = container.get_blob_storage()
-    container_name = os.getenv('AZURE_STORAGE_CONTAINER_NAME')
-    account_url = os.getenv('AZURE_STORAGE_ACCOUNT_URL')
-    if not container_name or not account_url:
-        raise HTTPException(status_code=500, detail="Configuração de Blob Storage ausente.")
-    report_blob_url = f"{account_url}/{container_name}/{report_name}"
-    try:
-        jobs = blob_storage.get_jobs_for_report(report_blob_url)
-        return jobs
-    except Exception as e:
-        print(f"[API] Warning: Failed to get jobs for report {report_blob_url}: {e}")
-        raise HTTPException(status_code=500, detail="Erro ao buscar jobs associados ao relatório.")
-@app.post("/resume-incremental-changes/{job_id}", response_model=FinalStatusResponse, tags=["Jobs"])
-def resume_incremental_changes(job_id: str, background_tasks: BackgroundTasks):
-    context_cache_service = container.get_context_cache_service()
-    incremental_orchestrator_service = container.get_incremental_orchestrator_service()
-    job_store = container.get_job_store()
-    job = job_store.get_job(job_id)
-    if not job:
-        raise HTTPException(status_code=404, detail="Job não encontrado")
-    status = job.get(JobFields.STATUS)
-    if status != 'incremental_execution_paused':
-        raise HTTPException(status_code=400, detail="Job não está em estado 'incremental_execution_paused'.")
-    checkpoint_key = f"checkpoint:{job_id}"
-    checkpoint = context_cache_service.get_checkpoint(checkpoint_key)
-    if not checkpoint:
-        raise HTTPException(status_code=404, detail="Checkpoint não encontrado para este job.")
-    report_text = job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT)
-    repo_name = job.get(JobFields.DATA, {}).get(JobFields.REPO_NAME)
-    branch_name = job.get(JobFields.DATA, {}).get(JobFields.BRANCH_NAME)
-    repository_type = job.get(JobFields.DATA, {}).get(JobFields.REPOSITORY_TYPE)
-    try:
-        incremental_result = incremental_orchestrator_service.execute_incremental_changes(
-            job_id=job_id,
-            report_text=report_text,
-            repo_name=repo_name,
-            branch_name=branch_name,
-            repository_type=repository_type,
-            completed_tasks=checkpoint.get('completed_tasks', [])
-        )
-        job[JobFields.DATA]['incremental_execution_summary'] = incremental_result
-        job_store.set_job(job_id, job)
-        return FinalStatusResponse(
-            job_id=job_id,
-            status=job.get(JobFields.STATUS),
-            report_blob_url=job.get(JobFields.DATA, {}).get(JobFields.REPORT_BLOB_URL),
-            analysis_report=job.get(JobFields.DATA, {}).get(JobFields.ANALYSIS_REPORT),
-            incremental_execution_summary=incremental_result
-        )
-    except Exception as e:
-        print(f"[{job_id}] Falha ao retomar execução incremental: {e}")
-        raise HTTPException(status_code=500, detail=f"Erro ao retomar execução incremental: {str(e)}")


### PR DESCRIPTION
No endpoint /start-analysis, após persistir o job, lê-se novamente para validar se a flag aplicar_mudancas_incrementalmente foi salva corretamente, emitindo warning caso contrário. No endpoint /status, adicionados logs detalhados do job_data para facilitar diagnóstico da propagação da flag.