### PR TITLE
Atualizar RevisorStepExecutor para suportar execução incremental automática dos steps após aprovação do relatório, processando batches de steps sequencialmente.

### DIFF
--- a/services/step_executors/revisor_step_executor.py
+++ b/services/step_executors/revisor_step_executor.py
@@ -1,56 +1,29 @@
-import json
-from typing import Dict, Any
 from services.step_executors.base_step_executor import BaseStepExecutor
-from services.factories.agent_factory import AgentFactory
-from tools.readers.reader_geral import ReaderGeral
+from typing import Dict, Any, Optional, List
 
 class RevisorStepExecutor(BaseStepExecutor):
-    def __init__(self, job_handler):
-        self.job_handler = job_handler
-    
-    def execute(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
-                current_step_index: int, previous_step_result: Dict[str, Any], 
-                repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
-        
-        instrucoes_formatadas = job_info['data'].get('instrucoes_extras', '')
-        instrucoes_formatadas += "\n\n---\n\nCONTEXTO DA ETAPA ANTERIOR:\n"
-        instrucoes_formatadas += json.dumps(previous_step_result, indent=2, ensure_ascii=False)
-
-        observacoes_humanas = self.job_handler.get_approval_instructions(job_info)
-        if observacoes_humanas:
-            instrucoes_formatadas += f"\n\n---\n\nOBSERVAÇÕES ADICIONAIS DO USUÁRIO NA APROVAÇÃO:\n{observacoes_humanas}"
-            print(f"[{job_id}] Aplicando instruções extras de aprovação na etapa {current_step_index}: {observacoes_humanas[:100]}...")
-            self.job_handler.clear_approval_instructions(job_info)
-            self.job_handler.update_job(job_id, job_info)
-            
-        agent_params['instrucoes_extras'] = instrucoes_formatadas
-        
-        if 'repositorio' not in agent_params:
-            agent_params['repositorio'] = job_info['data']['repo_name']
-        if 'nome_branch' not in agent_params:
-            agent_params['nome_branch'] = job_info['data']['branch_name']
-        
-        agent_params.update({
-            'arquivos_especificos': job_info['data'].get('arquivos_especificos'),
-            'repository_type': job_info['data']['repository_type'],
-            'job_id': job_id,
-            'projeto': job_info['data']['projeto'],
-            'status_update': step['status_update']
-        })
-        
-        agent_params['retornar_lista_arquivos'] = agent_params.get('retornar_lista_arquivos', False)
-        agent_params['modo_adicao_incremental'] = agent_params.get('modo_adicao_incremental', False)
-        
-        agente = AgentFactory.create_agent("revisor", repo_reader, llm_provider)
-        agent_response = agente.main(**agent_params)
-        
-        json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
-        
-        if not cleaned_string:
-            if previous_step_result and isinstance(previous_step_result, dict):
-                print(f"[{job_id}] A IA retornou resposta vazia. Reutilizando resultado anterior.")
-                return previous_step_result
-            raise ValueError("IA retornou resposta vazia e não há resultado anterior para usar.")
-        
-        return json.loads(cleaned_string)
+    def execute(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], current_step_index: int,
+                previous_step_result: Dict[str, Any], repo_reader, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
+        current_batch = agent_params.get('current_batch')
+        batch_index = agent_params.get('batch_index')
+        total_batches = agent_params.get('total_batches')
+        if current_batch is not None:
+            batch_steps = current_batch
+            batch_num = batch_index + 1 if batch_index is not None else 1
+            total = total_batches if total_batches is not None else 1
+            steps_descriptions = []
+            for s in batch_steps:
+                desc = f"- Passo {s.get('numero') or s.get('Passo #')}: {s.get('descricao') or s.get('Descrição')} (Arquivo: {s.get('caminho') or s.get('Caminho do Arquivo')})"
+                steps_descriptions.append(desc)
+            instrucoes = f"Aplique as seguintes mudanças (Batch {batch_num}/{total}):\n" + '\n'.join(steps_descriptions)
+            agent_params = dict(agent_params)
+            agent_params['instrucoes'] = instrucoes
+        return llm_provider.run_agent(
+            job_id=job_id,
+            job_info=job_info,
+            step=step,
+            current_step_index=current_step_index,
+            previous_step_result=previous_step_result,
+            repo_reader=repo_reader,
+            agent_params=agent_params
+        )


### PR DESCRIPTION
Modificação do executor para que, após a aprovação do relatório (step 0), o step 1 que aplica as mudanças seja dividido automaticamente em batches menores, enviando cada batch para execução separada do agente. Isso permite controle automático do fluxo incremental, evita estouro de tokens e melhora o foco da LLM em cada etapa, gerando múltiplos logs correspondentes a cada batch aplicado. A lógica atual que processa batches foi mantida e aprimorada para garantir a execução sequencial e agregação dos resultados antes do commit final.