### PR TITLE
Adicionado suporte para processar apenas os passos do batch atual, ajustando as instruções enviadas para a LLM para focar somente nesses passos.

### DIFF
--- a/services/step_executors/revisor_step_executor.py
+++ b/services/step_executors/revisor_step_executor.py
@@ -11,7 +11,6 @@ class RevisorStepExecutor(BaseStepExecutor):
     def execute(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                 current_step_index: int, previous_step_result: Dict[str, Any], 
                 repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
-        
         instrucoes_formatadas = job_info['data'].get('instrucoes_extras', '')
         instrucoes_formatadas += "\n\n---\n\nCONTEXTO DA ETAPA ANTERIOR:\n"
         instrucoes_formatadas += json.dumps(previous_step_result, indent=2, ensure_ascii=False)
@@ -22,14 +21,16 @@ class RevisorStepExecutor(BaseStepExecutor):
             print(f"[{job_id}] Aplicando instruções extras de aprovação na etapa {current_step_index}: {observacoes_humanas[:100]}...")
             self.job_handler.clear_approval_instructions(job_info)
             self.job_handler.update_job(job_id, job_info)
-            
+        # Suporte a processamento incremental por batch
+        if 'current_batch' in agent_params and agent_params['current_batch']:
+            batch_steps = agent_params['current_batch']
+            instrucoes_formatadas += "\n\n---\n\nExecutar APENAS os seguintes passos do relatório:\n"
+            instrucoes_formatadas += json.dumps(batch_steps, indent=2, ensure_ascii=False)
         agent_params['instrucoes_extras'] = instrucoes_formatadas
-        
         if 'repositorio' not in agent_params:
             agent_params['repositorio'] = job_info['data']['repo_name']
         if 'nome_branch' not in agent_params:
             agent_params['nome_branch'] = job_info['data']['branch_name']
-        
         agent_params.update({
             'arquivos_especificos': job_info['data'].get('arquivos_especificos'),
             'repository_type': job_info['data']['repository_type'],
@@ -37,20 +38,15 @@ class RevisorStepExecutor(BaseStepExecutor):
             'projeto': job_info['data']['projeto'],
             'status_update': step['status_update']
         })
-        
         agent_params['retornar_lista_arquivos'] = agent_params.get('retornar_lista_arquivos', False)
         agent_params['modo_adicao_incremental'] = agent_params.get('modo_adicao_incremental', False)
-        
         agente = AgentFactory.create_agent("revisor", repo_reader, llm_provider)
         agent_response = agente.main(**agent_params)
-        
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
-        
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):
                 print(f"[{job_id}] A IA retornou resposta vazia. Reutilizando resultado anterior.")
                 return previous_step_result
             raise ValueError("IA retornou resposta vazia e não há resultado anterior para usar.")
-        
         return json.loads(cleaned_string)


### PR DESCRIPTION
O executor RevisorStepExecutor foi modificado para detectar o parâmetro 'current_batch' em agent_params e incluir no campo 'instrucoes_extras' uma seção que instrui a LLM a executar somente os passos daquele batch. Isso permite que a execução incremental processe batches parciais do relatório, evitando sobrecarga e mantendo foco.