### PR TITLE
Modificação do DataFormatter para usar BranchNameSanitizer e gerar nomes de branch válidos e truncados.

### DIFF
--- a/services/data_formatter.py
+++ b/services/data_formatter.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any
+from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
 
 class DataFormatter:
     def __init__(self, changeset_filler=None):
@@ -7,9 +8,12 @@ class DataFormatter:
     def format_incremental_result_for_commit(self, final_result: Dict[str, Any]) -> Dict[str, Any]:
         resumo_geral = final_result.get("resumo_geral", "")
         conjunto_de_mudancas = final_result.get("conjunto_de_mudancas", [])
+        branch_sugerida_raw = resumo_geral[:50] if resumo_geral else "refatoracao-incremental"
+        branch_sugerida = BranchNameSanitizer.sanitize(branch_sugerida_raw)
+        titulo_pr = resumo_geral[:72] if resumo_geral else "Refatoração incremental"
         grupo = {
-            "branch_sugerida": resumo_geral[:50] if resumo_geral else "refatoracao-incremental",
-            "titulo_pr": resumo_geral[:72] if resumo_geral else "Refatoração incremental",
+            "branch_sugerida": branch_sugerida,
+            "titulo_pr": titulo_pr,
             "resumo_do_pr": resumo_geral if resumo_geral else "Refatoração incremental gerada automaticamente.",
             "conjunto_de_mudancas": conjunto_de_mudancas
         }


### PR DESCRIPTION
Alterado o método format_incremental_result_for_commit para sanitizar o nome da branch sugerida usando BranchNameSanitizer, garantindo que o nome da branch gerado seja válido e não cause erros nos sistemas de versionamento (passo 2 do relatório).