### PR TITLE
Sanitização do nome da branch no orquestrador antes de delegar para committers específicos.

### DIFF
--- a/tools/repo_committers/orchestrator.py
+++ b/tools/repo_committers/orchestrator.py
@@ -2,6 +2,7 @@ from typing import Dict, Any, List
 from .github_committer import processar_branch_github
 from .gitlab_committer import processar_branch_gitlab
 from .azure_committer import processar_branch_azure
+from .branch_name_sanitizer import BranchNameSanitizer
 
 def _is_gitlab_project(repo) -> bool:
     return hasattr(repo, 'web_url') or 'gitlab' in str(type(repo)).lower()
@@ -20,10 +21,11 @@ def processar_branch_por_provedor(
     repository_type: str,
     modo_adicao_incremental: bool = False
 ) -> Dict[str, Any]:
+    nome_branch_sanitizado = BranchNameSanitizer.sanitize(nome_branch)
     if repository_type == 'azure':
         print(f"[DEBUG] Usando repository_type explícito: Azure DevOps")
         return processar_branch_azure(
-            repo, nome_branch, branch_de_origem, branch_alvo_do_pr,
+            repo, nome_branch_sanitizado, branch_de_origem, branch_alvo_do_pr,
             mensagem_pr, descricao_pr, conjunto_de_mudancas,
             modo_adicao_incremental=modo_adicao_incremental
         )
@@ -31,14 +33,14 @@ def processar_branch_por_provedor(
     if repository_type == 'gitlab':
         print(f"[DEBUG] Usando repository_type explícito: GitLab")
         return processar_branch_gitlab(
-            repo, nome_branch, branch_de_origem, branch_alvo_do_pr,
+            repo, nome_branch_sanitizado, branch_de_origem, branch_alvo_do_pr,
             mensagem_pr, descricao_pr, conjunto_de_mudancas,
             modo_adicao_incremental=modo_adicao_incremental
         )
     
     print(f"[DEBUG] Usando repository_type explícito: GitHub")
     return processar_branch_github(
-        repo, nome_branch, branch_de_origem, branch_alvo_do_pr,
+        repo, nome_branch_sanitizado, branch_de_origem, branch_alvo_do_pr,
         mensagem_pr, descricao_pr, conjunto_de_mudancas,
         modo_adicao_incremental=modo_adicao_incremental
     )


### PR DESCRIPTION
No orchestrator, sanitiza o nome da branch antes de chamar os committers específicos (GitHub, GitLab, Azure), garantindo que nomes inválidos não sejam propagados e causem erros (passo 4 do relatório).