### PR TITLE
Validação rigorosa do nome da branch no committer Azure para evitar commits com nomes inválidos.

### DIFF
--- a/tools/repo_committers/azure_committer.py
+++ b/tools/repo_committers/azure_committer.py
@@ -4,6 +4,7 @@ import base64
 import traceback
 from tools.repo_committers.base_committer import BaseCommitter
 from tools.conectores.azure_conector import AzureConector
+from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
 
 def processar_branch_azure(
     repo: Dict[str, Any],
@@ -16,9 +17,14 @@ def processar_branch_azure(
     modo_adicao_incremental: bool = False
 ) -> Dict[str, Any]:
     print(f"\n--- Processando Lote Azure DevOps para a Branch: '{nome_branch}' ---")
-    
     resultado_branch = BaseCommitter._inicializar_resultado_branch(nome_branch)
-    
+    # Validação adicional do nome da branch
+    sanitized = BranchNameSanitizer.sanitize(nome_branch)
+    if sanitized != nome_branch or sanitized == "invalid-branch":
+        msg = f"Nome da branch inválido para Azure DevOps: '{nome_branch}' (sanitizado: '{sanitized}')"
+        print(f"[ERRO][AZURE] {msg}")
+        BaseCommitter._finalizar_resultado_erro(resultado_branch, msg)
+        return resultado_branch
     try:
         organization = repo['_organization']
         project = repo['_project']


### PR DESCRIPTION
No Azure committer, valida explicitamente o nome da branch usando BranchNameSanitizer no início do processamento. Se inválido, retorna erro imediatamente sem tentar criar a branch, evitando erros de push (passo 5 do relatório).