### PR TITLE
Validação do nome da branch no committer GitLab para evitar commits com nomes inválidos.

### DIFF
--- a/tools/repo_committers/gitlab_committer.py
+++ b/tools/repo_committers/gitlab_committer.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any, List
 from tools.repo_committers.base_committer import BaseCommitter
+from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
 
 def processar_branch_gitlab(
     repo,
@@ -13,8 +14,13 @@ def processar_branch_gitlab(
 ) -> Dict[str, Any]:
     print(f"\n--- Processando Lote GitLab para a Branch: '{nome_branch}' ---")
     print(f"[DEBUG][GITLAB] Tipo do objeto repo: {type(repo)}")
-    
     resultado_branch = BaseCommitter._inicializar_resultado_branch(nome_branch)
+    sanitized = BranchNameSanitizer.sanitize(nome_branch)
+    if sanitized != nome_branch or sanitized == "invalid-branch":
+        msg = f"Nome da branch inválido para GitLab: '{nome_branch}' (sanitizado: '{sanitized}')"
+        print(f"[ERRO][GITLAB] {msg}")
+        BaseCommitter._finalizar_resultado_erro(resultado_branch, msg)
+        return resultado_branch
     commits_realizados = 0
 
     try:


### PR DESCRIPTION
No GitLab committer, valida explicitamente o nome da branch usando BranchNameSanitizer no início do processamento. Se inválido, retorna erro imediatamente sem tentar criar a branch, evitando erros de push (passo 7 do relatório).