### PR TITLE
Aprimorada a lógica de consolidação de mudanças para garantir que cada arquivo tenha apenas uma operação final antes do commit.

### DIFF
--- a/services/change_consolidator_service.py
+++ b/services/change_consolidator_service.py
@@ -1,0 +1,41 @@
+from typing import List, Dict, Any
+
+class ChangeConsolidatorService:
+    @staticmethod
+    def consolidate_changes(changes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        consolidated = {}
+        remove_paths = set()
+        for change in changes:
+            path = change.get('caminho_do_arquivo') or change.get('path')
+            status = (change.get('status') or change.get('action') or '').upper()
+            conteudo = change.get('conteudo') or change.get('content')
+            if not path:
+                continue
+            if path in remove_paths:
+                continue
+            if path in consolidated:
+                prev = consolidated[path]
+                prev_status = (prev.get('status') or prev.get('action') or '').upper()
+                # ADICIONADO/CRIADO + MODIFICADO => manter ADICIONADO com conteúdo final
+                if prev_status in ('ADICIONADO', 'CRIADO') and status == 'MODIFICADO':
+                    prev['conteudo'] = conteudo
+                    prev['status'] = prev_status
+                    continue
+                # MODIFICADO + REMOVIDO => manter apenas REMOVIDO
+                if prev_status == 'MODIFICADO' and status == 'REMOVIDO':
+                    consolidated[path] = {
+                        **change,
+                        'status': 'REMOVIDO',
+                        'conteudo': None
+                    }
+                    continue
+                # ADICIONADO/CRIADO + REMOVIDO => remover ambas
+                if prev_status in ('ADICIONADO', 'CRIADO') and status == 'REMOVIDO':
+                    del consolidated[path]
+                    remove_paths.add(path)
+                    continue
+                # Para outros casos, a última operação prevalece
+                consolidated[path] = {**change, 'status': status, 'conteudo': conteudo}
+            else:
+                consolidated[path] = {**change, 'status': status, 'conteudo': conteudo}
+        return [v for k, v in consolidated.items() if k not in remove_paths]


### PR DESCRIPTION
Modificada a função consolidate_changes para implementar regras claras de consolidação: manter 'add' com conteúdo final se seguido de 'edit', substituir 'edit' por 'delete' se houver remoção, e remover completamente se 'add' for seguido por 'delete'. Essa alteração previne erros 400 por múltiplas operações no mesmo arquivo no commit.