### PR TITLE
Garantida a consolidação das mudanças antes da formatação final para commit, evitando operações conflitantes.

### DIFF
--- a/services/data_formatter.py
+++ b/services/data_formatter.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any
 from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
+from services.change_consolidator_service import ChangeConsolidatorService
 
 class DataFormatter:
     def __init__(self, changeset_filler=None):
@@ -8,6 +9,7 @@ class DataFormatter:
     def format_incremental_result_for_commit(self, final_result: Dict[str, Any]) -> Dict[str, Any]:
         resumo_geral = final_result.get("resumo_geral", "")
         conjunto_de_mudancas = final_result.get("conjunto_de_mudancas", [])
+        conjunto_de_mudancas = ChangeConsolidatorService.consolidate_changes(conjunto_de_mudancas)
         branch_sugerida_raw = resumo_geral[:50] if resumo_geral else "refatoracao-incremental"
         branch_sugerida = BranchNameSanitizer.sanitize(branch_sugerida_raw)
         titulo_pr = resumo_geral[:72] if resumo_geral else "Refatoração incremental"


### PR DESCRIPTION
Modificado para usar ChangeConsolidatorService.consolidate_changes garantindo que a lista de mudanças enviada para commit contenha apenas uma operação final por arquivo, conforme a nova lógica consolidada.