### PR TITLE
Aplicada consolidação das mudanças ao mesclar batches para evitar conflitos nas operações.

### DIFF
--- a/services/incremental_step_executor_service.py
+++ b/services/incremental_step_executor_service.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Optional
 from services.step_dependency_analyzer import StepDependencyAnalyzer
+from services.change_consolidator_service import ChangeConsolidatorService
 import re
 
 class IncrementalStepExecutorService:
@@ -74,6 +75,7 @@ class IncrementalStepExecutorService:
             batch_mudancas = batch.get("conjunto_de_mudancas")
             if isinstance(batch_mudancas, list):
                 conjunto_de_mudancas.extend(batch_mudancas)
+        conjunto_de_mudancas = ChangeConsolidatorService.consolidate_changes(conjunto_de_mudancas)
         return {
             "resumo_geral": " ".join(resumo_geral).strip(),
             "conjunto_de_mudancas": conjunto_de_mudancas


### PR DESCRIPTION
Modificado merge_all_batches para consolidar as mudanças de todos os batches usando ChangeConsolidatorService, prevenindo múltiplas operações conflitantes no mesmo arquivo.