### PR TITLE
Adicionada validação para garantir que não existam duplicatas de arquivos antes do commit.

### DIFF
--- a/tools/repo_committers/base_committer.py
+++ b/tools/repo_committers/base_committer.py
@@ -1,7 +1,6 @@
 from typing import Dict, Any, List
 
 class BaseCommitter:
-    
     @staticmethod
     def _inicializar_resultado_branch(nome_branch: str) -> Dict[str, Any]:
         return {
@@ -11,36 +10,28 @@ class BaseCommitter:
             "message": "",
             "arquivos_modificados": []
         }
-    
     @staticmethod
     def _processar_mudancas_comuns(conjunto_de_mudancas: list, resultado_branch: Dict[str, Any]) -> List[Dict[str, Any]]:
         mudancas_validas = []
-        
         for mudanca in conjunto_de_mudancas:
             caminho = mudanca.get("caminho_do_arquivo")
             status = mudanca.get("status", "").upper()
             conteudo = mudanca.get("conteudo")
-            
             if not caminho:
                 print("  [AVISO] Mudança ignorada por não ter 'caminho_do_arquivo'.")
                 continue
-            
             mudancas_validas.append({
                 "caminho": caminho,
                 "status": status,
                 "conteudo": conteudo,
                 "justificativa": mudanca.get("justificativa", f"Aplicando mudança em {caminho}")
             })
-            
             resultado_branch["arquivos_modificados"].append(caminho)
-        
         return mudancas_validas
-    
     @staticmethod
     def _finalizar_resultado_sucesso(resultado_branch: Dict[str, Any], pr_url: str = None, message: str = "PR criado.") -> None:
         resultado_branch["success"] = True
         resultado_branch["message"] = message
-        
         if pr_url and isinstance(pr_url, str) and pr_url.strip():
             resultado_branch["pr_url"] = pr_url.strip()
             print(f"  [SUCESSO] PR criado: {pr_url}")
@@ -48,18 +39,14 @@ class BaseCommitter:
             branch_name = resultado_branch.get("branch_name", "branch-desconhecida")
             resultado_branch["pr_url"] = f"PR criado para branch: {branch_name}"
             print(f"  [AVISO] PR criado mas URL não foi retornada. Branch: {branch_name}")
-    
     @staticmethod
     def _finalizar_resultado_erro(resultado_branch: Dict[str, Any], error_message: str) -> None:
         resultado_branch["success"] = False
         resultado_branch["message"] = error_message
-        
         if not resultado_branch.get("pr_url"):
             branch_name = resultado_branch.get("branch_name", "branch-desconhecida")
             resultado_branch["pr_url"] = f"ERRO: PR não criado para branch {branch_name}. {error_message}"
-        
         print(f"  [ERRO] {error_message}")
-    
     @staticmethod
     def _mesclar_conteudo(conteudo_existente: str, novo_conteudo: str) -> str:
         if conteudo_existente is None:
@@ -67,3 +54,9 @@ class BaseCommitter:
         if novo_conteudo is None:
             novo_conteudo = ""
         return conteudo_existente + "\n\n" + novo_conteudo
+    @staticmethod
+    def _validate_no_duplicate_paths(conjunto_de_mudancas: List[Dict[str, Any]]) -> None:
+        paths = [m.get('caminho_do_arquivo') or m.get('path') for m in conjunto_de_mudancas if m.get('caminho_do_arquivo') or m.get('path')]
+        duplicates = set([p for p in paths if paths.count(p) > 1])
+        if duplicates:
+            raise ValueError(f"Há arquivos duplicados na lista de mudanças: {', '.join(duplicates)}")


### PR DESCRIPTION
Incluído método _validate_no_duplicate_paths para lançar erro caso haja múltiplas operações para o mesmo arquivo, reforçando a integridade dos dados antes do commit.