### PR TITLE
Criado serviço para execução do build .NET e captura de erros.

### DIFF
--- a/services/dotnet_build_service.py
+++ b/services/dotnet_build_service.py
@@ -1,0 +1,25 @@
+import subprocess
+import os
+from typing import Tuple, Optional
+
+class DotNetBuildService:
+    def execute_build(self, repo_path: str) -> Tuple[bool, Optional[str]]:
+        if not os.path.isdir(repo_path):
+            return False, f"Erro: O diretório '{repo_path}' não foi encontrado."
+        command = ["dotnet", "build"]
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=repo_path
+            )
+            if result.returncode == 0:
+                return True, None
+            else:
+                return False, result.stderr
+        except FileNotFoundError:
+            return False, "Erro: O comando 'dotnet' não foi encontrado. Verifique se o .NET SDK está instalado e no PATH do sistema."
+        except Exception as e:
+            return False, f"Erro inesperado ao executar o build: {str(e)}"


### PR DESCRIPTION
Implementado DotNetBuildService com método execute_build que executa 'dotnet build' no diretório do repositório, captura saída e erros, e retorna sucesso ou mensagem de erro detalhada.