### PR TITLE
Adicionada execução do build .NET pós-commit para branches criadas, com captura e armazenamento dos erros.

### DIFF
--- a/services/commit_handler.py
+++ b/services/commit_handler.py
@@ -3,6 +3,11 @@ from tools.conectores.conexao_geral import ConexaoGeral
 from tools.repo_committers.orchestrator import processar_branch_por_provedor
 from tools.repository_provider_factory import get_repository_provider_explicit
 from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
+from services.dotnet_build_service import DotNetBuildService
+import tempfile
+import shutil
+import os
+from models import JobFields
 
 class CommitHandler:
     def __init__(self, repository_provider_factory=None, conexao_geral_factory=None):
@@ -10,7 +15,7 @@ class CommitHandler:
         self.conexao_geral_factory = conexao_geral_factory or ConexaoGeral.create_with_defaults
     
     def execute_commits(self, job_id: str, job_info: Dict[str, Any], dados_finais_formatados: Dict[str, Any], 
-                      repository_type: str, repo_name: str) -> None:
+                      repository_type: str, repo_name: str, executar_build_dotnet: bool = False) -> None:
         print(f"[{job_id}] BLINDAGEM: Iniciando execute_commits")
         print(f"[{job_id}] DIAGNÓSTICO - Estrutura de dados_finais_formatados recebida: {dados_finais_formatados}")
         try:
@@ -88,6 +93,19 @@ class CommitHandler:
             print(f"[{job_id}] DIAGNÓSTICO - commit_details salvo no job_info: {job_info['data']['commit_details']}")
             for i, result in enumerate(commit_results):
                 print(f"[{job_id}] DIAGNÓSTICO - PR {i+1}: pr_url='{result.get('pr_url')}', branch_name='{result.get('branch_name')}', success={result.get('success')}, arquivos_modificados={len(result.get('arquivos_modificados', []))}")
+            if executar_build_dotnet:
+                print(f"[{job_id}] [BUILD] Flag executar_build_dotnet=True. Iniciando validação de build .NET nas branches criadas.")
+                build_errors_list = []
+                for result in commit_results:
+                    if result.get('success'):
+                        branch_name = result.get('branch_name')
+                        build_error = self._execute_dotnet_build_for_branch(job_id, repo_name, branch_name, repository_type)
+                        if build_error:
+                            if 'build_errors' not in result or not isinstance(result['build_errors'], list):
+                                result['build_errors'] = []
+                            result['build_errors'].append(build_error)
+                            build_errors_list.append(build_error)
+                job_info['data'][JobFields.BUILD_ERRORS] = build_errors_list if build_errors_list else None
             print(f"[{job_id}] BLINDAGEM: execute_commits concluído com sucesso")
         except Exception as e:
             print(f"[{job_id}] ERRO CRÍTICO em execute_commits: {str(e)}")
@@ -124,3 +142,40 @@ class CommitHandler:
         if not url or not isinstance(url, str):
             return False
         return url.startswith('http://') or url.startswith('https://') or "Branch processada" in url or "PR criado" in url
+
+    def _execute_dotnet_build_for_branch(self, job_id: str, repo_name: str, branch_name: str, repository_type: str) -> str:
+        print(f"[{job_id}] [BUILD] Iniciando build .NET para branch '{branch_name}' do repositório '{repo_name}' (tipo: {repository_type})")
+        temp_dir = tempfile.mkdtemp(prefix=f"dotnet_build_{job_id}_")
+        try:
+            conexao_geral = self.conexao_geral_factory()
+            repository_provider = self.repository_provider_factory(repository_type)
+            print(f"[{job_id}] [BUILD] Clonando repositório para diretório temporário: {temp_dir}")
+            repo_local = conexao_geral.clone_to_path(
+                repositorio=repo_name,
+                repository_type=repository_type,
+                repository_provider=repository_provider,
+                path=temp_dir
+            )
+            print(f"[{job_id}] [BUILD] Checkout da branch '{branch_name}'")
+            if hasattr(repo_local, 'git'):
+                repo_local.git.checkout(branch_name)
+            elif hasattr(repo_local, 'checkout'):  # para outros providers
+                repo_local.checkout(branch_name)
+            else:
+                print(f"[{job_id}] [BUILD] AVISO: Não foi possível fazer checkout da branch '{branch_name}' (provider desconhecido)")
+            build_service = DotNetBuildService()
+            sucesso, erro = build_service.execute_build(temp_dir)
+            if sucesso:
+                print(f"[{job_id}] [BUILD] Build .NET bem-sucedido para branch '{branch_name}'")
+                return None
+            else:
+                print(f"[{job_id}] [BUILD] Build .NET FALHOU para branch '{branch_name}'. Erro: {erro}")
+                return erro
+        except Exception as e:
+            print(f"[{job_id}] [BUILD] ERRO CRÍTICO ao executar build .NET para branch '{branch_name}': {e}")
+            return f"Erro crítico ao executar build .NET: {str(e)}"
+        finally:
+            try:
+                shutil.rmtree(temp_dir)
+            except Exception as e:
+                print(f"[{job_id}] [BUILD] AVISO: Falha ao remover diretório temporário '{temp_dir}': {e}")


### PR DESCRIPTION
Modificada a função execute_commits para, após realizar os commits e PRs, verificar a flag executar_build_dotnet. Se habilitada, para cada branch com commit bem-sucedido, clona o repositório em diretório temporário, faz checkout da branch, executa o build .NET via DotNetBuildService e armazena erros no commit_details e no job_info. Incluído método auxiliar _execute_dotnet_build_for_branch para esta lógica.