### PR TITLE
Remoção da classe StartAnalysisPayload de models.py e manutenção das demais definições.

### DIFF
--- a/models.py
+++ b/models.py
@@ -68,25 +68,3 @@ class JobFields:
 class JobActions:
     APPROVE = 'approve'
     REJECT = 'reject'
-
-class StartAnalysisPayload(BaseModel):
-    repo_name_modernizado: str
-    branch_name_modernizado: Optional[str] = None
-    projeto: str
-    analysis_type: Any
-    instrucoes_extras: Optional[str] = None
-    usar_rag: bool = False
-    gerar_relatorio_apenas: bool = False
-    gerar_novo_relatorio: bool = True
-    model_name: Optional[str] = None
-    arquivos_especificos: Optional[List[str]] = None
-    analysis_name: Optional[str] = None
-    repository_type: str
-    repo_name_original: Optional[str] = None
-    branch_name_original: Optional[str] = None
-    retornar_lista_arquivos: bool = False
-    modo_adicao_incremental: bool = False
-    usuario_executor: Optional[str] = None
-    executar_steps_incrementalmente: bool = False
-    max_steps_per_batch: Optional[int] = Field(3, description="Número máximo de steps por batch na execução incremental")
-    executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")


### PR DESCRIPTION
A classe StartAnalysisPayload foi removida de models.py para evitar que seja importada em mcp_server_fastapi, conforme instruções do usuário. Os imports em models.py foram mantidos apenas para as classes e constantes que permanecem no arquivo.