### PR TITLE
Validação rigorosa do parâmetro pr_url para evitar valores None ou vazios.

### DIFF
--- a/tools/repo_committers/base_committer.py
+++ b/tools/repo_committers/base_committer.py
@@ -33,12 +33,10 @@ class BaseCommitter:
         print(f"[DEBUG][BaseCommitter] _finalizar_resultado_sucesso: pr_url recebido: {pr_url}")
         resultado_branch["success"] = True
         resultado_branch["message"] = message
-        if pr_url is not None and isinstance(pr_url, str) and pr_url.strip():
-            resultado_branch["pr_url"] = pr_url.strip()
-            print(f"  [SUCESSO] PR criado: {pr_url}")
-        else:
-            print(f"[ERRO][BaseCommitter] pr_url inválido recebido: {pr_url}")
-            raise ValueError(f"pr_url inválido recebido em _finalizar_resultado_sucesso: {pr_url}")
+        if not pr_url or not isinstance(pr_url, str) or not pr_url.strip():
+            raise ValueError(f"[ERRO][BaseCommitter] pr_url inválido recebido: tipo={type(pr_url)}, valor={pr_url}, repr={repr(pr_url)}")
+        resultado_branch["pr_url"] = pr_url.strip()
+        print(f"  [SUCESSO] PR criado: {pr_url}")
     @staticmethod
     def _finalizar_resultado_erro(resultado_branch: Dict[str, Any], error_message: str) -> None:
         resultado_branch["success"] = False


### PR DESCRIPTION
Adicionada validação que levanta exceção detalhada se pr_url for None, vazio ou não string, para garantir que a URL do PR seja sempre válida antes de ser atribuída.