### PR TITLE
Adicionada verificação e execução condicional do build .NET após commit, respeitando o parâmetro executar_build_dotnet, para garantir que o build seja executado e seus resultados retornados corretamente.

### DIFF
--- a/services/dotnet_build_service.py
+++ b/services/dotnet_build_service.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import shutil
 from typing import Dict, Any, Optional, List
 
 class DotNetBuildService:
@@ -13,11 +14,11 @@ class DotNetBuildService:
             "stdout": "",
             "stderr": ""
         }
+        local_dir = f"/tmp/{job_id}_{branch_name}"
         try:
-            local_dir = f"/tmp/{job_id}_{branch_name}"
             clone_url = self._get_clone_url(repository_type, repo_name)
             if os.path.exists(local_dir):
-                subprocess.run(["rm", "-rf", local_dir], check=True)
+                shutil.rmtree(local_dir)
             clone_cmd = ["git", "clone", "--branch", branch_name, clone_url, local_dir]
             clone_proc = subprocess.run(clone_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
             if clone_proc.returncode != 0:
@@ -34,6 +35,12 @@ class DotNetBuildService:
                 result["errors"] = self._parse_build_errors(build_proc.stdout, build_proc.stderr)
         except Exception as e:
             result["errors"].append(str(e))
+        finally:
+            if os.path.exists(local_dir):
+                try:
+                    shutil.rmtree(local_dir)
+                except Exception:
+                    pass
         return result
 
     def _get_clone_url(self, repository_type: str, repo_name: str) -> str:


### PR DESCRIPTION
Foi identificado que o build .NET não estava sendo executado quando executar_build_dotnet = True, fazendo com que o processo finalizasse com status completo sem realizar o build e sem retornar possíveis falhas. Este PR corrige esse comportamento ao integrar a chamada do método build_project do DotNetBuildService logo após o commit, somente se executar_build_dotnet for True, e retorna o resultado do build para o fluxo principal, garantindo que erros e logs do build sejam capturados e reportados.