### PR TITLE
Correção no committer GitLab para retry automático com renomeação do MR em caso de URL inválida, incluindo tratamento para erro de ValueError ao finalizar MR já existente sem URL válida.

### DIFF
--- a/tools/repo_committers/gitlab_committer.py
+++ b/tools/repo_committers/gitlab_committer.py
@@ -2,6 +2,11 @@ from typing import Dict, Any, List
 from tools.repo_committers.base_committer import BaseCommitter
 from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
 import json
+import random
+import string
+
+def _gerar_sufixo_aleatorio(tamanho=6):
+    return ''.join(random.choices(string.ascii_lowercase + string.digits, k=tamanho))
 
 def processar_branch_gitlab(
     repo,
@@ -86,36 +91,64 @@ def processar_branch_gitlab(
                 traceback.print_exc()
         print(f"[DEBUG][GITLAB] Commits realizados: {commits_realizados}")
         if commits_realizados > 0:
-            try:
-                print(f"\n[DEBUG][GITLAB] Criando Merge Request de '{nome_branch}' para '{branch_alvo_do_pr}'...")
-                mr_result = repo.mergerequests.create({
-                    'source_branch': nome_branch,
-                    'target_branch': branch_alvo_do_pr,
-                    'title': mensagem_pr,
-                    'description': descricao_pr or "Refatoração automática gerada pela plataforma de agentes de IA."
-                })
-                print(f"[DEBUG][GITLAB] Tipo do objeto mr_result: {type(mr_result)}")
-                print(f"[DEBUG][GITLAB] Atributos do objeto mr_result: {dir(mr_result)}")
-                print(f"[DEBUG][GITLAB] mr_result.__dict__: {mr_result.__dict__}")
-                print(f"[DEBUG][GITLAB] mr_result.web_url (direto): {getattr(mr_result, 'web_url', None)}")
-                if not hasattr(mr_result, 'web_url') or mr_result.web_url is None or not isinstance(mr_result.web_url, str) or not mr_result.web_url.strip():
-                    print(f"[ERRO][GITLAB] MR criado mas web_url inválido: {json.dumps(mr_result.__dict__, default=str)}")
-                    BaseCommitter._finalizar_resultado_erro(resultado_branch, f"MR criado mas web_url inválido: {json.dumps(mr_result.__dict__, default=str)}")
-                    return resultado_branch
-                BaseCommitter._finalizar_resultado_sucesso(resultado_branch, mr_result.web_url.strip())
-            except Exception as mr_e:
-                print(f"[ERRO][GITLAB] Exceção ao criar MR: {type(mr_e).__name__}: {mr_e}")
-                if "already exists" in str(mr_e).lower():
-                    mrs = repo.mergerequests.list(state='opened', source_branch=nome_branch, target_branch=branch_alvo_do_pr)
-                    mr_url = mrs[0].web_url if mrs else "URL não encontrada"
-                    print(f"AVISO: MR para esta branch GitLab já existe. URL: {mr_url}")
-                    BaseCommitter._finalizar_resultado_sucesso(resultado_branch, mr_url, "MR já existente.")
-                else:
-                    print(f"ERRO ao criar MR GitLab para '{nome_branch}': {mr_e}")
-                    BaseCommitter._finalizar_resultado_erro(resultado_branch, f"Erro ao criar MR: {mr_e}")
+            tentativas = 0
+            while tentativas < 2:
+                try:
+                    print(f"\n[DEBUG][GITLAB] Criando Merge Request de '{nome_branch}' para '{branch_alvo_do_pr}'...")
+                    mr_result = repo.mergerequests.create({
+                        'source_branch': nome_branch,
+                        'target_branch': branch_alvo_do_pr,
+                        'title': mensagem_pr,
+                        'description': descricao_pr or "Refatoração automática gerada pela plataforma de agentes de IA."
+                    })
+                    print(f"[DEBUG][GITLAB] Tipo do objeto mr_result: {type(mr_result)}")
+                    print(f"[DEBUG][GITLAB] Atributos do objeto mr_result: {dir(mr_result)}")
+                    print(f"[DEBUG][GITLAB] mr_result.__dict__: {mr_result.__dict__}")
+                    print(f"[DEBUG][GITLAB] mr_result.web_url (direto): {getattr(mr_result, 'web_url', None)}")
+                    print(f"[DEBUG][GITLAB] mr_result.web_url ANTES de _finalizar_resultado_sucesso: {getattr(mr_result, 'web_url', 'ATRIBUTO NÃO ENCONTRADO')}")
+                    BaseCommitter._finalizar_resultado_sucesso(resultado_branch, mr_result.web_url.strip())
+                    break
+                except ValueError as ve:
+                    print(f"[ERRO][GITLAB] Objeto MR retornado sem web_url ou web_url inválido: {getattr(mr_result, 'web_url', None)}")
+                    print(f"[ERRO][GITLAB] Detalhes do objeto MR: {mr_result.__dict__}")
+                    if tentativas == 0:
+                        sufixo = _gerar_sufixo_aleatorio()
+                        novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
+                        print(f"[GITLAB][RETRY] Tentando criar MR novamente com título modificado: {novo_titulo}")
+                        mensagem_pr = novo_titulo
+                        tentativas += 1
+                        continue
+                    else:
+                        raise
+                except Exception as mr_e:
+                    print(f"[ERRO][GITLAB] Exceção ao criar MR: {type(mr_e).__name__}: {mr_e}")
+                    if "already exists" in str(mr_e).lower():
+                        mrs = repo.mergerequests.list(state='opened', source_branch=nome_branch, target_branch=branch_alvo_do_pr)
+                        mr_url = mrs[0].web_url if mrs else "URL não encontrada"
+                        print(f"AVISO: MR para esta branch GitLab já existe. URL: {mr_url}")
+                        try:
+                            BaseCommitter._finalizar_resultado_sucesso(resultado_branch, mr_url, "MR já existente.")
+                        except ValueError as ve:
+                            print(f"[ERRO][GITLAB] MR já existente mas web_url inválido. Tentando retry com sufixo aleatório.")
+                            sufixo = _gerar_sufixo_aleatorio()
+                            novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
+                            mensagem_pr = novo_titulo
+                            continue
+                        break
+                    else:
+                        print(f"ERRO ao criar MR GitLab para '{nome_branch}': {mr_e}")
+                        BaseCommitter._finalizar_resultado_erro(resultado_branch, f"Erro ao criar MR: {mr_e}")
+                        break
         else:
             print(f"\nNenhum commit realizado para a branch GitLab '{nome_branch}'. Pulando criação do MR.")
-            BaseCommitter._finalizar_resultado_sucesso(resultado_branch, pr_url=f"MR criado para branch: {nome_branch}", message="Nenhuma mudança para commitar.")
+            try:
+                BaseCommitter._finalizar_resultado_sucesso(resultado_branch, pr_url=f"MR criado para branch: {nome_branch}", message="Nenhuma mudança para commitar.")
+            except ValueError as ve:
+                print(f"[ERRO][GITLAB] MR vazio mas web_url inválido. Tentando retry com sufixo aleatório.")
+                sufixo = _gerar_sufixo_aleatorio()
+                novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
+                mensagem_pr = novo_titulo
+                BaseCommitter._finalizar_resultado_sucesso(resultado_branch, pr_url=f"MR criado para branch: {nome_branch}-{sufixo}", message="Nenhuma mudança para commitar.")
     except Exception as e:
         print(f"[ERRO][GITLAB] ERRO FATAL ao processar branch GitLab '{nome_branch}': {type(e).__name__}: {e}")
         import traceback


### PR DESCRIPTION
Adicionados logs de debug detalhados antes da chamada de _finalizar_resultado_sucesso. Implementado retry com sufixo aleatório no título do MR caso a URL do MR seja inválida ou ocorra ValueError ao tentar finalizar com mensagem de MR já existente sem URL válida, conforme instrução do usuário para evitar erros de commit.