### PR TITLE
Adição do campo opcional 'commit_url' ao modelo PullRequestSummary em models.py.

### DIFF
--- a/models.py
+++ b/models.py
@@ -6,6 +6,7 @@ class PullRequestSummary(BaseModel):
     branch_name: str
     arquivos_modificados: List[str]
     build_result: Optional[Dict[str, Any]] = None
+    commit_url: Optional[str] = None
 
 class FinalStatusResponse(BaseModel):
     job_id: str


### PR DESCRIPTION
Incluído o campo 'commit_url' do tipo Optional[str] no modelo PullRequestSummary para armazenar a URL do commit associado ao pull request.