### PR TITLE
Inicialização do campo commit_url em base_committer.py para suportar propagação da URL do commit.

### DIFF
--- a/tools/repo_committers/base_committer.py
+++ b/tools/repo_committers/base_committer.py
@@ -8,7 +8,8 @@ class BaseCommitter:
             "success": False,
             "pr_url": None,
             "message": "",
-            "arquivos_modificados": []
+            "arquivos_modificados": [],
+            "commit_url": None
         }
     @staticmethod
     def _processar_mudancas_comuns(conjunto_de_mudancas: list, resultado_branch: Dict[str, Any]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Adiciona o campo commit_url inicializado como None no dicionário retornado por _inicializar_resultado_branch para armazenar a URL do commit.