### PR TITLE
Validação da URL do commit e ajuste na propagação da URL do commit no GitLab para garantir que seja uma URL válida da UI.

### DIFF
--- a/tools/repo_committers/gitlab_committer.py
+++ b/tools/repo_committers/gitlab_committer.py
@@ -98,8 +98,9 @@ def processar_branch_gitlab(
                 traceback.print_exc()
         if last_commit_id:
             repo_web_url = getattr(repo, 'web_url', None)
-            if repo_web_url:
-                resultado_branch['commit_url'] = f"{repo_web_url}/-/commit/{last_commit_id}"
+            commit_url_candidate = f"{repo_web_url}/-/commit/{last_commit_id}" if repo_web_url and last_commit_id else None
+            if commit_url_candidate and BaseCommitter._validate_commit_url(commit_url_candidate):
+                resultado_branch['commit_url'] = commit_url_candidate
             else:
                 resultado_branch['commit_url'] = None
         print(f"[DEBUG][GITLAB] Commits realizados: {commits_realizados}")


### PR DESCRIPTION
Incluída a validação com BaseCommitter._validate_commit_url para garantir que commit_url propagada seja uma URL válida da UI do commit no GitLab, evitando URLs de API JSON que não levam à interface gráfica do commit. Mantida lógica de criação e atualização de arquivos e commits conforme API do GitLab.