### PR TITLE
Ajuste no endpoint /start-analysis para garantir que o campo 'executar_build_dotnet' seja corretamente recebido, armazenado e logado, preparando para sua propagação no fluxo de execução incremental.

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -83,6 +83,8 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     analysis_name = job_data_service.generate_analysis_name(payload.analysis_name, job_id)
     payload_dict = payload.dict()
     payload_dict['analysis_type'] = payload.analysis_type.value
+    # DEBUG: Logar o valor de executar_build_dotnet recebido
+    print(f"[{job_id}] [DEBUG] Valor de executar_build_dotnet recebido no payload: {payload_dict.get('executar_build_dotnet')}")
     initial_job_data = job_data_service.create_initial_job_data(
         payload_dict, normalized_repo_name, analysis_name
     )


### PR DESCRIPTION
No endpoint /start-analysis, o campo 'executar_build_dotnet' do payload é extraído e armazenado corretamente em initial_job_data via job_data_service.create_initial_job_data(), e um log de debug foi adicionado para confirmar o valor recebido. Essa alteração atende ao passo 2 do relatório, porém a propagação do valor para execução incremental e build após commit ainda precisa de implementação para garantir o comportamento esperado quando 'executar_build_dotnet' e 'executar_steps_incrementalmente' forem True.