### PR TITLE
Inclusão de logs de debug e validações adicionais para monitorar a propagação e uso do campo executar_build_dotnet no workflow.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -178,7 +178,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
         dados_finais_formatados = self.data_formatter.format_incremental_result_for_commit(final_result)
         self.job_handler.update_job_status(job_id, 'committing_to_github')
         self.commit_handler.execute_commits(job_id, job_info, dados_finais_formatados, repository_type, repo_name)
-        print(f"[{job_id}] [FINALIZE] executar_build_dotnet={job_info['data'].get('executar_build_dotnet')}, commit_details presente: {bool(job_info['data'].get('commit_details'))}")
+        print(f"[{job_id}] [DEBUG] Após execute_commits: executar_build_dotnet={job_info['data'].get('executar_build_dotnet')}, commit_details presente: {bool(job_info['data'].get('commit_details'))}")
         if job_info['data'].get('executar_build_dotnet', False):
             commit_details = job_info['data'].get('commit_details', [])
             print(f"[{job_id}] [FINALIZE] Consolidando build_errors de {len(commit_details)} commits")
@@ -197,4 +197,12 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             job_info['data']['build_errors'] = None
         self.job_handler.update_job(job_id, job_info)
         print(f"[{job_id}] DIAGNÓSTICO - Job atualizado no job store")
+        # Validação adicional para commit_details
+        if job_info['data'].get('executar_build_dotnet', False):
+            commit_details = job_info['data'].get('commit_details', [])
+            for idx, commit in enumerate(commit_details):
+                if 'build_result' not in commit:
+                    print(f"[{job_id}] [ERRO CRÍTICO] build_result ausente no commit_details[{idx}] quando executar_build_dotnet=True")
+                if 'build_errors' not in commit:
+                    print(f"[{job_id}] [ERRO CRÍTICO] build_errors ausente no commit_details[{idx}] quando executar_build_dotnet=True")
         self.job_handler.update_job_status(job_id, 'completed')


### PR DESCRIPTION
No método _finalize_workflow de WorkflowOrchestrator, foram adicionados logs de debug imediatamente após a execução dos commits para verificar o valor e presença do campo executar_build_dotnet e commit_details. Também foi incluída validação extra para garantir que build_result e build_errors estejam presentes em cada commit quando executar_build_dotnet for True. Esses ajustes auxiliam a diagnosticar problemas de propagação e execução do build .NET após commits incrementais.