### PR TITLE
Expansão do modelo StartAnalysisPayload para suportar autenticação Git com campos opcionais git_username e git_token.

### DIFF
--- a/models.py
+++ b/models.py
@@ -67,6 +67,8 @@ class JobFields:
     EXECUTAR_BUILD_DOTNET = 'executar_build_dotnet'
     BUILD_ERRORS = 'build_errors'
     BUILD_RESULT = 'build_result'
+    GIT_USERNAME = 'git_username'
+    GIT_TOKEN = 'git_token'
 
 class JobActions:
     APPROVE = 'approve'
@@ -93,3 +95,5 @@ class StartAnalysisPayload(BaseModel):
     executar_steps_incrementalmente: bool = False
     max_steps_per_batch: Optional[int] = Field(3, description="Número máximo de steps por batch na execução incremental")
     executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")
+    git_username: Optional[str] = Field(None, description="Usuário para autenticação Git (privado)")
+    git_token: Optional[str] = Field(None, description="Token para autenticação Git (privado)")


### PR DESCRIPTION
Adicionados os campos opcionais git_username e git_token ao modelo StartAnalysisPayload para suportar autenticação em repositórios privados, permitindo que o sistema capture e utilize credenciais para acesso seguro.