### PR TITLE
Modificação do endpoint /start-analysis para capturar e propagar git_username e git_token no initial_job_data.

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -46,6 +46,8 @@ class StartAnalysisPayload(BaseModel):
     usuario_executor: Optional[str] = Field(None, description="Nome do usuário que está executando a análise")
     executar_steps_incrementalmente: bool = Field(False, description="Se True, os passos do relatório de implementação serão executados de forma incremental (um ou mais passos por vez, respeitando dependências), ao invés de enviar todas as mudanças de uma só vez. Útil para relatórios extensos que podem exceder limites de tokens da LLM.")
     executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")
+    git_username: Optional[str] = Field(None, description="Usuário para autenticação Git (privado)")
+    git_token: Optional[str] = Field(None, description="Token para autenticação Git (privado)")
     
 class StartAnalysisResponse(BaseModel):
     job_id: str
@@ -96,6 +98,11 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     payload_dict['analysis_type'] = payload.analysis_type.value
     # DEBUG: Logar o valor de executar_build_dotnet recebido
     print(f"[{job_id}] [DEBUG] Valor de executar_build_dotnet recebido no payload: {payload_dict.get('executar_build_dotnet')}")
+    # Passo 2: Propagar git_username e git_token se presentes
+    if hasattr(payload, 'git_username') and payload.git_username is not None:
+        payload_dict['git_username'] = payload.git_username
+    if hasattr(payload, 'git_token') and payload.git_token is not None:
+        payload_dict['git_token'] = payload.git_token
     initial_job_data = job_data_service.create_initial_job_data(
         payload_dict, normalized_repo_name, analysis_name
     )


### PR DESCRIPTION
O endpoint /start-analysis agora captura os campos opcionais git_username e git_token do payload e os propaga para o initial_job_data, garantindo que as credenciais para repositórios privados sejam armazenadas e utilizadas corretamente no fluxo de trabalho.