### PR TITLE
Extração e passagem de git_username e git_token no método _finalize_workflow para build dotnet.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -14,6 +14,7 @@ from tools.readers.reader_geral import ReaderGeral
 from tools.repository_provider_factory import get_repository_provider_explicit
 from models import JobFields
 from services.incremental_step_executor_service import IncrementalStepExecutorService
+from services.dotnet_build_service import DotNetBuildService
 class WorkflowOrchestrator(IWorkflowOrchestrator):
     def __init__(self, job_manager: IJobManager, blob_storage: IBlobStorageService, 
                  workflow_registry: Dict[str, Any], rag_retriever=None, 
@@ -192,6 +193,19 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 job_info['data']['build_errors'] = build_errors
             else:
                 job_info['data']['build_errors'] = None
+            # Extração das credenciais de autenticação
+            git_username = job_info['data'].get(JobFields.GIT_USERNAME)
+            git_token = job_info['data'].get(JobFields.GIT_TOKEN)
+            branch_name = job_info['data'].get('branch_name_modernizado') or job_info['data'].get('branch_name')
+            dotnet_build_service = DotNetBuildService()
+            dotnet_build_service.build_project(
+                job_id=job_id,
+                repository_type=repository_type,
+                repo_name=repo_name,
+                branch_name=branch_name,
+                git_username=git_username,
+                git_token=git_token
+            )
             self.job_handler.update_job(job_id, job_info)
         else:
             job_info['data']['build_errors'] = None


### PR DESCRIPTION
No método _finalize_workflow em services/workflow_orchestrator.py, após a execução dos commits, git_username e git_token são extraídos do job_info['data'] e passados para DotNetBuildService.build_project para permitir autenticação no build dotnet, especialmente para repositórios privados.