### PR TITLE
Atualização para que o DotNetBuildService obtenha as credenciais de acesso ao repositório Azure DevOps internamente via SecretManager, removendo a necessidade de passar git_username/git_token externamente.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -193,19 +193,14 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 job_info['data']['build_errors'] = build_errors
             else:
                 job_info['data']['build_errors'] = None
-            # Passo 4: Extrair credenciais do job_info['data'] e passar para o build_project
-            git_username = job_info['data'].get(JobFields.GIT_USERNAME)
-            git_token = job_info['data'].get(JobFields.GIT_TOKEN)
             branch_name = job_info['data'].get('branch_name_modernizado') or job_info['data'].get('branch_name')
-            print(f"[{job_id}] [DEBUG] build_project: git_username={git_username}, git_token={'sim' if git_token else 'não'}")
+            print(f"[{job_id}] [DEBUG] build_project: branch_name={branch_name}")
             dotnet_build_service = DotNetBuildService()
             dotnet_build_service.build_project(
                 job_id=job_id,
                 repository_type=repository_type,
                 repo_name=repo_name,
-                branch_name=branch_name,
-                git_username=git_username,
-                git_token=git_token
+                branch_name=branch_name
             )
             self.job_handler.update_job(job_id, job_info)
         else:


### PR DESCRIPTION
Este PR ajusta a chamada do método build_project no serviço de workflow para não passar mais git_username e git_token. A assinatura do método build_project em DotNetBuildService foi atualizada para remover esses parâmetros e implementar a lógica interna de obtenção das credenciais via SecretManager. O serviço tenta buscar o token no Azure SecretManager usando o nome do segredo baseado na organização do repositório. Se o token não for encontrado, o build falha com mensagem clara de erro. Essa mudança centraliza a gestão de credenciais e melhora a segurança e manutenção do código.