### PR TITLE
Generalização do build .NET para suportar repositórios privados com autenticação via token, buscando token antes do clone e ajustando URL de clone com token.

### DIFF
--- a/services/dotnet_build_service.py
+++ b/services/dotnet_build_service.py
@@ -2,12 +2,13 @@ import subprocess
 import os
 import shutil
 from typing import Dict, Any, Optional, List
+from tools.azure_secret_manager import AzureSecretManager
 
 class DotNetBuildService:
     def __init__(self):
-        pass
+        self.secret_manager = AzureSecretManager()
 
-    def build_project(self, job_id: str, repository_type: str, repo_name: str, branch_name: str) -> Dict[str, Any]:
+    def build_project(self, job_id: str, repository_type: str, repo_name: str, branch_name: str, usuario_executor: Optional[str] = None) -> Dict[str, Any]:
         print(f"[{job_id}] [DotNetBuildService] Iniciando build para repo={repo_name}, branch={branch_name}")
         result = {
             "success": False,
@@ -18,6 +19,26 @@ class DotNetBuildService:
         local_dir = f"/tmp/{job_id}_{branch_name}"
         try:
             clone_url = self._get_clone_url(repository_type, repo_name)
+            token = self._get_token_for_repository(repository_type, repo_name, usuario_executor)
+            if token:
+                org = self._extract_org_from_repo_name(repository_type, repo_name)
+                print(f"[{job_id}] [DotNetBuildService] Token encontrado para org={org}, repository_type={repository_type}")
+                if repository_type == "azure":
+                    # Exemplo: https://{token}@dev.azure.com/org/project/repo
+                    if clone_url.startswith("https://"):
+                        clone_url = clone_url.replace("https://", f"https://{token}@", 1)
+                elif repository_type == "github":
+                    # Exemplo: https://{token}@github.com/org/repo.git
+                    if clone_url.startswith("https://"):
+                        clone_url = clone_url.replace("https://", f"https://{token}@", 1)
+                elif repository_type == "gitlab":
+                    # Exemplo: https://oauth2:{token}@gitlab.com/namespace/repo.git
+                    if clone_url.startswith("https://"):
+                        clone_url = clone_url.replace("https://", f"https://oauth2:{token}@", 1)
+                else:
+                    print(f"[{job_id}] [DotNetBuildService] Tipo de repositório não reconhecido para autenticação: {repository_type}")
+            else:
+                print(f"[{job_id}] [DotNetBuildService] Nenhum token encontrado, tentando clone sem autenticação.")
             if os.path.exists(local_dir):
                 shutil.rmtree(local_dir)
             clone_cmd = ["git", "clone", "--branch", branch_name, clone_url, local_dir]
@@ -61,3 +82,48 @@ class DotNetBuildService:
             if "error" in line.lower():
                 errors.append(line.strip())
         return errors if errors else ["Falha no build, mas nenhum erro específico encontrado."]
+
+    def _get_token_for_repository(self, repository_type: str, repo_name: str, usuario_executor: Optional[str]) -> Optional[str]:
+        org = self._extract_org_from_repo_name(repository_type, repo_name)
+        search_keys = []
+        if usuario_executor:
+            search_keys.append(f"{repository_type}-token-{org}-{usuario_executor}")
+        search_keys.append(f"{repository_type}-token-{org}")
+        search_keys.append(f"{repository_type}-token")
+        for key in search_keys:
+            try:
+                token = self.secret_manager.get_secret(key)
+                if token:
+                    print(f"[DotNetBuildService] Token encontrado para chave: {key}")
+                    return token
+            except Exception as e:
+                print(f"[DotNetBuildService] Erro ao buscar token para chave {key}: {e}")
+        print(f"[DotNetBuildService] Nenhum token encontrado para repo_type={repository_type}, org={org}, usuario_executor={usuario_executor}")
+        return None
+
+    def _extract_org_from_repo_name(self, repository_type: str, repo_name: str) -> str:
+        if repository_type == "azure":
+            parts = repo_name.split('/')
+            if len(parts) >= 1:
+                return parts[0]
+            else:
+                raise ValueError(f"Nome do repositório Azure inválido: {repo_name}")
+        elif repository_type == "github":
+            parts = repo_name.split('/')
+            if len(parts) >= 1:
+                return parts[0]
+            else:
+                raise ValueError(f"Nome do repositório GitHub inválido: {repo_name}")
+        elif repository_type == "gitlab":
+            try:
+                # Tenta tratar como Project ID numérico
+                int(repo_name)
+                return 'gitlab'
+            except ValueError:
+                parts = repo_name.strip().split('/')
+                if len(parts) >= 1:
+                    return parts[0]
+                else:
+                    return 'gitlab'
+        else:
+            raise ValueError(f"Tipo de repositório não suportado para extração de organização: {repository_type}")


### PR DESCRIPTION
O método build_project foi modificado para receber repository_type e usuario_executor, e para buscar o token hierarquicamente antes de clonar o repositório. A URL de clone é ajustada para incluir o token conforme o tipo do repositório (azure, github, gitlab). A extração da organização do repositório é usada para montar as chaves de busca do token. Isso permite o build de branchs privadas e públicas sem alterações na interface externa.