### PR TITLE
Validação do formato do nome do repositório GitHub para garantir extração correta da organização e suporte à autenticação.

### DIFF
--- a/tools/conectores/github_conector.py
+++ b/tools/conectores/github_conector.py
@@ -10,12 +10,15 @@ class GitHubConector(BaseConector):
     
     def _extract_org_name(self, repositorio: str) -> str:
         try:
-            org_name = repositorio.strip().split('/')[0]
+            parts = repositorio.strip().split('/')
+            if len(parts) < 2:
+                raise ValueError(f"O nome do repositório '{repositorio}' tem formato inválido. Esperado 'organizacao/repositorio'.")
+            org_name = parts[0]
             print(f"[GitHub Conector] Organização extraída: {org_name}")
             return org_name
-        except (ValueError, IndexError):
+        except (ValueError, IndexError) as e:
             print(f"[GitHub Conector] ERRO: Formato inválido do repositório: {repositorio}")
-            raise ValueError(f"O nome do repositório '{repositorio}' tem formato inválido. Esperado 'organizacao/repositorio'.")
+            raise
     
     def connection(self, repositorio: str) -> Union[Repository, object]:
         org_name = self._extract_org_name(repositorio)


### PR DESCRIPTION
O método _extract_org_name foi aprimorado para validar se o nome do repositório GitHub possui pelo menos duas partes separadas por '/', lançando exceção clara em caso de formato inválido. Essa validação é fundamental para garantir que a organização seja extraída corretamente para a busca do token no Key Vault, necessária para builds em branches privadas.