### PR TITLE
Propagação do parâmetro usuario_executor para commit_handler no método _finalize_workflow.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -177,7 +177,9 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             final_result = IncrementalStepExecutorService.merge_all_batches(batch_results)
         dados_finais_formatados = self.data_formatter.format_incremental_result_for_commit(final_result)
         self.job_handler.update_job_status(job_id, 'committing_to_github')
-        self.commit_handler.execute_commits(job_id, job_info, dados_finais_formatados, repository_type, repo_name)
+        # Passo 11: garantir que usuario_executor seja extraído e passado para execute_commits
+        usuario_executor = job_info['data'].get('usuario_executor')
+        self.commit_handler.execute_commits(job_id, job_info, dados_finais_formatados, repository_type, repo_name, usuario_executor=usuario_executor)
         print(f"[{job_id}] [DEBUG] Após execute_commits: executar_build_dotnet={job_info['data'].get('executar_build_dotnet')}, commit_details presente: {bool(job_info['data'].get('commit_details'))}")
         if job_info['data'].get('executar_build_dotnet', False):
             commit_details = job_info['data'].get('commit_details', [])


### PR DESCRIPTION
No método _finalize_workflow da classe WorkflowOrchestrator, o parâmetro usuario_executor é extraído de job_info['data'] e passado explicitamente para o método execute_commits do commit_handler, garantindo que o usuário executor seja corretamente utilizado na etapa de commit e build do projeto .NET.