### PR TITLE
Simplificação da regra de dependência para considerar apenas o nome do arquivo, ignorando caminho e normalizando o nome.

### DIFF
--- a/services/step_dependency_analyzer.py
+++ b/services/step_dependency_analyzer.py
@@ -7,11 +7,7 @@ class StepDependencyAnalyzer:
         path2 = StepDependencyAnalyzer._normalize_path(step2.get('Caminho do Arquivo', ''))
         if not path1 or not path2:
             return False
-        if path1 == path2:
-            return True
-        if path1.startswith(path2) or path2.startswith(path1):
-            return True
-        return False
+        return path1 == path2
 
     @staticmethod
     def _normalize_path(path: str) -> str:


### PR DESCRIPTION
A classe StepDependencyAnalyzer foi modificada para que a dependência entre steps seja determinada exclusivamente pela igualdade do nome do arquivo normalizado (sem caminho). Isso atende à instrução explícita do usuário de que arquivos com o mesmo nome devem estar no mesmo batch.