### PR TITLE
Ajuste na lógica de batching para agrupar steps que modificam arquivos com o mesmo nome no mesmo batch, independentemente do limite máximo de steps por batch.

### DIFF
--- a/services/incremental_step_executor_service.py
+++ b/services/incremental_step_executor_service.py
@@ -44,19 +44,30 @@ class IncrementalStepExecutorService:
         print(f"[INCREMENTAL] {len(steps)} steps parseados do relatório.")
         batches = []
         current_batch = []
+        current_batch_paths = set()
         for step in steps:
+            step_path = StepDependencyAnalyzer._normalize_path(step.get('Caminho do Arquivo', ''))
             if not current_batch:
                 current_batch.append(step)
-            else:
-                dependent = any(
-                    StepDependencyAnalyzer.are_steps_dependent(step, prev_step)
-                    for prev_step in current_batch
-                )
-                if len(current_batch) < max_steps_per_batch and not dependent:
-                    current_batch.append(step)
-                else:
-                    batches.append(current_batch)
-                    current_batch = [step]
+                if step_path:
+                    current_batch_paths.add(step_path)
+                continue
+            # Se o arquivo já está no batch atual, adiciona (independente do tamanho do batch)
+            if step_path and step_path in current_batch_paths:
+                current_batch.append(step)
+                continue
+            # Se o batch não atingiu o limite, adiciona
+            if len(current_batch) < max_steps_per_batch:
+                current_batch.append(step)
+                if step_path:
+                    current_batch_paths.add(step_path)
+                continue
+            # Caso contrário, fecha o batch atual e inicia um novo
+            batches.append(current_batch)
+            current_batch = [step]
+            current_batch_paths = set()
+            if step_path:
+                current_batch_paths.add(step_path)
         if current_batch:
             batches.append(current_batch)
         print(f"[INCREMENTAL] {len(batches)} batches criados.")


### PR DESCRIPTION
O método get_step_batches_from_report foi modificado para usar a normalização do nome do arquivo (via StepDependencyAnalyzer) e garantir que todos os steps que modificam arquivos com o mesmo nome sejam agrupados no mesmo batch. O batch só é fechado quando um novo step modifica um arquivo com nome diferente e o limite máximo é atingido.