### PR TITLE
Inclusão de validação rigorosa de caminhos usando PathValidator em todos os committers (GitHub, GitLab, Azure).

### DIFF
--- a/tools/repo_committers/azure_committer.py
+++ b/tools/repo_committers/azure_committer.py
@@ -6,6 +6,7 @@ from tools.repo_committers.base_committer import BaseCommitter
 from tools.conectores.azure_conector import AzureConector
 from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
 from tools.repo_committers.azure_pr_url_builder import build_pr_ui_url
+from tools.repo_committers.path_validator import PathValidator
 import json
 import random
 import string
@@ -96,38 +97,43 @@ def processar_branch_azure(
             raise Exception(f"Erro ao criar branch: {branch_response.status_code} - {branch_response.text}")
         changes = []
         mudancas_validas = BaseCommitter._processar_mudancas_comuns(conjunto_de_mudancas, resultado_branch)
-        mudancas_validas = _deduplicar_mudancas_por_arquivo(mudancas_validas)
-        for mudanca in mudancas_validas:
+        mudancas_validas_filtradas = []
+        for idx, mudanca in enumerate(mudancas_validas):
             caminho = mudanca["caminho"]
+            try:
+                caminho_validado = PathValidator.validate_path(caminho)
+            except Exception as e:
+                print(f"[ERRO][AZURE][processar_branch_azure] Mudança {idx}: caminho inválido: '{caminho}'. Erro: {e}")
+                continue
             status = mudanca["status"]
             conteudo = mudanca["conteudo"]
             if status in ("ADICIONADO", "CRIAR", "CRIADO"):
                 change_item = {
-                    "item": {"path": f"/{caminho}"},
+                    "item": {"path": f"/{caminho_validado}"},
                     "changeType": "add",
                     "newContent": {"content": conteudo or "", "contentType": "rawtext"}
                 }
             elif status == "MODIFICADO":
                 if modo_adicao_incremental:
-                    get_item_url = f"{base_url}/git/repositories/{repository_id}/items?path=/{caminho}&api-version=7.0"
+                    get_item_url = f"{base_url}/git/repositories/{repository_id}/items?path=/{caminho_validado}&api-version=7.0"
                     item_response = requests.get(get_item_url, headers=headers, timeout=30)
                     if item_response.status_code == 200:
                         conteudo_existente = item_response.text
                         conteudo = BaseCommitter._mesclar_conteudo(conteudo_existente, conteudo)
                 change_item = {
-                    "item": {"path": f"/{caminho}"},
+                    "item": {"path": f"/{caminho_validado}"},
                     "changeType": "edit",
                     "newContent": {"content": conteudo or "", "contentType": "rawtext"}
                 }
             elif status == "REMOVIDO":
                 change_item = {
-                    "item": {"path": f"/{caminho}"},
+                    "item": {"path": f"/{caminho_validado}"},
                     "changeType": "delete"
                 }
             else:
                 continue
             changes.append(change_item)
-        # PASSO 5: Validação se há mudanças válidas
+            mudancas_validas_filtradas.append(mudanca)
         if len(changes) == 0:
             print(f"[AVISO][AZURE] Nenhuma mudança válida para commitar para a branch '{nome_branch}'. Commit será ignorado.")
             try:
@@ -151,16 +157,12 @@ def processar_branch_azure(
                 "changes": changes
             }]
         }
-        print(f"[LOG][AZURE] push_payload: {json.dumps(push_payload, indent=2, default=str)}")
         max_push_attempts = 2
         push_attempt = 0
         commit_url = None
         commit_id = None
         while push_attempt < max_push_attempts:
-            print(f"[LOG][AZURE] Realizando push tentativa {push_attempt+1} para branch '{nome_branch}' com current_commit_id: {current_commit_id}")
             push_response = requests.post(push_url, headers=headers, json=push_payload, timeout=60)
-            print(f"[LOG][AZURE] push_response.status_code: {push_response.status_code}, push_response.text: {push_response.text}")
-            # INÍCIO DA LÓGICA DO PASSO 8
             if push_response.status_code in [200, 201]:
                 try:
                     push_data = push_response.json()
@@ -175,18 +177,15 @@ def processar_branch_azure(
                     commit_id = commit_info.get('commitId')
                     if commit_id:
                         commit_url_candidate = _build_commit_ui_url(organization, project, repo_name, commit_id)
-                        print(f"[LOG][AZURE] commit_id extraído: {commit_id}, commit_url_candidate: {commit_url_candidate}")
                         if BaseCommitter._validate_commit_url(commit_url_candidate):
                             commit_url = commit_url_candidate
                         else:
-                            print(f"[WARN][AZURE] commit_url construído não é válido: {commit_url_candidate}")
                             commit_url = None
                 except Exception as e:
                     print(f"[ERRO][AZURE] Não foi possível extrair commit_url do push_response: {e}")
                     commit_url = None
                 break
             elif push_response.status_code in [400, 409]:
-                print(f"[ERRO][AZURE] Push falhou com status {push_response.status_code}. Tentando atualizar current_commit_id e retentar...")
                 refs_url_destino = f"{base_url}/git/repositories/{repository_id}/refs?filter=heads/{nome_branch}&api-version=7.0"
                 refs_response_destino = requests.get(refs_url_destino, headers=headers, timeout=30)
                 refs_response_destino.raise_for_status()
@@ -194,12 +193,10 @@ def processar_branch_azure(
                 if not refs_data_destino.get('value'):
                     raise Exception(f"Branch '{nome_branch}' não encontrada ao tentar atualizar SHA para retry do push.")
                 current_commit_id = refs_data_destino['value'][0]['objectId']
-                print(f"[DEBUG][AZURE] Novo current_commit_id para retry: {current_commit_id}")
                 push_payload['refUpdates'][0]['oldObjectId'] = current_commit_id
                 push_attempt += 1
                 continue
             else:
-                print(f"[ERRO][AZURE] Erro ao fazer push (commit): {push_response.status_code} - {push_response.text}")
                 raise Exception(f"Erro ao fazer push (commit): {push_response.status_code} - {push_response.text}")
         if commit_url and BaseCommitter._validate_commit_url(commit_url):
             resultado_branch['commit_url'] = commit_url
@@ -208,7 +205,6 @@ def processar_branch_azure(
         tentativas = 0
         while tentativas < 2:
             try:
-                print(f"[DEBUG][AZURE] Criando Pull Request de '{nome_branch}' para '{branch_alvo_do_pr}'")
                 pr_url = f"{base_url}/git/repositories/{repository_id}/pullrequests?api-version=7.0"
                 pr_payload = {
                     "sourceRefName": f"refs/heads/{nome_branch}",
@@ -217,31 +213,23 @@ def processar_branch_azure(
                     "description": descricao_pr
                 }
                 pr_response = requests.post(pr_url, headers=headers, json=pr_payload, timeout=30)
-                print(f"[LOG][AZURE] pr_response.status_code: {pr_response.status_code}, pr_response.text: {pr_response.text}")
                 if pr_response.status_code in [200, 201]:
                     pr_data = pr_response.json()
-                    print(f"[DEBUG][AZURE] pr_response.status_code: {pr_response.status_code}")
-                    print(f"[DEBUG][AZURE] pr_data COMPLETO: {json.dumps(pr_data, indent=2, default=str)}")
                     pull_request_id = pr_data.get('pullRequestId')
                     if pull_request_id and organization and project and repo_name:
                         pr_web_url = build_pr_ui_url(organization, project, repo_name, pull_request_id)
-                        print(f"[DEBUG][AZURE] pr_web_url construído manualmente: {pr_web_url}")
                     else:
                         pr_web_url = None
-                        print(f"[ERRO][AZURE] Não foi possível construir a URL de UI do PR: pullRequestId={pull_request_id}, organization={organization}, project={project}, repo_name={repo_name}")
                     if not pr_web_url or not isinstance(pr_web_url, str) or not pr_web_url.strip():
-                        print(f"[ERRO][AZURE] pr_web_url extraído está vazio. pr_data: {pr_data}")
                         BaseCommitter._finalizar_resultado_erro(resultado_branch, f"PR criado mas web_url inválido: {json.dumps(pr_data, default=str)}")
                         break
                     BaseCommitter._finalizar_resultado_sucesso(resultado_branch, pr_web_url.strip())
                     break
                 else:
                     if "already exists" in pr_response.text.lower():
-                        print(f"AVISO: PR para esta branch Azure já existe.")
                         try:
                             BaseCommitter._finalizar_resultado_sucesso(resultado_branch, message="PR já existente.")
                         except ValueError as ve:
-                            print(f"[ERRO][AZURE] PR já existente mas pr_url inválido. Tentando retry com sufixo aleatório.")
                             sufixo = _gerar_sufixo_aleatorio()
                             novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
                             mensagem_pr = novo_titulo
@@ -249,21 +237,18 @@ def processar_branch_azure(
                             continue
                         break
                     else:
-                        print(f"[ERRO][AZURE] Erro ao criar PR Azure: {pr_response.status_code} - {pr_response.text}")
-                        raise Exception(f"Erro ao criar PR Azure: {pr_response.status_code} - {pr_response.text}")
+                        BaseCommitter._finalizar_resultado_erro(resultado_branch, f"Erro ao criar PR Azure: {pr_response.status_code} - {pr_response.text}")
+                        break
             except ValueError as ve:
-                print(f"[ERRO][AZURE] PR retornado sem web_url ou web_url inválido.")
                 if tentativas == 0:
                     sufixo = _gerar_sufixo_aleatorio()
                     novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
-                    print(f"[AZURE][RETRY] Tentando criar PR novamente com título modificado: {novo_titulo}")
                     mensagem_pr = novo_titulo
                     tentativas += 1
                     continue
                 else:
                     raise
             except Exception as e:
-                print(f"[ERRO][AZURE] Falha crítica ao criar PR: {e}")
                 BaseCommitter._finalizar_resultado_erro(resultado_branch, f"Erro crítico ao validar PR: {e}")
                 break
     except Exception as e:

--- a/tools/repo_committers/github_committer.py
+++ b/tools/repo_committers/github_committer.py
@@ -2,6 +2,7 @@ from github import GithubException, UnknownObjectException
 from typing import Dict, Any, List
 from tools.repo_committers.base_committer import BaseCommitter
 from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
+from tools.repo_committers.path_validator import PathValidator
 import json
 import random
 import string
@@ -35,36 +36,31 @@ def processar_branch_github(
         return resultado_branch
     commits_realizados = 0
     commit_url = None
-    try:
-        ref_base = repo.get_git_ref(f"heads/{branch_de_origem}")
-        repo.create_git_ref(ref=f"refs/heads/{nome_branch}", sha=ref_base.object.sha)
-        print(f"Branch '{nome_branch}' criada a partir de '{branch_de_origem}'.")
-    except GithubException as e:
-        if e.status == 422 and "Reference already exists" in str(e.data):
-            print(f"AVISO: A branch '{nome_branch}' já existe. Commits serão adicionados a ela.")
-        else:
-            raise
-    print(f"Iniciando aplicação de {len(conjunto_de_mudancas)} mudanças...")
     mudancas_validas = BaseCommitter._processar_mudancas_comuns(conjunto_de_mudancas, resultado_branch)
-    for mudanca in mudancas_validas:
+    for idx, mudanca in enumerate(mudancas_validas):
         caminho = mudanca["caminho"]
+        try:
+            caminho_validado = PathValidator.validate_path(caminho)
+        except Exception as e:
+            print(f"[ERRO][GITHUB][processar_branch_github] Mudança {idx}: caminho inválido: '{caminho}'. Erro: {e}")
+            continue
         status = mudanca["status"]
         conteudo = mudanca["conteudo"]
         try:
             sha_arquivo_existente = None
             arquivo_existente = None
             try:
-                arquivo_existente = repo.get_contents(caminho, ref=nome_branch)
+                arquivo_existente = repo.get_contents(caminho_validado, ref=nome_branch)
                 sha_arquivo_existente = arquivo_existente.sha
             except UnknownObjectException:
                 pass
             if status in ("ADICIONADO", "CRIADO"):
                 if sha_arquivo_existente:
-                    print(f"  [AVISO] Arquivo '{caminho}' marcado como ADICIONADO já existe. Será tratado como MODIFICADO.")
-                    commit_response = repo.update_file(path=caminho, message=f"refactor: {caminho}", content=conteudo or "", sha=sha_arquivo_existente, branch=nome_branch)
+                    print(f"  [AVISO] Arquivo '{caminho_validado}' marcado como ADICIONADO já existe. Será tratado como MODIFICADO.")
+                    commit_response = repo.update_file(path=caminho_validado, message=f"refactor: {caminho_validado}", content=conteudo or "", sha=sha_arquivo_existente, branch=nome_branch)
                 else:
-                    commit_response = repo.create_file(path=caminho, message=f"feat: {caminho}", content=conteudo or "", branch=nome_branch)
-                print(f"  [CRIADO/MODIFICADO] {caminho}")
+                    commit_response = repo.create_file(path=caminho_validado, message=f"feat: {caminho_validado}", content=conteudo or "", branch=nome_branch)
+                print(f"  [CRIADO/MODIFICADO] {caminho_validado}")
                 commits_realizados += 1
                 if commit_response and 'commit' in commit_response and hasattr(commit_response['commit'], 'html_url'):
                     commit_url_candidate = getattr(commit_response['commit'], 'html_url', None)
@@ -76,13 +72,13 @@ def processar_branch_github(
                         commit_url = commit_url_candidate
             elif status == "MODIFICADO":
                 if not sha_arquivo_existente or not arquivo_existente:
-                    print(f"  [ERRO] Arquivo '{caminho}' marcado como MODIFICADO não foi encontrado na branch. Ignorando.")
+                    print(f"  [ERRO] Arquivo '{caminho_validado}' marcado como MODIFICADO não foi encontrado na branch. Ignorando.")
                     continue
                 if modo_adicao_incremental:
                     conteudo_existente = arquivo_existente.decoded_content.decode('utf-8')
                     conteudo = BaseCommitter._mesclar_conteudo(conteudo_existente, conteudo)
-                commit_response = repo.update_file(path=caminho, message=f"refactor: {caminho}", content=conteudo or "", sha=sha_arquivo_existente, branch=nome_branch)
-                print(f"  [MODIFICADO] {caminho}")
+                commit_response = repo.update_file(path=caminho_validado, message=f"refactor: {caminho_validado}", content=conteudo or "", sha=sha_arquivo_existente, branch=nome_branch)
+                print(f"  [MODIFICADO] {caminho_validado}")
                 commits_realizados += 1
                 if commit_response and 'commit' in commit_response and hasattr(commit_response['commit'], 'html_url'):
                     commit_url_candidate = getattr(commit_response['commit'], 'html_url', None)
@@ -94,10 +90,10 @@ def processar_branch_github(
                         commit_url = commit_url_candidate
             elif status == "REMOVIDO":
                 if not sha_arquivo_existente:
-                    print(f"  [AVISO] Arquivo '{caminho}' marcado como REMOVIDO já não existe. Ignorando.")
+                    print(f"  [AVISO] Arquivo '{caminho_validado}' marcado como REMOVIDO já não existe. Ignorando.")
                     continue
-                commit_response = repo.delete_file(path=caminho, message=f"refactor: remove {caminho}", sha=sha_arquivo_existente, branch=nome_branch)
-                print(f"  [REMOVIDO] {caminho}")
+                commit_response = repo.delete_file(path=caminho_validado, message=f"refactor: remove {caminho_validado}", sha=sha_arquivo_existente, branch=nome_branch)
+                print(f"  [REMOVIDO] {caminho_validado}")
                 commits_realizados += 1
                 if commit_response and 'commit' in commit_response and hasattr(commit_response['commit'], 'html_url'):
                     commit_url_candidate = getattr(commit_response['commit'], 'html_url', None)
@@ -108,11 +104,11 @@ def processar_branch_github(
                     if commit_url_candidate and BaseCommitter._validate_commit_url(commit_url_candidate):
                         commit_url = commit_url_candidate
             else:
-                print(f"  [AVISO] Status '{status}' não reconhecido para o arquivo '{caminho}'. Ignorando.")
+                print(f"  [AVISO] Status '{status}' não reconhecido para o arquivo '{caminho_validado}'. Ignorando.")
         except GithubException as e:
-            print(f"ERRO ao processar o arquivo '{caminho}': {e.data.get('message', str(e))}")
+            print(f"ERRO ao processar o arquivo '{caminho_validado}': {e.data.get('message', str(e))}")
         except Exception as e:
-            print(f"ERRO inesperado ao processar o arquivo '{caminho}': {e}")
+            print(f"ERRO inesperado ao processar o arquivo '{caminho_validado}': {e}")
     if commit_url and BaseCommitter._validate_commit_url(commit_url):
         resultado_branch['commit_url'] = commit_url
     else:

--- a/tools/repo_committers/gitlab_committer.py
+++ b/tools/repo_committers/gitlab_committer.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, List
 from tools.repo_committers.base_committer import BaseCommitter
 from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
+from tools.repo_committers.path_validator import PathValidator
 import json
 import random
 import string
@@ -34,143 +35,123 @@ def processar_branch_gitlab(
         return resultado_branch
     commits_realizados = 0
     last_commit_id = None
-    try:
-        print(f"[DEBUG][GITLAB] Iniciando criação da branch: {nome_branch} a partir de {branch_de_origem}")
+    mudancas_validas = BaseCommitter._processar_mudancas_comuns(conjunto_de_mudancas, resultado_branch)
+    for idx, mudanca in enumerate(mudancas_validas):
+        caminho = mudanca["caminho"]
         try:
-            print(f"[DEBUG][GITLAB] Chamando repo.branches.create com parâmetros: {{'branch': '{nome_branch}', 'ref': '{branch_de_origem}'}}")
-            repo.branches.create({'branch': nome_branch, 'ref': branch_de_origem})
-            print(f"[DEBUG][GITLAB] Branch GitLab '{nome_branch}' criada com sucesso.")
+            caminho_validado = PathValidator.validate_path(caminho)
         except Exception as e:
-            print(f"[DEBUG][GITLAB] Exceção ao criar branch: {type(e).__name__}: {str(e)}")
-            if "already exists" in str(e).lower():
-                print(f"AVISO: A branch GitLab '{nome_branch}' já existe. Commits serão adicionados a ela.")
+            print(f"[ERRO][GITLAB][processar_branch_gitlab] Mudança {idx}: caminho inválido: '{caminho}'. Erro: {e}")
+            continue
+        status = mudanca["status"]
+        conteudo = mudanca["conteudo"]
+        try:
+            commit_id = None
+            if status in ("ADICIONADO", "CRIADO"):
+                dados_criacao = {
+                    'file_path': caminho_validado,
+                    'branch': nome_branch,
+                    'content': conteudo or "",
+                    'commit_message': f"feat: Cria {caminho_validado}"
+                }
+                file_obj = repo.files.create(dados_criacao)
+                commits_realizados += 1
+                if hasattr(file_obj, 'commit_id'):
+                    commit_id = getattr(file_obj, 'commit_id', None)
+            elif status == "MODIFICADO":
+                arquivo = repo.files.get(file_path=caminho_validado, ref=nome_branch)
+                conteudo_existente = arquivo.decode().decode('utf-8') if hasattr(arquivo, 'decode') else arquivo.content
+                if modo_adicao_incremental:
+                    conteudo = BaseCommitter._mesclar_conteudo(conteudo_existente, conteudo)
+                arquivo.content = conteudo or ""
+                arquivo.save(branch=nome_branch, commit_message=f"refactor: Modifica {caminho_validado}")
+                commits_realizados += 1
+                if hasattr(arquivo, 'commit_id'):
+                    commit_id = getattr(arquivo, 'commit_id', None)
+            elif status == "REMOVIDO":
+                delete_result = repo.files.delete(file_path=caminho_validado,
+                                  branch=nome_branch,
+                                  commit_message=f"refactor: Remove {caminho_validado}")
+                commits_realizados += 1
+                if isinstance(delete_result, dict) and 'commit_id' in delete_result:
+                    commit_id = delete_result['commit_id']
             else:
-                print(f"[ERRO][GITLAB] Falha crítica ao criar branch: {e}")
-                raise
-        print(f"[DEBUG][GITLAB] Iniciando aplicação de {len(conjunto_de_mudancas)} mudanças no GitLab...")
-        mudancas_validas = BaseCommitter._processar_mudancas_comuns(conjunto_de_mudancas, resultado_branch)
-        for i, mudanca in enumerate(mudancas_validas):
-            print(f"[DEBUG][GITLAB] Processando mudança {i+1}/{len(mudancas_validas)}")
-            caminho = mudanca["caminho"]
-            status = mudanca["status"]
-            conteudo = mudanca["conteudo"]
-            print(f"[DEBUG][GITLAB] Mudança: arquivo='{caminho}', status='{status}', conteudo_length={len(conteudo) if conteudo else 0}")
+                print(f"  [AVISO] Status '{status}' não reconhecido para o arquivo GitLab '{caminho_validado}'. Ignorando.")
+            if commit_id:
+                last_commit_id = commit_id
+        except Exception as file_e:
+            print(f"[ERRO][GITLAB] Erro ao processar o arquivo '{caminho_validado}': {type(file_e).__name__}: {file_e}")
+            import traceback
+            traceback.print_exc()
+    if last_commit_id:
+        repo_web_url = getattr(repo, 'web_url', None)
+        commit_url_candidate = f"{repo_web_url}/-/commit/{last_commit_id}" if repo_web_url and last_commit_id else None
+        if commit_url_candidate and BaseCommitter._validate_commit_url(commit_url_candidate):
+            resultado_branch['commit_url'] = commit_url_candidate
+        else:
+            resultado_branch['commit_url'] = None
+    print(f"[DEBUG][GITLAB] Commits realizados: {commits_realizados}")
+    if commits_realizados > 0:
+        tentativas = 0
+        while tentativas < 2:
             try:
-                commit_id = None
-                if status in ("ADICIONADO", "CRIADO"):
-                    print(f"[DEBUG][GITLAB] Chamando repo.files.create para {caminho}")
-                    dados_criacao = {
-                        'file_path': caminho,
-                        'branch': nome_branch,
-                        'content': conteudo or "",
-                        'commit_message': f"feat: Cria {caminho}"
-                    }
-                    file_obj = repo.files.create(dados_criacao)
-                    commits_realizados += 1
-                    if hasattr(file_obj, 'commit_id'):
-                        commit_id = getattr(file_obj, 'commit_id', None)
-                elif status == "MODIFICADO":
-                    print(f"[DEBUG][GITLAB] Buscando arquivo para modificar: {caminho}")
-                    arquivo = repo.files.get(file_path=caminho, ref=nome_branch)
-                    conteudo_existente = arquivo.decode().decode('utf-8') if hasattr(arquivo, 'decode') else arquivo.content
-                    if modo_adicao_incremental:
-                        conteudo = BaseCommitter._mesclar_conteudo(conteudo_existente, conteudo)
-                    arquivo.content = conteudo or ""
-                    arquivo.save(branch=nome_branch, commit_message=f"refactor: Modifica {caminho}")
-                    commits_realizados += 1
-                    if hasattr(arquivo, 'commit_id'):
-                        commit_id = getattr(arquivo, 'commit_id', None)
-                elif status == "REMOVIDO":
-                    print(f"[DEBUG][GITLAB] Chamando repo.files.delete para {caminho}")
-                    delete_result = repo.files.delete(file_path=caminho,
-                                      branch=nome_branch,
-                                      commit_message=f"refactor: Remove {caminho}")
-                    commits_realizados += 1
-                    if isinstance(delete_result, dict) and 'commit_id' in delete_result:
-                        commit_id = delete_result['commit_id']
-                else:
-                    print(f"  [AVISO] Status '{status}' não reconhecido para o arquivo GitLab '{caminho}'. Ignorando.")
-                if commit_id:
-                    last_commit_id = commit_id
-            except Exception as file_e:
-                print(f"[ERRO][GITLAB] Erro ao processar o arquivo '{caminho}': {type(file_e).__name__}: {file_e}")
-                import traceback
-                traceback.print_exc()
-        if last_commit_id:
-            repo_web_url = getattr(repo, 'web_url', None)
-            commit_url_candidate = f"{repo_web_url}/-/commit/{last_commit_id}" if repo_web_url and last_commit_id else None
-            if commit_url_candidate and BaseCommitter._validate_commit_url(commit_url_candidate):
-                resultado_branch['commit_url'] = commit_url_candidate
-            else:
-                resultado_branch['commit_url'] = None
-        print(f"[DEBUG][GITLAB] Commits realizados: {commits_realizados}")
-        if commits_realizados > 0:
-            tentativas = 0
-            while tentativas < 2:
-                try:
-                    print(f"\n[DEBUG][GITLAB] Criando Merge Request de '{nome_branch}' para '{branch_alvo_do_pr}'...")
-                    mr_result = repo.mergerequests.create({
-                        'source_branch': nome_branch,
-                        'target_branch': branch_alvo_do_pr,
-                        'title': mensagem_pr,
-                        'description': descricao_pr or "Refatoração automática gerada pela plataforma de agentes de IA."
-                    })
-                    print(f"[DEBUG][GITLAB] Tipo do objeto mr_result: {type(mr_result)}")
-                    print(f"[DEBUG][GITLAB] Atributos do objeto mr_result: {dir(mr_result)}")
-                    print(f"[DEBUG][GITLAB] mr_result.__dict__: {mr_result.__dict__}")
-                    print(f"[DEBUG][GITLAB] mr_result.web_url (direto): {getattr(mr_result, 'web_url', None)}")
-                    print(f"[DEBUG][GITLAB] mr_result.web_url ANTES de validação: {getattr(mr_result, 'web_url', 'ATRIBUTO NÃO ENCONTRADO')}")
-                    if not hasattr(mr_result, 'web_url') or mr_result.web_url is None or not isinstance(mr_result.web_url, str) or not mr_result.web_url.strip():
-                        print(f"[ERRO][GITLAB] MR criado mas web_url inválido: {json.dumps(mr_result.__dict__, default=str)}")
-                        BaseCommitter._finalizar_resultado_erro(resultado_branch, f"MR criado mas web_url inválido: {json.dumps(mr_result.__dict__, default=str)}")
-                        break
-                    BaseCommitter._finalizar_resultado_sucesso(resultado_branch, mr_result.web_url.strip())
+                print(f"\n[DEBUG][GITLAB] Criando Merge Request de '{nome_branch}' para '{branch_alvo_do_pr}'...")
+                mr_result = repo.mergerequests.create({
+                    'source_branch': nome_branch,
+                    'target_branch': branch_alvo_do_pr,
+                    'title': mensagem_pr,
+                    'description': descricao_pr or "Refatoração automática gerada pela plataforma de agentes de IA."
+                })
+                print(f"[DEBUG][GITLAB] Tipo do objeto mr_result: {type(mr_result)}")
+                print(f"[DEBUG][GITLAB] Atributos do objeto mr_result: {dir(mr_result)}")
+                print(f"[DEBUG][GITLAB] mr_result.__dict__: {mr_result.__dict__}")
+                print(f"[DEBUG][GITLAB] mr_result.web_url (direto): {getattr(mr_result, 'web_url', None)}")
+                print(f"[DEBUG][GITLAB] mr_result.web_url ANTES de validação: {getattr(mr_result, 'web_url', 'ATRIBUTO NÃO ENCONTRADO')}")
+                if not hasattr(mr_result, 'web_url') or mr_result.web_url is None or not isinstance(mr_result.web_url, str) or not mr_result.web_url.strip():
+                    print(f"[ERRO][GITLAB] MR criado mas web_url inválido: {json.dumps(mr_result.__dict__, default=str)}")
+                    BaseCommitter._finalizar_resultado_erro(resultado_branch, f"MR criado mas web_url inválido: {json.dumps(mr_result.__dict__, default=str)}")
                     break
-                except ValueError as ve:
-                    print(f"[ERRO][GITLAB] Objeto MR retornado sem web_url ou web_url inválido: {getattr(mr_result, 'web_url', None)}")
-                    print(f"[ERRO][GITLAB] Detalhes do objeto MR: {mr_result.__dict__}")
-                    if tentativas == 0:
+                BaseCommitter._finalizar_resultado_sucesso(resultado_branch, mr_result.web_url.strip())
+                break
+            except ValueError as ve:
+                print(f"[ERRO][GITLAB] Objeto MR retornado sem web_url ou web_url inválido: {getattr(mr_result, 'web_url', None)}")
+                print(f"[ERRO][GITLAB] Detalhes do objeto MR: {mr_result.__dict__}")
+                if tentativas == 0:
+                    sufixo = _gerar_sufixo_aleatorio()
+                    novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
+                    print(f"[GITLAB][RETRY] Tentando criar MR novamente com título modificado: {novo_titulo}")
+                    mensagem_pr = novo_titulo
+                    tentativas += 1
+                    continue
+                else:
+                    raise
+            except Exception as mr_e:
+                print(f"[ERRO][GITLAB] Exceção ao criar MR: {type(mr_e).__name__}: {mr_e}")
+                if "already exists" in str(mr_e).lower():
+                    mrs = repo.mergerequests.list(state='opened', source_branch=nome_branch, target_branch=branch_alvo_do_pr)
+                    mr_url = mrs[0].web_url if mrs else "URL não encontrada"
+                    print(f"AVISO: MR para esta branch GitLab já existe. URL: {mr_url}")
+                    try:
+                        BaseCommitter._finalizar_resultado_sucesso(resultado_branch, mr_url, "MR já existente.")
+                    except ValueError as ve:
+                        print(f"[ERRO][GITLAB] MR já existente mas web_url inválido. Tentando retry com sufixo aleatório.")
                         sufixo = _gerar_sufixo_aleatorio()
                         novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
-                        print(f"[GITLAB][RETRY] Tentando criar MR novamente com título modificado: {novo_titulo}")
                         mensagem_pr = novo_titulo
-                        tentativas += 1
                         continue
-                    else:
-                        raise
-                except Exception as mr_e:
-                    print(f"[ERRO][GITLAB] Exceção ao criar MR: {type(mr_e).__name__}: {mr_e}")
-                    if "already exists" in str(mr_e).lower():
-                        mrs = repo.mergerequests.list(state='opened', source_branch=nome_branch, target_branch=branch_alvo_do_pr)
-                        mr_url = mrs[0].web_url if mrs else "URL não encontrada"
-                        print(f"AVISO: MR para esta branch GitLab já existe. URL: {mr_url}")
-                        try:
-                            BaseCommitter._finalizar_resultado_sucesso(resultado_branch, mr_url, "MR já existente.")
-                        except ValueError as ve:
-                            print(f"[ERRO][GITLAB] MR já existente mas web_url inválido. Tentando retry com sufixo aleatório.")
-                            sufixo = _gerar_sufixo_aleatorio()
-                            novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
-                            mensagem_pr = novo_titulo
-                            continue
-                        break
-                    else:
-                        print(f"ERRO ao criar MR GitLab para '{nome_branch}': {mr_e}")
-                        BaseCommitter._finalizar_resultado_erro(resultado_branch, f"Erro ao criar MR: {mr_e}")
-                        break
-        else:
-            print(f"\nNenhum commit realizado para a branch GitLab '{nome_branch}'. Pulando criação do MR.")
-            try:
-                BaseCommitter._finalizar_resultado_sucesso(resultado_branch, pr_url=f"MR criado para branch: {nome_branch}", message="Nenhuma mudança para commitar.")
-            except ValueError as ve:
-                print(f"[ERRO][GITLAB] MR vazio mas web_url inválido. Tentando retry com sufixo aleatório.")
-                sufixo = _gerar_sufixo_aleatorio()
-                novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
-                mensagem_pr = novo_titulo
-                BaseCommitter._finalizar_resultado_sucesso(resultado_branch, pr_url=f"MR criado para branch: {nome_branch}-{sufixo}", message="Nenhuma mudança para commitar.")
-    except Exception as e:
-        print(f"[ERRO][GITLAB] ERRO FATAL ao processar branch GitLab '{nome_branch}': {type(e).__name__}: {e}")
-        import traceback
-        traceback.print_exc()
-        BaseCommitter._finalizar_resultado_erro(resultado_branch, f"Erro fatal: {e}")
-    print(f"[DEBUG][GITLAB] Resultado final da branch {nome_branch}: {resultado_branch}")
+                    break
+                else:
+                    print(f"ERRO ao criar MR GitLab para '{nome_branch}': {mr_e}")
+                    BaseCommitter._finalizar_resultado_erro(resultado_branch, f"Erro ao criar MR: {mr_e}")
+                    break
+    else:
+        print(f"\nNenhum commit realizado para a branch GitLab '{nome_branch}'. Pulando criação do MR.")
+        try:
+            BaseCommitter._finalizar_resultado_sucesso(resultado_branch, pr_url=f"MR criado para branch: {nome_branch}", message="Nenhuma mudança para commitar.")
+        except ValueError as ve:
+            print(f"[ERRO][GITLAB] MR vazio mas web_url inválido. Tentando retry com sufixo aleatório.")
+            sufixo = _gerar_sufixo_aleatorio()
+            novo_titulo = f"{mensagem_pr}-retry-{sufixo}"
+            mensagem_pr = novo_titulo
+            BaseCommitter._finalizar_resultado_sucesso(resultado_branch, pr_url=f"MR criado para branch: {nome_branch}-{sufixo}", message="Nenhuma mudança para commitar.")
     return resultado_branch


### PR DESCRIPTION
Em cada committer, antes do processamento das mudanças, os caminhos são validados e normalizados. Mudanças com caminhos inválidos são ignoradas com logs claros. Isso previne que mudanças com caminho None ou inválido sejam processadas, eliminando erros de duplicidade e falhas na criação de PR/MR.