### PR TITLE
Implementação do método format_incremental_result_for_commit na classe DataFormatter.

### DIFF
--- a/services/data_formatter.py
+++ b/services/data_formatter.py
@@ -18,3 +18,16 @@ class DataFormatter:
                 mudancas_invalidas.append({"indice": idx, "caminho": caminho, "erro": str(e)})
         print(f"[DataFormatter][format_data] job_id={job_id}: {len(mudancas_validas)} mudanças validadas, {len(mudancas_invalidas)} rejeitadas.")
         return mudancas_validas
+
+    def format_incremental_result_for_commit(self, final_result):
+        # Se já está no formato esperado (tem 'grupos' que é lista de dicts), retorna direto
+        if isinstance(final_result, dict) and 'grupos' in final_result and isinstance(final_result['grupos'], list):
+            return final_result
+        # Caso contrário, encapsula em um grupo único
+        grupo = {
+            "titulo_pr": final_result.get("resumo_geral", "Implementação incremental"),
+            "resumo_do_pr": final_result.get("resumo_geral", "Implementação incremental"),
+            "branch_sugerida": "implementacao-incremental",
+            "conjunto_de_mudancas": final_result.get("conjunto_de_mudancas", [])
+        }
+        return {"grupos": [grupo]}


### PR DESCRIPTION
Adicionado o método format_incremental_result_for_commit na classe DataFormatter para formatar o resultado incremental para commit, encapsulando o resultado em um grupo quando necessário.