### PR TITLE
Adição do método format_incremental_result_for_commit à classe DataFormatter

### DIFF
--- a/services/data_formatter.py
+++ b/services/data_formatter.py
@@ -20,10 +20,8 @@ class DataFormatter:
         return mudancas_validas
 
     def format_incremental_result_for_commit(self, final_result):
-        # Se já está no formato esperado (tem 'grupos' que é lista de dicts), retorna direto
         if isinstance(final_result, dict) and 'grupos' in final_result and isinstance(final_result['grupos'], list):
             return final_result
-        # Caso contrário, encapsula em um grupo único
         grupo = {
             "titulo_pr": final_result.get("resumo_geral", "Implementação incremental"),
             "resumo_do_pr": final_result.get("resumo_geral", "Implementação incremental"),


### PR DESCRIPTION
Inclui o método format_incremental_result_for_commit na classe DataFormatter para formatar resultados incrementais no padrão esperado, facilitando o uso no workflow.