### PR TITLE
Implementação do passo 7: adicionados logs detalhados no método merge_all_batches para rastrear batch_results e conjunto_de_mudancas, e garantia de retorno de estrutura válida (mesmo que vazia) caso batch_results esteja vazio ou malformado.

### DIFF
--- a/services/incremental_step_executor_service.py
+++ b/services/incremental_step_executor_service.py
@@ -49,7 +49,6 @@ class IncrementalStepExecutorService:
         for idx, step in enumerate(steps):
             step_path = StepDependencyAnalyzer._normalize_path(step.get('Caminho do Arquivo', ''))
             print(f"[INCREMENTAL][DEBUG] Iteração {idx}: step_path='{step_path}'")
-            # Se step_path já está mapeado, adicionar ao batch existente
             if step_path in file_to_batch_index:
                 batch_idx = file_to_batch_index[step_path]
                 if batch_idx < len(batches):
@@ -60,21 +59,18 @@ class IncrementalStepExecutorService:
                 else:
                     print(f"[INCREMENTAL][ERRO] batch_idx {batch_idx} fora do range de batches (len={len(batches)}), step {idx+1}")
                 continue
-            # Se batch atual está vazio, iniciar
             if not current_batch:
                 current_batch.append(step)
                 if step_path:
                     current_batch_paths.add(step_path)
                 print(f"[INCREMENTAL][DEBUG] Novo current_batch iniciado com step {idx+1}, arquivos: {list(current_batch_paths)}")
                 continue
-            # Se batch atual não atingiu o limite, adicionar
             if len(current_batch) < max_steps_per_batch:
                 current_batch.append(step)
                 if step_path:
                     current_batch_paths.add(step_path)
                 print(f"[INCREMENTAL][DEBUG] Step {idx+1} adicionado ao current_batch, tamanho atual: {len(current_batch)}")
                 continue
-            # Fechar batch atual e iniciar novo
             batches.append(current_batch)
             for p in current_batch_paths:
                 file_to_batch_index[p] = len(batches) - 1
@@ -96,8 +92,15 @@ class IncrementalStepExecutorService:
 
     @staticmethod
     def merge_all_batches(batch_results: List[Dict]) -> Dict[str, any]:
+        print(f"[INCREMENTAL][MERGE] batch_results recebido para merge_all_batches: {json.dumps(batch_results, default=str) if batch_results else '[]'}")
         resumo_geral = []
         conjunto_de_mudancas = []
+        if not batch_results or not isinstance(batch_results, list):
+            print(f"[INCREMENTAL][MERGE][AVISO] batch_results está vazio ou malformado. Retornando estrutura padrão vazia.")
+            return {
+                "resumo_geral": "",
+                "conjunto_de_mudancas": []
+            }
         for batch in batch_results:
             if not isinstance(batch, dict):
                 continue
@@ -107,7 +110,9 @@ class IncrementalStepExecutorService:
             batch_mudancas = batch.get("conjunto_de_mudancas")
             if isinstance(batch_mudancas, list):
                 conjunto_de_mudancas.extend(batch_mudancas)
+        print(f"[INCREMENTAL][MERGE] conjunto_de_mudancas antes da consolidação: {json.dumps(conjunto_de_mudancas, default=str)}")
         conjunto_de_mudancas = ChangeConsolidatorService.consolidate_changes(conjunto_de_mudancas)
+        print(f"[INCREMENTAL][MERGE] conjunto_de_mudancas após consolidação: {json.dumps(conjunto_de_mudancas, default=str)}")
         return {
             "resumo_geral": " ".join(resumo_geral).strip(),
             "conjunto_de_mudancas": conjunto_de_mudancas


### PR DESCRIPTION
No arquivo services/incremental_step_executor_service.py, o método merge_all_batches foi aprimorado para incluir logs detalhados que exibem os dados recebidos e o estado antes e depois da consolidação das mudanças. Também foi garantido que a função retorne uma estrutura padrão válida mesmo quando os dados de entrada estiverem vazios ou incorretos.