### PR TITLE
Correção no método format_incremental_result_for_commit para lidar com conjunto_de_mudancas vazio

### DIFF
--- a/services/data_formatter.py
+++ b/services/data_formatter.py
@@ -20,14 +20,16 @@ class DataFormatter:
         return mudancas_validas
 
     def format_incremental_result_for_commit(self, final_result):
-        # Se já está no formato esperado (tem 'grupos' que é lista de dicts), retorna direto
         if isinstance(final_result, dict) and 'grupos' in final_result and isinstance(final_result['grupos'], list):
             return final_result
-        # Caso contrário, encapsula em um grupo único
+        conjunto_de_mudancas = final_result.get("conjunto_de_mudancas", [])
+        if not conjunto_de_mudancas:
+            print("[AVISO][DataFormatter][format_incremental_result_for_commit] conjunto_de_mudancas está vazio após consolidação. Será gerada estrutura com grupos como lista vazia.")
+            return {"grupos": []}
         grupo = {
             "titulo_pr": final_result.get("resumo_geral", "Implementação incremental"),
             "resumo_do_pr": final_result.get("resumo_geral", "Implementação incremental"),
             "branch_sugerida": "implementacao-incremental",
-            "conjunto_de_mudancas": final_result.get("conjunto_de_mudancas", [])
+            "conjunto_de_mudancas": conjunto_de_mudancas
         }
         return {"grupos": [grupo]}


### PR DESCRIPTION
Implementado o passo 8 do relatório, garantindo que quando conjunto_de_mudancas estiver vazio após a consolidação, a estrutura retornada contenha grupos como uma lista vazia e um aviso seja logado. Essa alteração está em services/data_formatter.py no método format_incremental_result_for_commit.