### PR TITLE
Normalização das chaves de caminho para 'caminho' e validação com PathValidator no DataFormatter.

### DIFF
--- a/services/data_formatter.py
+++ b/services/data_formatter.py
@@ -8,7 +8,19 @@ class DataFormatter:
         mudancas_validas = []
         mudancas_invalidas = []
         for idx, mudanca in enumerate(conjunto_de_mudancas):
-            caminho = mudanca.get("caminho")
+            # Normalização de chaves de caminho (passo 1 do relatório)
+            caminho = None
+            if 'caminho' in mudanca:
+                caminho = mudanca['caminho']
+            elif 'caminho_do_arquivo' in mudanca:
+                caminho = mudanca['caminho_do_arquivo']
+                mudanca['caminho'] = caminho
+            elif 'path' in mudanca:
+                caminho = mudanca['path']
+                mudanca['caminho'] = caminho
+            else:
+                caminho = None
+                mudanca['caminho'] = None
             try:
                 caminho_validado = PathValidator.validate_path(caminho)
                 mudanca["caminho"] = caminho_validado
@@ -21,11 +33,27 @@ class DataFormatter:
 
     def format_incremental_result_for_commit(self, final_result):
         if isinstance(final_result, dict) and 'grupos' in final_result and isinstance(final_result['grupos'], list):
+            # Normalização de chaves de caminho para todos os grupos (passo 1)
+            for grupo in final_result['grupos']:
+                if 'conjunto_de_mudancas' in grupo and isinstance(grupo['conjunto_de_mudancas'], list):
+                    for mudanca in grupo['conjunto_de_mudancas']:
+                        if 'caminho' not in mudanca:
+                            if 'caminho_do_arquivo' in mudanca:
+                                mudanca['caminho'] = mudanca['caminho_do_arquivo']
+                            elif 'path' in mudanca:
+                                mudanca['caminho'] = mudanca['path']
             return final_result
         conjunto_de_mudancas = final_result.get("conjunto_de_mudancas", [])
         if not conjunto_de_mudancas:
             print("[AVISO][DataFormatter][format_incremental_result_for_commit] conjunto_de_mudancas está vazio após consolidação. Será gerada estrutura com grupos como lista vazia.")
             return {"grupos": []}
+        # Normalização de chaves de caminho (passo 1)
+        for mudanca in conjunto_de_mudancas:
+            if 'caminho' not in mudanca:
+                if 'caminho_do_arquivo' in mudanca:
+                    mudanca['caminho'] = mudanca['caminho_do_arquivo']
+                elif 'path' in mudanca:
+                    mudanca['caminho'] = mudanca['path']
         grupo = {
             "titulo_pr": final_result.get("resumo_geral", "Implementação incremental"),
             "resumo_do_pr": final_result.get("resumo_geral", "Implementação incremental"),


### PR DESCRIPTION
Implementada a normalização das chaves de caminho ('caminho_do_arquivo', 'path') para 'caminho' antes da validação, conforme passo 1 do relatório. Isso evita erros de caminho None no fluxo de commit e garante que o PathValidator receba sempre a chave correta.