### PR TITLE
Ajustada chamada para validação/criação da branch para garantir que commit tenha referência válida.

### DIFF
--- a/tools/repo_committers/github_committer.py
+++ b/tools/repo_committers/github_committer.py
@@ -34,6 +34,16 @@ def processar_branch_github(
     except ValueError as ve:
         BaseCommitter._finalizar_resultado_erro(resultado_branch, str(ve))
         return resultado_branch
+
+    # PASSO 2: Garantir que a branch de destino existe ou criar explicitamente
+    try:
+        BaseCommitter._validate_branch_exists(repo, nome_branch, 'github', branch_de_origem)
+    except Exception as e:
+        msg = f"Falha ao validar/criar branch '{nome_branch}': {e}"
+        print(f"[ERRO][GITHUB] {msg}")
+        BaseCommitter._finalizar_resultado_erro(resultado_branch, msg)
+        return resultado_branch
+
     commits_realizados = 0
     commit_url = None
     mudancas_validas = BaseCommitter._processar_mudancas_comuns(conjunto_de_mudancas, resultado_branch)


### PR DESCRIPTION
No método processar_branch_github, mantida a chamada para _validate_branch_exists que agora aguarda confirmação da criação da branch. Isso garante que o commit tenha um ponto de partida válido e elimina o erro crítico ao tentar commitar em branch inexistente ou não propagada.