### PR TITLE
Ajuste na lógica de batching para garantir que todas as mudanças de um mesmo arquivo estejam em um único batch, eliminando conflitos de merge entre batches.

### DIFF
--- a/services/incremental_step_executor_service.py
+++ b/services/incremental_step_executor_service.py
@@ -44,50 +44,26 @@ class IncrementalStepExecutorService:
             return []
         print(f"[INCREMENTAL] {len(steps)} steps parseados do relatório.")
         batches = []
-        current_batch = []
-        current_batch_paths = set()
-        file_to_batch_index = {}
+        arquivo_para_batch_index = {}
         for idx, step in enumerate(steps):
             step_path = StepDependencyAnalyzer._normalize_path(step.get('Caminho do Arquivo', ''))
             print(f"[INCREMENTAL][DEBUG] Iteração {idx}: step_path='{step_path}'")
-            if step_path in file_to_batch_index:
-                batch_idx = file_to_batch_index[step_path]
-                if batch_idx < len(batches):
-                    batches[batch_idx].append(step)
-                    print(f"[INCREMENTAL][BATCHING] Step {idx+1} adicionado ao batch existente {batch_idx} para arquivo '{step_path}'")
-                    print(f"[INCREMENTAL][DEBUG] file_to_batch_index: {file_to_batch_index}")
-                    print(f"[INCREMENTAL][DEBUG] batches[{batch_idx}] tamanho: {len(batches[batch_idx])}")
-                else:
-                    print(f"[INCREMENTAL][ERRO] batch_idx {batch_idx} fora do range de batches (len={len(batches)}), step {idx+1}")
+            if step_path and step_path in arquivo_para_batch_index:
+                batch_idx = arquivo_para_batch_index[step_path]
+                batches[batch_idx].append(step)
+                print(f"[INCREMENTAL][BATCHING] Step {idx+1} adicionado ao batch existente {batch_idx} para arquivo '{step_path}'")
                 continue
-            if not current_batch:
-                current_batch.append(step)
+            # Tentar adicionar ao batch atual se não estourar o limite e não há conflito de arquivos
+            if batches and len(batches[-1]) < max_steps_per_batch:
+                batches[-1].append(step)
                 if step_path:
-                    current_batch_paths.add(step_path)
-                print(f"[INCREMENTAL][DEBUG] Novo current_batch iniciado com step {idx+1}, arquivos: {list(current_batch_paths)}")
-                continue
-            if len(current_batch) < max_steps_per_batch:
-                current_batch.append(step)
+                    arquivo_para_batch_index[step_path] = len(batches) - 1
+                print(f"[INCREMENTAL][DEBUG] Step {idx+1} adicionado ao batch atual {len(batches)-1}, tamanho atual: {len(batches[-1])}")
+            else:
+                batches.append([step])
                 if step_path:
-                    current_batch_paths.add(step_path)
-                print(f"[INCREMENTAL][DEBUG] Step {idx+1} adicionado ao current_batch, tamanho atual: {len(current_batch)}")
-                continue
-            batches.append(current_batch)
-            for p in current_batch_paths:
-                file_to_batch_index[p] = len(batches) - 1
-            print(f"[INCREMENTAL][BATCHING] Batch {len(batches)-1} criado com {len(current_batch)} steps: arquivos {list(current_batch_paths)}")
-            print(f"[INCREMENTAL][DEBUG] file_to_batch_index após fechamento de batch: {file_to_batch_index}")
-            current_batch = [step]
-            current_batch_paths = set()
-            if step_path:
-                current_batch_paths.add(step_path)
-            print(f"[INCREMENTAL][DEBUG] Novo current_batch iniciado com step {idx+1}, arquivos: {list(current_batch_paths)}")
-        if current_batch:
-            batches.append(current_batch)
-            for p in current_batch_paths:
-                file_to_batch_index[p] = len(batches) - 1
-            print(f"[INCREMENTAL][BATCHING] Batch {len(batches)-1} criado com {len(current_batch)} steps: arquivos {list(current_batch_paths)}")
-            print(f"[INCREMENTAL][DEBUG] file_to_batch_index após fechamento final: {file_to_batch_index}")
+                    arquivo_para_batch_index[step_path] = len(batches) - 1
+                print(f"[INCREMENTAL][DEBUG] Novo batch {len(batches)-1} iniciado com step {idx+1}, arquivo: '{step_path}'")
         print(f"[INCREMENTAL] {len(batches)} batches criados.")
         return batches
 


### PR DESCRIPTION
Modificada a função get_step_batches_from_report para que todos os steps que modificam o mesmo arquivo sejam agrupados em um único batch, independentemente do limite máximo de steps por batch. A função agora verifica se o arquivo já está associado a um batch e adiciona o step a ele, criando um novo batch apenas quando o arquivo ainda não foi alocado. Essa abordagem previne conflitos de merge causados por múltiplos batches modificando o mesmo arquivo. Mantidos logs detalhados para facilitar o debug.