### PR TITLE
Criação da classe PathNormalizer para normalização de caminhos de arquivos.

### DIFF
--- a/tools/repo_committers/path_normalizer.py
+++ b/tools/repo_committers/path_normalizer.py
@@ -1,0 +1,11 @@
+class PathNormalizer:
+    @staticmethod
+    def normalize(path: str) -> str:
+        if not isinstance(path, str):
+            return ''
+        path = path.strip()
+        if not path:
+            return ''
+        path = path.lstrip('/')
+        normalized = '/' + path if path else ''
+        return normalized


### PR DESCRIPTION
Implementada a classe utilitária PathNormalizer com método estático normalize que remove barras iniciais duplicadas e espaços em branco, garantindo que os caminhos dos arquivos enviados ao Azure estejam no formato correto, iniciando com uma única barra.