### PR TITLE
Implementação da classe PathDeduplicator para deduplicar mudanças por caminho, mesclando conteúdos e justificativas para status 'MODIFICADO'.

### DIFF
--- a/tools/repo_committers/path_deduplicator.py
+++ b/tools/repo_committers/path_deduplicator.py
@@ -1,0 +1,23 @@
+from typing import List, Dict
+
+class PathDeduplicator:
+    @staticmethod
+    def deduplicate_changes(changes: List[Dict]) -> List[Dict]:
+        if not changes:
+            return []
+        dedup = {}
+        for change in changes:
+            caminho = change.get('caminho') or change.get('caminho_do_arquivo')
+            status = change.get('status')
+            if not caminho:
+                continue
+            if caminho in dedup:
+                existing = dedup[caminho]
+                if status == 'MODIFICADO' and existing.get('status') == 'MODIFICADO':
+                    existing['conteudo'] = change.get('conteudo', existing.get('conteudo'))
+                    existing['justificativa'] = change.get('justificativa', existing.get('justificativa'))
+                else:
+                    dedup[caminho] = change
+            else:
+                dedup[caminho] = change
+        return list(dedup.values())


### PR DESCRIPTION
Criada a classe PathDeduplicator com método deduplicate_changes que recebe uma lista de mudanças e retorna uma lista deduplicada, onde cada caminho aparece apenas uma vez. A deduplicação considera o status da mudança, mesclando conteúdos para modificações e substituindo para outros status. Essa classe pode ser usada como utilitário para garantir integridade antes do commit.