### PR TITLE
Aprimoramento da normalização de caminhos para remoção universal de barras duplas e formatação consistente, com método para normalização em lote.

### DIFF
--- a/tools/repo_committers/path_normalizer.py
+++ b/tools/repo_committers/path_normalizer.py
@@ -1,11 +1,22 @@
+from typing import List
+import re
+
 class PathNormalizer:
     @staticmethod
     def normalize(path: str) -> str:
-        if not isinstance(path, str):
+        if not path or not isinstance(path, str):
             return ''
+        path = path.replace('\\', '/').replace('//', '/')
+        while '//' in path:
+            path = path.replace('//', '/')
+        path = re.sub(r'/+', '/', path)
         path = path.strip()
-        if not path:
-            return ''
-        path = path.lstrip('/')
-        normalized = '/' + path if path else ''
-        return normalized
+        if not path.startswith('/'):
+            path = '/' + path
+        return path
+
+    @staticmethod
+    def normalize_batch(paths: List[str]) -> List[str]:
+        if not paths:
+            return []
+        return [PathNormalizer.normalize(p) for p in paths]


### PR DESCRIPTION
O método normalize foi aprimorado para substituir todas as ocorrências de barras duplas e múltiplas por uma única barra, garantindo que todos os caminhos iniciem com uma barra única e estejam limpos. Foi adicionado o método normalize_batch para normalizar listas de caminhos de forma eficiente. Essa centralização previne regressões no formato dos caminhos e evita erros de timeout na API do Azure DevOps causados por caminhos inválidos.