### PR TITLE
Validação explícita para evitar paths None no normalizador de caminhos.

### DIFF
--- a/tools/repo_committers/path_normalizer.py
+++ b/tools/repo_committers/path_normalizer.py
@@ -4,6 +4,8 @@ import re
 class PathNormalizer:
     @staticmethod
     def normalize(path: str) -> str:
+        if path is None:
+            raise ValueError("Path cannot be None")
         if not path or not isinstance(path, str):
             return ''
         path = path.replace('\\', '/').replace('//', '/')
@@ -23,6 +25,8 @@ class PathNormalizer:
 
     @staticmethod
     def normalize_for_grouping(path: str) -> str:
+        if path is None:
+            raise ValueError("Path cannot be None")
         if not path or not isinstance(path, str):
             return ''
         path = path.replace('`', '')


### PR DESCRIPTION
Incluída validação explícita para levantar exceção se path for None, tornando o erro mais descritivo e evitando erros silenciosos.