### PR TITLE
Garantia de que múltiplos passos para o mesmo arquivo sejam mantidos juntos no mesmo batch na execução incremental e correção da chave de resposta do committer para 'branch_name'.

### DIFF
--- a/services/incremental_step_executor_service.py
+++ b/services/incremental_step_executor_service.py
@@ -52,9 +52,10 @@ class IncrementalStepExecutorService:
                     group_steps_sorted = sorted(group_steps, key=lambda x: int(x.get('Passo #', '0')))
                 except Exception:
                     group_steps_sorted = group_steps
+                # Garantir que todos os passos do mesmo arquivo estejam juntos no mesmo batch
                 if max_steps_per_batch is not None and max_steps_per_batch > 0:
-                    for i in range(0, len(group_steps_sorted), max_steps_per_batch):
-                        batches.append(group_steps_sorted[i:i+max_steps_per_batch])
+                    # Se o grupo excede o tamanho máximo, ainda assim mantenha todos juntos
+                    batches.append(group_steps_sorted)
                 else:
                     batches.append(group_steps_sorted)
         else:


### PR DESCRIPTION
Atualizada a função get_step_batches_from_report para manter passos do mesmo arquivo juntos, mesmo que excedam o limite máximo por batch, respeitando a ordenação por Passo #. Corrigida a função merge_all_batches para consolidar e deduplicar mudanças corretamente. Corrigida a resposta do committer para usar a chave 'branch_name' em vez de 'branch', alinhando com o orquestrador e evitando erros de chave.