### PR TITLE
Adicionado suporte para clone autenticado usando token de acesso e execução do build .NET.

### DIFF
--- a/services/dotnet_build_service.py
+++ b/services/dotnet_build_service.py
@@ -7,7 +7,7 @@ class DotNetBuildService:
     def __init__(self):
         pass
 
-    def build_project(self, job_id: str, repository_type: str, repo_name: str, branch_name: str) -> Dict[str, Any]:
+    def build_project(self, job_id: str, repository_type: str, repo_name: str, branch_name: str, access_token: Optional[str] = None) -> Dict[str, Any]:
         print(f"[{job_id}] [DotNetBuildService] Iniciando build para repo={repo_name}, branch={branch_name}")
         result = {
             "success": False,
@@ -17,7 +17,7 @@ class DotNetBuildService:
         }
         local_dir = f"/tmp/{job_id}_{branch_name}"
         try:
-            clone_url = self._get_clone_url(repository_type, repo_name)
+            clone_url = self._get_clone_url(repository_type, repo_name, access_token)
             if os.path.exists(local_dir):
                 shutil.rmtree(local_dir)
             clone_cmd = ["git", "clone", "--branch", branch_name, clone_url, local_dir]
@@ -46,12 +46,18 @@ class DotNetBuildService:
         print(f"[{job_id}] [DotNetBuildService] Build finalizado. success={result['success']}, errors={len(result['errors'])}")
         return result
 
-    def _get_clone_url(self, repository_type: str, repo_name: str) -> str:
+    def _get_clone_url(self, repository_type: str, repo_name: str, access_token: Optional[str] = None) -> str:
         if repository_type == "azure":
+            if access_token:
+                return f"https://{access_token}@dev.azure.com/{repo_name}"
             return f"https://dev.azure.com/{repo_name}"
         elif repository_type == "github":
+            if access_token:
+                return f"https://{access_token}@github.com/{repo_name}.git"
             return f"https://github.com/{repo_name}.git"
         elif repository_type == "gitlab":
+            if access_token:
+                return f"https://{access_token}@gitlab.com/{repo_name}.git"
             return f"https://gitlab.com/{repo_name}.git"
         return repo_name
 


### PR DESCRIPTION
O DotNetBuildService foi modificado para aceitar um parâmetro opcional access_token que é usado para construir a URL de clone autenticada para repositórios privados (Azure, GitHub, GitLab). O método build_project realiza o clone da branch especificada usando essa URL e executa o build dotnet, capturando erros e saída do processo.