### PR TITLE
Robustez na manipulação do campo 'build_errors' na resposta final para evitar erros de chave ausente.

### DIFF
--- a/services/response_builder_service.py
+++ b/services/response_builder_service.py
@@ -41,7 +41,7 @@ class ResponseBuilderService:
         build_errors = []
         commit_details = job_data.get(JobFields.COMMIT_DETAILS, [])
         for idx, commit in enumerate(commit_details):
-            errors = commit.get("build_errors")
+            errors = commit.get('build_errors')
             if errors:
                 print(f"[{job_id}] [DEBUG][ResponseBuilderService] build_errors encontrados em commit_details[{idx}]: {errors}")
                 build_errors.extend(errors)
@@ -65,7 +65,7 @@ class ResponseBuilderService:
         build_errors = []
         commit_details = job_data.get(JobFields.COMMIT_DETAILS, [])
         for idx, commit in enumerate(commit_details):
-            errors = commit.get("build_errors")
+            errors = commit.get('build_errors')
             if errors:
                 print(f"[{job_id}] [DEBUG][ResponseBuilderService] build_errors encontrados em commit_details[{idx}]: {errors}")
                 build_errors.extend(errors)


### PR DESCRIPTION
Ajustada a ResponseBuilderService para acessar o campo 'build_errors' usando commit.get('build_errors') e só adicionar à lista se não for None. Isso evita erros de chave ausente e mantém a consistência do campo nas respostas de sucesso e falha.