### PR TITLE
Correção do tratamento de erros no build para preservar a URL do PR e evitar erro de variável local não associada.

### DIFF
--- a/services/commit_handler.py
+++ b/services/commit_handler.py
@@ -5,7 +5,6 @@ from tools.repository_provider_factory import get_repository_provider_explicit
 from tools.repo_committers.branch_name_sanitizer import BranchNameSanitizer
 import json
 from services.dotnet_build_service import DotNetBuildService
-
 from tools.azure_secret_manager import AzureSecretManager
 from models import JobFields
 
@@ -15,12 +14,11 @@ class CommitHandler:
         self.conexao_geral_factory = conexao_geral_factory or ConexaoGeral.create_with_defaults
         self.dotnet_build_service = dotnet_build_service or DotNetBuildService()
         self.secret_manager = secret_manager or AzureSecretManager()
-    
+
     def execute_commits(self, job_id: str, job_info: Dict[str, Any], dados_finais_formatados: Dict[str, Any], 
-                      repository_type: str, repo_name: str) -> None:
+                        repository_type: str, repo_name: str) -> None:
         print(f"[{job_id}] [DEBUG] INICIO execute_commits: executar_build_dotnet={job_info.get('data', {}).get('executar_build_dotnet')}")
         print(f"[{job_id}] BLINDAGEM: Iniciando execute_commits")
-        
         try:
             branch_base_para_pr = job_info['data'].get('branch_name', 'main')
             print(f"[{job_id}] Iniciando commit com repositório: '{repo_name}' (tipo: {repository_type})")
@@ -40,7 +38,9 @@ class CommitHandler:
                     "pr_url": f"ERRO: Falha na conexão com repositório. {str(e)}",
                     "message": f"Erro de conexão: {str(e)}",
                     "arquivos_modificados": [],
-                    "commit_url": None
+                    "commit_url": None,
+                    "build_result": None,
+                    "build_errors": None
                 }]
                 print(f"[{job_id}] BLINDAGEM: Erro de conexão tratado, commit_details definido")
                 return
@@ -54,7 +54,9 @@ class CommitHandler:
                     "pr_url": "ERRO: Formato de entrada de grupos está vazio ou malformado.",
                     "message": "Formato de entrada de grupos está vazio ou malformado.",
                     "arquivos_modificados": [],
-                    "commit_url": None
+                    "commit_url": None,
+                    "build_result": None,
+                    "build_errors": None
                 }]
                 print(f"[{job_id}] BLINDAGEM: commit_details definido com erro de formato")
                 return
@@ -64,13 +66,15 @@ class CommitHandler:
             for i, grupo in enumerate(grupos):
                 grupo_titulo = grupo.get('titulo_pr', f'Grupo {i+1}')
                 print(f"[{job_id}] Processando grupo {i+1}/{len(grupos)}: {grupo_titulo}")
+                conjunto_de_mudancas = grupo.get("conjunto_de_mudancas", [])
+                if not isinstance(conjunto_de_mudancas, list):
+                    print(f"[{job_id}] ERRO: conjunto_de_mudancas do grupo {i+1} não é uma lista. Valor: {conjunto_de_mudancas}")
+                    conjunto_de_mudancas = []
+                branch_sugerida = grupo.get("branch_sugerida", f"branch-grupo-{i+1}")
+                branch_sugerida = BranchNameSanitizer.sanitize(branch_sugerida)
+                build_result = None
+                build_errors = None
                 try:
-                    conjunto_de_mudancas = grupo.get("conjunto_de_mudancas", [])
-                    if not isinstance(conjunto_de_mudancas, list):
-                        print(f"[{job_id}] ERRO: conjunto_de_mudancas do grupo {i+1} não é uma lista. Valor: {conjunto_de_mudancas}")
-                        conjunto_de_mudancas = []
-                    branch_sugerida = grupo.get("branch_sugerida", f"branch-grupo-{i+1}")
-                    branch_sugerida = BranchNameSanitizer.sanitize(branch_sugerida)
                     resultado_branch = processar_branch_por_provedor(
                         repo=repo,
                         nome_branch=branch_sugerida,
@@ -85,42 +89,63 @@ class CommitHandler:
                     resultado_branch = self._validate_and_fix_pr_url(job_id, resultado_branch, i+1)
                     if 'commit_url' not in resultado_branch:
                         resultado_branch['commit_url'] = None
+                    # Build .NET após commit/PR, se solicitado
                     if executar_build_dotnet:
-                        commit_details = job_info['data'].get('commit_details', [])
-                        for idx, commit_info in enumerate(commit_details):
-                            branch_name = commit_info.get('branch_name')
-                            if not branch_name:
-                                raise ValueError(f"[{job_id}] ERRO: branch_name ausente em commit_info para build.")
-                            repo_name_commit = commit_info.get('repo_name', repo_name)
+                        branch_name = resultado_branch.get('branch_name')
+                        repo_name_commit = job_info['data'].get('repo_name', repo_name)
+                        token = None
+                        try:
                             token = self._get_access_token(repository_type, repo_name_commit)
-                            print(f"[{job_id}] [CommitHandler] Iniciando build. repository_type={repository_type}, repo_name={repo_name_commit}, branch_name={branch_name}, access_token presente: {bool(token)}")
-                            dotnet_build_service = DotNetBuildService()
-                            build_result = dotnet_build_service.build_project(job_id, repository_type, repo_name_commit, branch_name, access_token=token)
-                            print(f"[{job_id}] [CommitHandler] Build finalizado. success={build_result.get('success')}, errors={len(build_result.get('errors', []))}")
-                            commit_info['build_result'] = build_result
+                        except Exception as e:
+                            print(f"[{job_id}] [CommitHandler] Falha ao obter token: {e}")
+                        print(f"[{job_id}] [CommitHandler][BUILD] Iniciando build. repository_type={repository_type}, repo_name={repo_name_commit}, branch_name={branch_name}, access_token presente: {bool(token)}")
+                        try:
+                            build_result = self.dotnet_build_service.build_project(
+                                job_id=job_id,
+                                repository_type=repository_type,
+                                repo_name=repo_name_commit,
+                                branch_name=branch_name,
+                                access_token=token
+                            )
+                            print(f"[{job_id}] [CommitHandler][BUILD] Build finalizado. success={build_result.get('success')}, errors={len(build_result.get('errors', []))}, build_result={json.dumps(build_result, default=str)[:300]}")
                             if not build_result.get('success'):
-                                commit_info['build_errors'] = build_result.get('errors')
-                        job_info['data']['commit_details'] = commit_details
-                        print(f"[{job_id}] [DEBUG] Resultado do build: success={build_result.get('success')}, errors={len(build_result.get('errors', []) )}")
+                                build_errors = build_result.get('errors')
+                        except Exception as e:
+                            print(f"[{job_id}] [CommitHandler][BUILD] Exceção no build: {e}")
+                            build_errors = [str(e)]
+                            build_result = {"success": False, "errors": build_errors}
+                        print(f"[{job_id}] [CommitHandler][BUILD] build_result será adicionado ao commit_info: {json.dumps(build_result, default=str)[:300]}")
+                    commit_info = {
+                        "branch_name": resultado_branch.get('branch_name'),
+                        "success": resultado_branch.get('success'),
+                        "pr_url": resultado_branch.get('pr_url'),
+                        "message": resultado_branch.get('message'),
+                        "arquivos_modificados": resultado_branch.get('arquivos_modificados', []),
+                        "commit_url": resultado_branch.get('commit_url'),
+                        "build_result": build_result,
+                        "build_errors": build_errors
+                    }
                 except Exception as e:
                     print(f"[{job_id}] ERRO no processamento do grupo {i+1}: {str(e)}")
-                    resultado_branch = {
+                    commit_info = {
                         "branch_name": branch_sugerida,
                         "success": False,
-                        "pr_url": f"ERRO: Falha no processamento do grupo {i+1}. {str(e)}",
+                        "pr_url": resultado_branch.get('pr_url') if 'resultado_branch' in locals() and resultado_branch.get('pr_url') else f"ERRO: Falha no processamento do grupo {i+1}. {str(e)}",
                         "message": f"Erro no grupo {i+1}: {str(e)}",
                         "arquivos_modificados": [arquivo.get('caminho_do_arquivo', '') for arquivo in conjunto_de_mudancas],
-                        "commit_url": None
+                        "commit_url": resultado_branch.get('commit_url') if 'resultado_branch' in locals() else None,
+                        "build_result": build_result,
+                        "build_errors": build_errors if build_errors else [str(e)]
                     }
-                print(f"[{job_id}] DIAGNÓSTICO - Resultado do grupo {i+1}: success={resultado_branch.get('success')}, pr_url='{resultado_branch.get('pr_url')}', branch_name='{resultado_branch.get('branch_name')}', commit_url='{resultado_branch.get('commit_url')}'")
-                commit_results.append(resultado_branch)
+                print(f"[{job_id}] DIAGNÓSTICO - Resultado do grupo {i+1}: success={commit_info.get('success')}, pr_url='{commit_info.get('pr_url')}', branch_name='{commit_info.get('branch_name')}', commit_url='{commit_info.get('commit_url')}', build_result={commit_info.get('build_result')}, build_errors={commit_info.get('build_errors')}")
+                commit_results.append(commit_info)
             print(f"[{job_id}] [DEBUG] Pós-loop grupos: commit_results contém build_result/build_errors?")
             for idx, res in enumerate(commit_results):
                 print(f"[{job_id}] [DEBUG] Grupo {idx+1}: build_result presente={ 'build_result' in res }, build_errors presente={ 'build_errors' in res }, build_result={res.get('build_result')}")
             print(f"[{job_id}] Commit concluído. Resultados: {len(commit_results)} branches processadas")
             print(f"[{job_id}] DIAGNÓSTICO FINAL - commit_results antes de salvar: {json.dumps(commit_results, default=str)}")
             for i, result in enumerate(commit_results):
-                print(f"[{job_id}] DIAGNÓSTICO - PR {i+1}: pr_url='{result.get('pr_url')}', branch_name='{result.get('branch_name')}', success={result.get('success')}, arquivos_modificados={len(result.get('arquivos_modificados', []) )}, commit_url='{result.get('commit_url')}'")
+                print(f"[{job_id}] DIAGNÓSTICO - PR {i+1}: pr_url='{result.get('pr_url')}', branch_name='{result.get('branch_name')}', success={result.get('success')}, arquivos_modificados={len(result.get('arquivos_modificados', []) )}, commit_url='{result.get('commit_url')}', build_result={result.get('build_result')}, build_errors={result.get('build_errors')}")
             print(f"[{job_id}] BLINDAGEM: execute_commits concluído com sucesso")
             job_info['data']['commit_details'] = commit_results
         except Exception as e:
@@ -132,11 +157,13 @@ class CommitHandler:
                     "pr_url": f"ERRO: Falha geral no commit. {str(e)}",
                     "message": f"Erro geral: {str(e)}",
                     "arquivos_modificados": [],
-                    "commit_url": None
+                    "commit_url": None,
+                    "build_result": None,
+                    "build_errors": [str(e)]
                 }]
             print(f"[{job_id}] BLINDAGEM: Erro geral tratado, commit_details garantido")
             raise e
-    
+
     def _validate_and_fix_pr_url(self, job_id: str, resultado_branch: Dict[str, Any], grupo_num: int) -> Dict[str, Any]:
         print(f"[DEBUG][CommitHandler] _validate_and_fix_pr_url: job_id={job_id}, grupo_num={grupo_num}, pr_url={resultado_branch.get('pr_url')}, success={resultado_branch.get('success')}, branch_name={resultado_branch.get('branch_name')}")
         pr_url = resultado_branch.get('pr_url')
@@ -144,7 +171,10 @@ class CommitHandler:
         if success:
             if not pr_url or not isinstance(pr_url, str) or not pr_url.strip():
                 raise Exception(f"[CommitHandler] Resultado marcado como sucesso mas pr_url inválido: {json.dumps(resultado_branch, default=str)}")
-            if not self._is_valid_url(pr_url):
+            if self._is_valid_url(pr_url):
+                # Não altera pr_url se for válida
+                pass
+            else:
                 print(f"[{job_id}] AVISO: Grupo {grupo_num} tem pr_url que não é uma URL válida: '{pr_url}'")
                 if "Branch processada" in str(pr_url) or "PR criado" in str(pr_url):
                     pass
@@ -157,7 +187,7 @@ class CommitHandler:
             raise Exception(f"[CommitHandler] Resultado marcado como sucesso mas pr_url inválido: {json.dumps(resultado_branch, default=str)}")
         print(f"[DEBUG][CommitHandler] _validate_and_fix_pr_url (final): pr_url={resultado_branch.get('pr_url')}")
         return resultado_branch
-    
+
     def _is_valid_url(self, url: str) -> bool:
         if not url or not isinstance(url, str):
             return False


### PR DESCRIPTION
Este PR corrige o problema onde, ao ocorrer erro no build após a criação do PR, a URL válida do PR era sobrescrita por mensagens de erro, causando retorno incorreto na API. Ajusta o escopo das variáveis build_result e build_errors para garantir inicialização antes do uso e separa claramente o tratamento de exceções do build para não impactar a URL do PR. Mantém logs detalhados para rastreamento e assegura que a estrutura commit_results contenha sempre a URL correta do PR, mesmo em caso de falhas no build.