### PR TITLE
Adicionado campo para cache do conteúdo do repositório no modelo de dados do job.

### DIFF
--- a/models.py
+++ b/models.py
@@ -67,6 +67,7 @@ class JobFields:
     EXECUTAR_BUILD_DOTNET = 'executar_build_dotnet'
     BUILD_ERRORS = 'build_errors'
     BUILD_RESULT = 'build_result'
+    REPOSITORY_CONTENT_CACHE = 'repository_content_cache'
 
 class JobActions:
     APPROVE = 'approve'


### PR DESCRIPTION
Incluído JobFields.REPOSITORY_CONTENT_CACHE para armazenar o cache do conteúdo do repositório, permitindo evitar leituras repetidas durante execução incremental.