### PR TITLE
ProcessadorStepExecutor utiliza cache do repositório para evitar leituras repetidas, melhorando performance.

### DIFF
--- a/services/step_executors/processador_step_executor.py
+++ b/services/step_executors/processador_step_executor.py
@@ -30,22 +30,28 @@ class ProcessadorStepExecutor(BaseStepExecutor):
             'nome_branch': job_info['data']['branch_name'],
             'repository_type': job_info['data']['repository_type']
         })
-        
         agent_params['retornar_lista_arquivos'] = agent_params.get('retornar_lista_arquivos', False)
         if isinstance(previous_step_result, dict) and 'lista_arquivos' in previous_step_result:
             agent_params['lista_arquivos'] = previous_step_result['lista_arquivos']
         agent_params['modo_adicao_incremental'] = agent_params.get('modo_adicao_incremental', False)
-        
+
+        # USO DO CACHE DE REPOSITÓRIO
+        if 'repository_content_cache' in agent_params and agent_params['repository_content_cache'] is not None:
+            arquivos_codigo = agent_params['repository_content_cache']
+            print(f"[{job_id}] [PERFORMANCE] Utilizando cache do repositório (ProcessadorStepExecutor) com {len(arquivos_codigo)} arquivos.")
+            agent_params['arquivos_codigo'] = arquivos_codigo
+        else:
+            arquivos_codigo = repo_reader.read_repository()
+            print(f"[{job_id}] [PERFORMANCE] Lendo repositório normalmente (ProcessadorStepExecutor) com {len(arquivos_codigo)} arquivos.")
+            agent_params['arquivos_codigo'] = arquivos_codigo
+
         agente = AgentFactory.create_agent("processador", None, llm_provider)
         agent_response = agente.main(**agent_params)
-        
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
-        
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):
                 print(f"[{job_id}] A IA retornou resposta vazia. Reutilizando resultado anterior.")
                 return previous_step_result
             raise ValueError("IA retornou resposta vazia e não há resultado anterior para usar.")
-        
         return json.loads(cleaned_string)


### PR DESCRIPTION
No método execute, verifica se o cache do repositório está presente em agent_params e o utiliza para evitar nova leitura. Logs indicam uso do cache ou leitura normal.