### PR TITLE
ComparadorStepExecutor utiliza cache do repositório para evitar leituras repetidas, melhorando performance.

### DIFF
--- a/services/step_executors/comparador_step_executor.py
+++ b/services/step_executors/comparador_step_executor.py
@@ -31,17 +31,23 @@ class ComparadorStepExecutor(BaseStepExecutor):
             'projeto': job_info['data']['projeto'],
             'status_update': step['status_update']
         })
-        
+        # USO DO CACHE DE REPOSITÓRIO
+        if 'repository_content_cache' in agent_params and agent_params['repository_content_cache'] is not None:
+            arquivos_codigo_modernizado = agent_params['repository_content_cache']
+            print(f"[{job_id}] [PERFORMANCE] Utilizando cache do repositório (ComparadorStepExecutor) com {len(arquivos_codigo_modernizado)} arquivos.")
+            agent_params['arquivos_codigo_modernizado'] = arquivos_codigo_modernizado
+            # Para comparação, se necessário, pode-se adicionar lógica para arquivos_codigo_original
+        else:
+            arquivos_codigo_modernizado = repo_reader.read_repository()
+            print(f"[{job_id}] [PERFORMANCE] Lendo repositório normalmente (ComparadorStepExecutor) com {len(arquivos_codigo_modernizado)} arquivos.")
+            agent_params['arquivos_codigo_modernizado'] = arquivos_codigo_modernizado
         agente = AgentFactory.create_agent("comparador", repo_reader, llm_provider)
         agent_response = agente.main(**agent_params)
-        
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
-        cleaned_string = json_string.replace("```json", "").replace("```", "").strip()
-        
+        cleaned_string = json_string.replace("", "").replace("", "").strip()
         if not cleaned_string:
             if previous_step_result and isinstance(previous_step_result, dict):
                 print(f"[{job_id}] A IA retornou resposta vazia. Reutilizando resultado anterior.")
                 return previous_step_result
             raise ValueError("IA retornou resposta vazia e não há resultado anterior para usar.")
-        
         return json.loads(cleaned_string)


### PR DESCRIPTION
No método execute, verifica se o cache do repositório está presente em agent_params e o utiliza para evitar nova leitura. Logs indicam uso do cache ou leitura normal.