### PR TITLE
Criação do serviço RepositoryFilterService para filtrar arquivos específicos no cache do repositório.

### DIFF
--- a/services/repository_filter_service.py
+++ b/services/repository_filter_service.py
@@ -1,0 +1,18 @@
+import os
+from typing import Dict, Optional, List
+
+class RepositoryFilterService:
+    @staticmethod
+    def filter_by_specific_files(repository_content: Dict[str, str], arquivos_especificos: Optional[List[str]]) -> Dict[str, str]:
+        if not arquivos_especificos:
+            return repository_content
+        arquivos_especificos_normalizados = set()
+        for path in arquivos_especificos:
+            p = path.lstrip('/').lower()
+            arquivos_especificos_normalizados.add(p)
+        resultado = {}
+        for repo_path, conteudo in repository_content.items():
+            repo_path_normalizado = repo_path.lstrip('/').lower()
+            if repo_path_normalizado in arquivos_especificos_normalizados:
+                resultado[repo_path] = conteudo
+        return resultado


### PR DESCRIPTION
Implementado RepositoryFilterService com método estático filter_by_specific_files que recebe o conteúdo completo do repositório e uma lista opcional de arquivos específicos, retornando apenas os arquivos filtrados conforme a lista, com normalização dos caminhos para comparação.