### PR TITLE
Ajuste na leitura do repositório para ocorrer somente no step 0 e filtragem do cache por arquivos_especificos.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -81,7 +81,8 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                         tipo_analise=job_info['data']['original_analysis_type'],
                         repository_type=job_info['data']['repository_type']
                     )
-                    repository_content_cache = RepositoryFilterService.filter_by_specific_files(repository_content_cache, arquivos_especificos)
+                    if arquivos_especificos:
+                        repository_content_cache = RepositoryFilterService.filter_by_specific_files(repository_content_cache, arquivos_especificos)
                     job_info['data'][JobFields.REPOSITORY_CONTENT_CACHE] = repository_content_cache
                     self.job_handler.update_job(job_id, job_info)
                     print(f"[{job_id}] [PERFORMANCE] Cache do repositório populado com {len(repository_content_cache)} arquivos.")
@@ -93,7 +94,8 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     tipo_analise=job_info['data']['original_analysis_type'],
                     repository_type=job_info['data']['repository_type']
                 )
-                repository_content_cache = RepositoryFilterService.filter_by_specific_files(repository_content_cache, arquivos_especificos)
+                if arquivos_especificos:
+                    repository_content_cache = RepositoryFilterService.filter_by_specific_files(repository_content_cache, arquivos_especificos)
                 job_info['data'][JobFields.REPOSITORY_CONTENT_CACHE] = repository_content_cache
                 self.job_handler.update_job(job_id, job_info)
                 print(f"[{job_id}] [PERFORMANCE] Cache do repositório populado com {len(repository_content_cache)} arquivos.")


### PR DESCRIPTION
Modificado o WorkflowOrchestrator para garantir que a leitura do repositório seja feita apenas no step 0, populando o cache com os arquivos filtrados pela lista arquivos_especificos. Também aplicado o mesmo filtro no modo incremental para que o cache contenha somente os arquivos relevantes desde o início, evitando leituras repetidas e desnecessárias nos steps subsequentes.