### PR TITLE
Uso do cache do repositório no RevisorStepExecutor para evitar leituras redundantes.

### DIFF
--- a/services/step_executors/revisor_step_executor.py
+++ b/services/step_executors/revisor_step_executor.py
@@ -60,7 +60,7 @@ class RevisorStepExecutor(BaseStepExecutor):
                 agent_response = agente.main(**agent_params)
                 raw_response_from_llm = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
                 cleaned_string = None
-                match = re.search(r"```json\s*([\s\S]*?)\s*```", raw_response_from_llm)
+                match = re.search(r"\s*([\s\S]*?)\s*", raw_response_from_llm)
                 if match:
                     cleaned_string = match.group(1).strip()
                 else:


### PR DESCRIPTION
Adicionada lógica para utilizar o cache do repositório se disponível, evitando leitura redundante no step 1 e subsequentes, melhorando a performance e estabilidade.