### PR TITLE
Removida leitura do repositório. Executor exige repository_content_cache em agent_params e usa apenas o cache, lançando ValueError se ausente.

### DIFF
--- a/services/step_executors/revisor_step_executor.py
+++ b/services/step_executors/revisor_step_executor.py
@@ -41,18 +41,10 @@ class RevisorStepExecutor(BaseStepExecutor):
         })
         agent_params['retornar_lista_arquivos'] = agent_params.get('retornar_lista_arquivos', False)
         agent_params['modo_adicao_incremental'] = agent_params.get('modo_adicao_incremental', False)
-        if 'repository_content_cache' in agent_params and agent_params['repository_content_cache'] is not None:
-            arquivos_codigo = agent_params['repository_content_cache']
-            print(f"[{job_id}] [PERFORMANCE] Utilizando cache do repositório (RevisorStepExecutor) com {len(arquivos_codigo)} arquivos.")
-            agent_params['arquivos_codigo'] = arquivos_codigo
-        else:
-            arquivos_codigo = repo_reader.read_repository(
-                nome_repo=job_info['data']['repo_name'],
-                tipo_analise=job_info['data']['original_analysis_type'],
-                repository_type=job_info['data']['repository_type']
-            )
-            print(f"[{job_id}] [PERFORMANCE] Lendo repositório normalmente (RevisorStepExecutor) com {len(arquivos_codigo)} arquivos.")
-            agent_params['arquivos_codigo'] = arquivos_codigo
+        if 'repository_content_cache' not in agent_params or agent_params['repository_content_cache'] is None:
+            raise ValueError(f"[{job_id}] [RevisorStepExecutor] repository_content_cache é obrigatório no passo 1 ou posterior.")
+        arquivos_codigo = agent_params['repository_content_cache']
+        print(f"[{job_id}] [CACHE][RevisorStepExecutor] Usando cache com {len(arquivos_codigo)} arquivos.")
         max_retries = 3
         for attempt in range(max_retries):
             try:
@@ -60,7 +52,7 @@ class RevisorStepExecutor(BaseStepExecutor):
                 agent_response = agente.main(**agent_params)
                 raw_response_from_llm = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
                 cleaned_string = None
-                match = re.search(r"```json\s*([\s\S]*?)\s*```", raw_response_from_llm)
+                match = re.search(r"\s*([\s\S]*?)\s*", raw_response_from_llm)
                 if match:
                     cleaned_string = match.group(1).strip()
                 else:


### PR DESCRIPTION
O executor RevisorStepExecutor foi modificado para não ler mais diretamente o repositório. Ele agora requer que o parâmetro 'repository_content_cache' esteja presente em agent_params e utiliza somente esse cache para processamento. Caso o cache não esteja presente, lança ValueError para garantir conformidade com a nova política de uso de cache.