### PR TITLE
Removida leitura do repositório. Executor exige repository_content_cache em agent_params e usa apenas o cache, lançando ValueError se ausente.

### DIFF
--- a/services/step_executors/comparador_step_executor.py
+++ b/services/step_executors/comparador_step_executor.py
@@ -31,18 +31,10 @@ class ComparadorStepExecutor(BaseStepExecutor):
             'projeto': job_info['data']['projeto'],
             'status_update': step['status_update']
         })
-        if 'repository_content_cache' in agent_params and agent_params['repository_content_cache'] is not None:
-            arquivos_codigo_modernizado = agent_params['repository_content_cache']
-            print(f"[{job_id}] [PERFORMANCE] Utilizando cache do repositório (ComparadorStepExecutor) com {len(arquivos_codigo_modernizado)} arquivos.")
-            agent_params['arquivos_codigo_modernizado'] = arquivos_codigo_modernizado
-        else:
-            arquivos_codigo_modernizado = repo_reader.read_repository(
-                nome_repo=job_info['data']['repo_name'],
-                tipo_analise=job_info['data']['original_analysis_type'],
-                repository_type=job_info['data']['repository_type']
-            )
-            print(f"[{job_id}] [PERFORMANCE] Lendo repositório normalmente (ComparadorStepExecutor) com {len(arquivos_codigo_modernizado)} arquivos.")
-            agent_params['arquivos_codigo_modernizado'] = arquivos_codigo_modernizado
+        if 'repository_content_cache' not in agent_params or agent_params['repository_content_cache'] is None:
+            raise ValueError(f"[{job_id}] [ComparadorStepExecutor] repository_content_cache é obrigatório.")
+        arquivos_codigo_modernizado = agent_params['repository_content_cache']
+        print(f"[{job_id}] [CACHE][ComparadorStepExecutor] Usando cache com {len(arquivos_codigo_modernizado)} arquivos.")
         agente = AgentFactory.create_agent("comparador", repo_reader, llm_provider)
         agent_response = agente.main(**agent_params)
         json_string = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')


### PR DESCRIPTION
O executor ComparadorStepExecutor foi modificado para não realizar leitura direta do repositório. Ele passa a exigir o parâmetro 'repository_content_cache' em agent_params e utiliza somente esse cache para processamento, garantindo conformidade com a nova política de uso de cache.