### PR TITLE
Adição do método abstrato read_from_cache na classe BaseReader para suportar leitura condicional de arquivos e listas do cache.

### DIFF
--- a/tools/readers/base_reader.py
+++ b/tools/readers/base_reader.py
@@ -74,3 +74,7 @@ class BaseReader(ABC):
         retornar_lista_arquivos: bool
     ) -> Dict:
         pass
+
+    @abstractmethod
+    def read_from_cache(self, job_id: str, cache_service, retornar_lista_arquivos: bool = False) -> Optional[Dict]:
+        pass


### PR DESCRIPTION
Incluído método abstrato read_from_cache para padronizar a interface dos leitores de repositórios, permitindo leitura de dados do cache conforme parâmetros.