### PR TITLE
Adição dos parâmetros access_token e access_token_original na interface do step strategy.

### DIFF
--- a/services/step_strategies/step_strategy_interface.py
+++ b/services/step_strategies/step_strategy_interface.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from tools.readers.reader_geral import ReaderGeral
 
 class IStepStrategy(ABC):
     @abstractmethod
     def execute_step(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                     current_step_index: int, previous_step_result: Dict[str, Any], 
-                    repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
+                    repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any],
+                    access_token: str, access_token_original: Optional[str] = None) -> Dict[str, Any]:
         pass
     
     @abstractmethod


### PR DESCRIPTION
Modificado o arquivo services/step_strategies/step_strategy_interface.py para incluir o parâmetro obrigatório access_token e o opcional access_token_original na assinatura do método abstrato execute_step da interface IStepStrategy, garantindo que todas as implementações futuras recebam esses tokens conforme passo 5.