### PR TITLE
Atualização do método execute_step para propagar access_token e access_token_original para executores.

### DIFF
--- a/services/step_strategies/default_step_strategy.py
+++ b/services/step_strategies/default_step_strategy.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from services.step_executors.step_executor_factory import StepExecutorFactory
 from tools.readers.reader_geral import ReaderGeral
 
@@ -8,24 +8,29 @@ class DefaultStepStrategy:
     
     def execute_step(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                     current_step_index: int, previous_step_result: Dict[str, Any], 
-                    repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
-        
+                    repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any],
+                    access_token: str, access_token_original: Optional[str] = None) -> Dict[str, Any]:
         agent_type = step.get('agent_type')
         if not agent_type:
             raise ValueError(f"Tipo de agente não especificado na etapa {current_step_index}")
-        
         executor = StepExecutorFactory.create_executor(agent_type, self.job_handler)
-        
-        return executor.execute(
-            job_id, job_info, step, current_step_index, 
-            previous_step_result, repo_reader, llm_provider, agent_params
-        )
+        if access_token_original is not None:
+            return executor.execute(
+                job_id, job_info, step, current_step_index, 
+                previous_step_result, repo_reader, llm_provider, agent_params,
+                access_token, access_token_original=access_token_original
+            )
+        else:
+            return executor.execute(
+                job_id, job_info, step, current_step_index, 
+                previous_step_result, repo_reader, llm_provider, agent_params,
+                access_token
+            )
     
     def should_finalize_workflow(self, job_info: Dict[str, Any], current_step_index: int) -> bool:
         return job_info.get('data', {}).get('gerar_relatorio_apenas', False) and current_step_index == 0
 
     def should_pause_for_approval(self, job_info: Dict[str, Any], step: Dict[str, Any]) -> bool:
-        # Agora acessamos o 'job_info' diretamente
         gerar_relatorio_apenas = job_info.get('data', {}).get('gerar_relatorio_apenas', False)
         result = not gerar_relatorio_apenas and step.get('requires_approval', False)
         print(f"[should_pause_for_approval] step_index=?, gerar_relatorio_apenas={gerar_relatorio_apenas}, requires_approval={step.get('requires_approval', False)}, result={result}")


### PR DESCRIPTION
No arquivo services/step_strategies/default_step_strategy.py, a assinatura do método execute_step foi atualizada para incluir os parâmetros access_token e access_token_original (opcional). Estes são repassados para o executor criado, garantindo a propagação correta dos tokens conforme passos 6 e 12.