### PR TITLE
Inclusão dos parâmetros access_token e access_token_original na classe base dos step executors.

### DIFF
--- a/services/step_executors/base_step_executor.py
+++ b/services/step_executors/base_step_executor.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from tools.readers.reader_geral import ReaderGeral
 
 class BaseStepExecutor(ABC):
     @abstractmethod
     def execute(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                 current_step_index: int, previous_step_result: Dict[str, Any], 
-                repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
+                repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any],
+                access_token: str, access_token_original: Optional[str] = None) -> Dict[str, Any]:
         pass


### PR DESCRIPTION
Modificado services/step_executors/base_step_executor.py para adicionar os parâmetros access_token (obrigatório) e access_token_original (opcional) na assinatura do método abstrato execute da classe BaseStepExecutor, padronizando a interface para todos os executores conforme passos 7 e 13.