### PR TITLE
Implementação do cache Redis para lista de arquivos da branch e arquivos lidos, com métodos específicos para manipulação da lista de arquivos no cache.

### DIFF
--- a/services/redis_cache_service.py
+++ b/services/redis_cache_service.py
@@ -1,11 +1,10 @@
 import json
 import redis
-from typing import Any, Optional
+from typing import Any, Optional, List
 from domain.interfaces.cache_interface import ICacheService
 from tools.job_store import RedisJobStore
 
 class RedisCacheService(ICacheService):
-    # O construtor agora exige que o 'job_store' seja injetado.
     def __init__(self, job_store: RedisJobStore):
         self.redis_conn = job_store.get_connection()
 
@@ -41,3 +40,20 @@ class RedisCacheService(ICacheService):
         except Exception as e:
             print(f"[RedisCacheService] Erro ao verificar existência da chave {key}: {e}")
             return False
+
+    def get_cached_file_list(self, cache_key: str) -> Optional[List[str]]:
+        try:
+            val = self.redis_conn.get(cache_key)
+            if val:
+                return json.loads(val)
+            return None
+        except Exception as e:
+            print(f"[RedisCacheService] Erro ao obter lista de arquivos do cache {cache_key}: {e}")
+            return None
+
+    def set_cached_file_list(self, cache_key: str, file_list: List[str], ttl: Optional[int] = 3600):
+        try:
+            val = json.dumps(file_list)
+            self.redis_conn.setex(cache_key, ttl, val)
+        except Exception as e:
+            print(f"[RedisCacheService] Erro ao salvar lista de arquivos no cache {cache_key}: {e}")

--- a/tools/readers/reader_geral.py
+++ b/tools/readers/reader_geral.py
@@ -63,16 +63,17 @@ class ReaderGeral(IRepositoryReader):
         cache_resultado = {}
         cache_ttl = 3600
         arquivos_para_ler = arquivos_especificos if arquivos_especificos is not None else None
-        # --- CACHE DA LISTA DE ARQUIVOS ---
         lista_arquivos_cache_key = f"repo_file_list:{repository_type}:{nome_repo}:{nome_branch}"
         lista_arquivos_do_cache = None
         if retornar_lista_arquivos and self.cache_service:
-            lista_arquivos_do_cache = self.cache_service.get(lista_arquivos_cache_key)
+            if hasattr(self.cache_service, 'get_cached_file_list'):
+                lista_arquivos_do_cache = self.cache_service.get_cached_file_list(lista_arquivos_cache_key)
+            else:
+                lista_arquivos_do_cache = self.cache_service.get(lista_arquivos_cache_key)
             if lista_arquivos_do_cache is not None:
                 print(f"[Reader Geral] CACHE HIT (lista de arquivos): {lista_arquivos_cache_key}")
             else:
                 print(f"[Reader Geral] CACHE MISS (lista de arquivos): {lista_arquivos_cache_key}")
-        # --- CACHE DE ARQUIVOS ESPECÍFICOS ---
         if arquivos_para_ler is not None and self.cache_service:
             print(f"[Reader Geral] Usando cache para leitura de arquivos específicos.")
             arquivos_lidos = {}
@@ -109,14 +110,15 @@ class ReaderGeral(IRepositoryReader):
                 resultado = self.github_reader.read_repository_internal(
                     repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes, retornar_lista_arquivos
                 )
-            # --- SALVAR NO CACHE A LISTA DE ARQUIVOS SE RETORNAR_LISTA_ARQUIVOS ---
             if self.cache_service and retornar_lista_arquivos and isinstance(resultado, dict) and 'lista_arquivos' in resultado:
                 if lista_arquivos_do_cache is None:
-                    self.cache_service.set(lista_arquivos_cache_key, resultado['lista_arquivos'], ttl=cache_ttl)
+                    if hasattr(self.cache_service, 'set_cached_file_list'):
+                        self.cache_service.set_cached_file_list(lista_arquivos_cache_key, resultado['lista_arquivos'], ttl=cache_ttl)
+                    else:
+                        self.cache_service.set(lista_arquivos_cache_key, resultado['lista_arquivos'], ttl=cache_ttl)
                     print(f"[Reader Geral] Lista de arquivos salva no cache: {lista_arquivos_cache_key}")
                 else:
                     print(f"[Reader Geral] Lista de arquivos já estava no cache: {lista_arquivos_cache_key}")
-            # --- SALVAR NO CACHE OS ARQUIVOS DE CÓDIGO LIDOS (CASO NÃO SEJA ARQUIVOS ESPECÍFICOS) ---
             if self.cache_service and isinstance(resultado, dict):
                 codigo_dict = resultado['codigo'] if retornar_lista_arquivos and 'codigo' in resultado else resultado
                 for file_path, file_content in codigo_dict.items():


### PR DESCRIPTION
Adicionados métodos get_cached_file_list e set_cached_file_list na classe RedisCacheService para manipular a lista de arquivos no Redis. Modificada a classe ReaderGeral para consultar a lista de arquivos no cache antes da leitura e salvar após a leitura, quando retornar_lista_arquivos=True. Também mantida a lógica de cache para arquivos específicos lidos da branch, consultando e salvando no cache conforme necessário. Essa abordagem reduz leituras desnecessárias e melhora a performance do processo de geração de report.