### PR TITLE
Correção e refinamento da lógica de cache para a lista de arquivos na leitura do repositório com retornar_lista_arquivos=True em ReaderGeral.

### DIFF
--- a/tools/readers/reader_geral.py
+++ b/tools/readers/reader_geral.py
@@ -72,6 +72,9 @@ class ReaderGeral(IRepositoryReader):
                 lista_arquivos_do_cache = self.cache_service.get(lista_arquivos_cache_key)
             if lista_arquivos_do_cache is not None:
                 print(f"[Reader Geral] CACHE HIT (lista de arquivos): {lista_arquivos_cache_key}")
+                # Se arquivos_especificos não está definido, retorna só a lista do cache
+                if arquivos_para_ler is None:
+                    return {'codigo': {}, 'lista_arquivos': lista_arquivos_do_cache}
             else:
                 print(f"[Reader Geral] CACHE MISS (lista de arquivos): {lista_arquivos_cache_key}")
         if arquivos_para_ler is not None and self.cache_service:
@@ -110,6 +113,7 @@ class ReaderGeral(IRepositoryReader):
                 resultado = self.github_reader.read_repository_internal(
                     repositorio, tipo_analise, nome_branch, arquivos_especificos, self._mapeamento_tipo_extensoes, retornar_lista_arquivos
                 )
+            # Salvar a lista de arquivos no cache se retornar_lista_arquivos e resultado correto
             if self.cache_service and retornar_lista_arquivos and isinstance(resultado, dict) and 'lista_arquivos' in resultado:
                 if lista_arquivos_do_cache is None:
                     if hasattr(self.cache_service, 'set_cached_file_list'):


### PR DESCRIPTION
Ajustada a verificação e armazenamento da lista de arquivos no cache Redis para evitar cache miss desnecessário. Garantido que a lista de arquivos seja consultada antes da leitura e salva após a leitura, usando os métodos get_cached_file_list e set_cached_file_list quando disponíveis. Mantido o cache para arquivos específicos e leitura padrão para outros casos.