### PR TITLE
Revisão da interface ICacheService para incluir métodos específicos para cache de lista de arquivos.

### DIFF
--- a/domain/interfaces/cache_interface.py
+++ b/domain/interfaces/cache_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 class ICacheService(ABC):
     @abstractmethod
@@ -16,4 +16,12 @@ class ICacheService(ABC):
 
     @abstractmethod
     def exists(self, key: str) -> bool:
+        pass
+
+    @abstractmethod
+    def get_cached_file_list(self, cache_key: str) -> Optional[List[str]]:
+        pass
+
+    @abstractmethod
+    def set_cached_file_list(self, cache_key: str, file_list: List[str], ttl: Optional[int] = 3600):
         pass


### PR DESCRIPTION
Adicionados métodos abstratos get_cached_file_list e set_cached_file_list para manipulação específica de listas de arquivos no cache, com suporte a TTL padrão de 3600 segundos.