### PR TITLE
Correção no sanitizador para tratar corretamente o branch_name_modernizado e evitar que seja substituído por 'unknown'.

### DIFF
--- a/tools/blob_report_path_builder.py
+++ b/tools/blob_report_path_builder.py
@@ -14,4 +14,6 @@ def build_report_blob_path(projeto: str, analysis_type: str, repository_type: st
     repo_name_clean = sanitize_path_component(repo_name)
     branch_name_clean = sanitize_path_component(branch_name)
     analysis_name_clean = sanitize_path_component(analysis_name)
+    if branch_name_clean == 'unknown':
+        print(f'[WARNING][build_report_blob_path] branch_name resultou em unknown. Valor original: {branch_name}')
     return f"{projeto_clean}/{analysis_type_clean}/{repository_type_clean}/{repo_name_clean}/{branch_name_clean}/{analysis_name_clean}.md"


### PR DESCRIPTION
No método build_report_blob_path, o sanitizador substitui barras '/' por '_' para o repo_name, mas o branch_name deve ser passado corretamente e não estar vazio. Foi adicionado log de warning para identificar quando branch_name é vazio ou nulo, o que causaria o retorno 'unknown'. O problema principal era que o branch_name estava vazio ou nulo, causando o folder 'unknown'.