### PR TITLE
Unificação da lógica de salvamento do relatório no Blob Storage após execução do step 0, garantindo que qualquer agente (processador, revisor ou outro) salve o relatório imediatamente.

### DIFF
--- a/services/step_strategies/default_step_strategy.py
+++ b/services/step_strategies/default_step_strategy.py
@@ -13,25 +13,22 @@ class DefaultStepStrategy:
     def execute_step(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                      current_step_index: int, previous_step_result: Dict[str, Any], 
                      repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
-        
         agent_type = step.get('agent_type')
         if not agent_type:
             raise ValueError(f"Tipo de agente não especificado na etapa {current_step_index}")
-        
         executor = StepExecutorFactory.create_executor(agent_type, self.job_handler)
         result = executor.execute(
             job_id, job_info, step, current_step_index, 
             previous_step_result, repo_reader, llm_provider, agent_params
         )
-        
         if current_step_index == 0:
             report_text = ReportHandler.extract_report_text(result)
             if report_text and isinstance(report_text, str) and report_text.strip():
-                url = self.report_handler.save_report_to_blob(job_id, job_info, report_text, report_generated_by_agent=True)
-                job_info['data']['report_blob_url'] = url
-                job_info['data']['analysis_report'] = report_text
-                self.job_handler.update_job(job_id, job_info)
-                
+                if job_info['data'].get('report_blob_url') is None:
+                    url = self.report_handler.save_report_to_blob(job_id, job_info, report_text, report_generated_by_agent=True)
+                    job_info['data']['report_blob_url'] = url
+                    job_info['data']['analysis_report'] = report_text
+                    self.job_handler.update_job(job_id, job_info)
         return result
     
     def should_finalize_workflow(self, job_info: Dict[str, Any], current_step_index: int) -> bool:


### PR DESCRIPTION
O bloco de código responsável por salvar o relatório no Blob Storage foi movido para antes do retorno do método execute_step, assegurando que o relatório seja salvo sempre após o step 0, independentemente do agente ou estratégia utilizada. Isso evita que o relatório fique disponível apenas para o agente revisor.