### PR TITLE
Integrada criação de cards no Azure Boards ao final do workflow, usando EpicoParserService para extrair épicos do relatório e AzureBoardsService para criar múltiplos cards no projeto Azure.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -16,6 +16,7 @@ from models import JobFields
 from services.incremental_step_executor_service import IncrementalStepExecutorService
 from services.dotnet_build_service import DotNetBuildService
 from tools.azure_secret_manager import AzureSecretManager
+from services.epico_parser_service import EpicoParserService
 
 class WorkflowOrchestrator(IWorkflowOrchestrator):
     def __init__(self, job_manager: IJobManager, blob_storage: IBlobStorageService, 
@@ -104,7 +105,6 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                             result = self._execute_step_with_strategy(
                                 job_id, job_info, step, current_step_index, previous_step_result, repo_reader, i, start_from_step, agent_params_override=agent_params
                             )
-                            # Salvar relatório do batch se gerado
                             if job_info['data'].get('analysis_report') and not job_info['data'].get('report_blob_url'):
                                 self._save_generated_report(job_id, job_info, result, current_step_index)
                             batch_results.append(result)
@@ -131,15 +131,11 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 step_result = self._execute_step_with_strategy(
                     job_id, job_info, step, current_step_index, previous_step_result, repo_reader, i, start_from_step
                 )
-                # REMOVIDO: Salvar relatório imediatamente após geração (agora responsabilidade dos executores)
-                # if job_info['data'].get('analysis_report') and not job_info['data'].get('report_blob_url'):
-                #     self._save_generated_report(job_id, job_info, step_result, current_step_index)
                 self.job_handler.save_step_result(job_info, current_step_index, step_result)
                 previous_step_result = step_result
                 strategy = StepStrategyFactory.create_strategy(step, self.job_handler, self.report_handler)
                 if strategy.should_pause_for_approval(job_info, step):
                     if not job_info['data'].get('report_blob_url'):
-                        # Tentar salvar o relatório antes de lançar exceção
                         saved = self._save_generated_report(job_id, job_info, step_result, current_step_index)
                         if not job_info['data'].get('report_blob_url'):
                             raise ValueError(f"[{job_id}] ERRO CRÍTICO: Tentativa de pausar para aprovação sem relatório salvo no Blob Storage. analysis_report presente: {bool(job_info['data'].get('analysis_report'))}, tamanho: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
@@ -158,7 +154,6 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     print(f"[{job_id}] [execute_workflow] (DEPOIS update_job_status completed) gerar_relatorio_apenas: {job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS)}, tamanho analysis_report: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
                     print(f"[{job_id}] Workflow finalizado com sucesso (modo report_only)")
                     return
-            # INSTRUÇÃO DO USUÁRIO: Após o loop de steps, garantir que o relatório do step 0 seja salvo
             if (
                 steps_to_run and
                 start_from_step == 0 and
@@ -217,14 +212,10 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             job_id, job_info, step, current_step_index, 
             previous_step_result, repo_reader, llm_provider, agent_params
         )
-        # REMOVIDO: Salvar relatório imediatamente após geração (agora responsabilidade dos executores)
-        # if job_info['data'].get('analysis_report') and not job_info['data'].get('report_blob_url'):
-        #     self._save_generated_report(job_id, job_info, result, current_step_index)
         return result
                                         
     def handle_approval_step(self, job_id: str, job_info: Dict[str, Any], step_index: int, step_result: Dict[str, Any]) -> None:
         print(f"[{job_id}] Etapa requer aprovação.")
-        # Validação: report_blob_url deve estar presente antes de verificar o texto do relatório
         if job_info['data'].get('report_blob_url'):
             report_text = self.report_handler.extract_report_text(step_result)
             job_info['data']['analysis_report'] = report_text
@@ -232,7 +223,6 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             self.job_handler.set_paused_step(job_info, step_index)
             self.job_handler.update_job(job_id, job_info)
             return
-        # Tentar salvar o relatório antes de lançar exceção
         saved = self._save_generated_report(job_id, job_info, step_result, step_index)
         if not job_info['data'].get('report_blob_url'):
             raise ValueError(f"[{job_id}] ERRO CRÍTICO: Tentativa de pausar para aprovação sem relatório salvo no Blob Storage. analysis_report presente: {bool(job_info['data'].get('analysis_report'))}, tamanho: {len(job_info['data'].get('analysis_report', ''))}, report_blob_url: {job_info['data'].get('report_blob_url')}")
@@ -282,6 +272,38 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     print(f"[{job_id}] [ERRO CRÍTICO] build_result ausente no commit_details[{idx}] quando executar_build_dotnet=True")
                 if 'build_errors' not in commit:
                     print(f"[{job_id}] [ERRO CRÍTICO] build_errors ausente no commit_details[{idx}] quando executar_build_dotnet=True")
+        # --- INÍCIO DA NOVA LÓGICA PARA CRIAÇÃO DE CARDS NO AZURE BOARDS ---
+        try:
+            if job_info['data'].get('criar_cards_azure'):
+                azure_project_name = job_info['data'].get('azure_project_name')
+                organization_url = None
+                if repository_type == 'azure':
+                    parts = repo_name.split('/')
+                    if len(parts) >= 1:
+                        org_name = parts[0]
+                        organization_url = f"https://dev.azure.com/{org_name}"
+                if not azure_project_name or not organization_url:
+                    print(f"[{job_id}] [AZURE BOARDS] azure_project_name ou organization_url ausente. azure_project_name={azure_project_name}, organization_url={organization_url}")
+                    job_info['data']['cards_creation_errors'] = ["azure_project_name ou organization_url ausente"]
+                    self.job_handler.update_job(job_id, job_info)
+                else:
+                    azure_boards_service = self.dependency_container.get_azure_boards_service(organization_url, azure_project_name)
+                    report_text = job_info['data'].get('analysis_report', '')
+                    epicos = EpicoParserService.parse_epicos_from_report(report_text)
+                    print(f"[{job_id}] [AZURE BOARDS] Iniciando criação de {len(epicos)} cards de épicos no Azure Boards...")
+                    try:
+                        cards_criados = azure_boards_service.criar_multiplos_cards(epicos)
+                        job_info['data']['cards_criados'] = cards_criados
+                        print(f"[{job_id}] [AZURE BOARDS] {len(cards_criados)} cards criados com sucesso.")
+                    except Exception as e:
+                        print(f"[{job_id}] [AZURE BOARDS] Erro ao criar cards: {e}")
+                        job_info['data']['cards_creation_errors'] = [str(e)]
+                        self.job_handler.update_job(job_id, job_info)
+        except Exception as e:
+            print(f"[{job_id}] [AZURE BOARDS] Erro inesperado ao tentar criar cards: {e}")
+            job_info['data']['cards_creation_errors'] = [str(e)]
+            self.job_handler.update_job(job_id, job_info)
+        # --- FIM DA NOVA LÓGICA ---
         self.job_handler.update_job_status(job_id, 'completed')
 
     def _get_access_token(self, repository_type: str, repo_name: str) -> Optional[str]:


### PR DESCRIPTION
Modificada a função _finalize_workflow do WorkflowOrchestrator para, após commits, verificar se deve criar cards no Azure Boards. Se habilitado, extrai épicos do relatório aprovado, conecta ao Azure Boards via DependencyContainer e cria os cards. Erros são tratados e registrados no job_info. Mantém o fluxo atual de commits e build, adicionando a criação dos cards conforme nova necessidade do usuário.