### PR TITLE
Adicionado suporte a campos para o novo fluxo de geração de épicos e cards no Azure Boards no serviço de dados de jobs.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -42,7 +42,6 @@ class JobDataService:
         if not isinstance(executar_build_dotnet, bool):
             executar_build_dotnet = bool(executar_build_dotnet)
         data[JobFields.EXECUTAR_BUILD_DOTNET] = executar_build_dotnet
-        # Adiciona campos para fluxo de épicos
         data[JobFields.TRANSCRICAO_REUNIAO] = payload_dict.get('transcricao_reuniao')
         data[JobFields.GERAR_EPICOS] = payload_dict.get('gerar_epicos', False)
         data[JobFields.CRIAR_CARDS_AZURE] = payload_dict.get('criar_cards_azure', False)


### PR DESCRIPTION
Modificações no serviço JobDataService para incluir os campos transcricao_reuniao, gerar_epicos, criar_cards_azure e azure_project_name no método create_initial_job_data, permitindo configurar o job para o novo fluxo independente de commits e geração de código.