### PR TITLE
Métodos para criação de cards de épicos e tarefas no Azure Boards, suportando criação múltipla e tratamento de erros.

### DIFF
--- a/services/azure_boards_service.py
+++ b/services/azure_boards_service.py
@@ -61,7 +61,6 @@ class AzureBoardsService:
             patch_document.append(JsonPatchOperation(op="add", path="/fields/Microsoft.VSTS.Common.AcceptanceCriteria", value=tarefa.criterios_aceite))
         if tarefa.estimativa_tempo:
             patch_document.append(JsonPatchOperation(op="add", path="/fields/Microsoft.VSTS.Scheduling.OriginalEstimate", value=tarefa.estimativa_tempo))
-        # Relacionamento com épico pai
         relations = [
             {
                 "rel": "System.LinkTypes.Hierarchy-Reverse",


### PR DESCRIPTION
Adicionados métodos criar_card_tarefa e criar_multiplas_tarefas ao AzureBoardsService para criação de tarefas no Azure Boards, mantendo o método para criação de épicos e múltiplos épicos. Implementação contempla associação hierárquica das tarefas ao épico pai e tratamento de exceções para reportar erros na criação.