### PR TITLE
Ajustes no serviço de dados de jobs para refletir a remoção da variável epicos_aprovados e manter o suporte a gerar_tarefas conforme o novo fluxo.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -44,7 +44,6 @@ class JobDataService:
         data[JobFields.CRIAR_CARDS_AZURE] = payload_dict.get('criar_cards_azure', False)
         data[JobFields.AZURE_PROJECT_NAME] = payload_dict.get('azure_project_name')
         data[JobFields.GERAR_TAREFAS] = payload_dict.get('gerar_tarefas', False)
-        data[JobFields.EPICOS_APROVADOS] = payload_dict.get('epicos_aprovados')
         return {
             JobFields.STATUS: None,
             JobFields.DATA: data


### PR DESCRIPTION
Modificada a criação dos dados iniciais e derivados do job para não incluir epicos_aprovados, mantendo flags para gerar_epicos e gerar_tarefas. O fluxo de geração de tarefas permanece compatível com o prompt de criação de tarefas e não gera commits.