### PR TITLE
Modificado o método parse_tarefas_from_report para aceitar epico_nome e filtrar tarefas pelo nome do épico.

### DIFF
--- a/services/tarefa_parser_service.py
+++ b/services/tarefa_parser_service.py
@@ -1,10 +1,10 @@
 import re
-from typing import List
+from typing import List, Optional
 from models import TarefaCard
 
 class TarefaParserService:
     @staticmethod
-    def parse_tarefas_from_report(report_text: str, epico_id: str) -> List[TarefaCard]:
+    def parse_tarefas_from_report(report_text: str, epico_nome: Optional[str] = None) -> List[TarefaCard]:
         if not report_text or '| ID |' not in report_text:
             return []
         lines = [line.strip() for line in report_text.splitlines() if line.strip()]
@@ -23,17 +23,27 @@ class TarefaParserService:
             if not line.startswith('|') or line == separator:
                 continue
             columns = [col.strip() for col in line.strip('|').split('|')]
-            if len(columns) < 6:
+            # Ajuste: espera-se que a tabela de tarefas contenha epico_nome como coluna
+            if len(columns) < 7:
                 continue
-            if columns[3] != epico_id:
-                continue
+            id = columns[0]
+            titulo_tarefa = columns[1]
+            descricao_tarefa = columns[2]
+            epico_id = columns[3]
+            estimativa_tempo = columns[4]
+            criterios_aceite = columns[5]
+            epico_nome_col = columns[6]
+            if epico_nome is not None:
+                if epico_nome_col != epico_nome:
+                    continue
             tarefa = TarefaCard(
-                id=columns[0],
-                titulo_tarefa=columns[1],
-                descricao_tarefa=columns[2],
-                epico_id=columns[3],
-                estimativa_tempo=columns[4],
-                criterios_aceite=columns[5]
+                id=id,
+                titulo_tarefa=titulo_tarefa,
+                descricao_tarefa=descricao_tarefa,
+                epico_id=epico_id,
+                estimativa_tempo=estimativa_tempo,
+                criterios_aceite=criterios_aceite,
+                epico_nome=epico_nome_col
             )
             tarefas.append(tarefa)
         return tarefas


### PR DESCRIPTION
O método parse_tarefas_from_report em services/tarefa_parser_service.py foi ajustado para receber um parâmetro opcional epico_nome. Ao informar epico_nome, o parser filtra as tarefas retornadas para incluir somente aquelas cujo campo epico_nome na tabela corresponde ao parâmetro, permitindo a criação incremental de tarefas associadas a um épico específico.