### PR TITLE
Criação da interface IRepositoryProviderFactory

### DIFF
--- a/domain/interfaces/repository_provider_factory_interface.py
+++ b/domain/interfaces/repository_provider_factory_interface.py
@@ -1,0 +1,7 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+class IRepositoryProviderFactory(ABC):
+    @abstractmethod
+    def get_provider(self, repository_type: str) -> Any:
+        pass


### PR DESCRIPTION
Implementação da interface IRepositoryProviderFactory com método abstrato get_provider para obtenção de provedores de repositório conforme passo 13.