### PR TITLE
Consolidação das interfaces ILLMProvider removendo intermediárias.

### DIFF
--- a/domain/interfaces/llm_provider_interface.py
+++ b/domain/interfaces/llm_provider_interface.py
@@ -2,32 +2,19 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 class ILLMProvider(ABC):
-    """
-    Interface base para provedores de Large Language Models (LLM).
-    
-    Contrato de Implementação:
-    - Implementações devem garantir thread-safety se usadas concorrentemente
-    - Respostas devem ser estruturadas consistentemente
-    - Erros de rede/API devem ser encapsulados em RuntimeError
-    - Validação de parâmetros deve gerar ValueError
-    """
-    
     @abstractmethod
     def executar_prompt(
         self,
-        tipo_tarefa: str,          
-        prompt_principal: str,   
+        tipo_tarefa: str,
+        prompt_principal: str,
         instrucoes_extras: str = "",
         usar_rag: bool = False,
         model_name: Optional[str] = None,
         job_id: Optional[str] = None,
         max_token_out: int = 15000
     ) -> Dict[str, Any]:
-       
         pass
 
-class ILLMProviderWithRAG(ILLMProvider):
-  
     @abstractmethod
     def executar_prompt_com_rag(
         self,
@@ -39,12 +26,8 @@ class ILLMProviderWithRAG(ILLMProvider):
         job_id: Optional[str] = None,
         max_token_out: int = 15000
     ) -> Dict[str, Any]:
-       
         pass
 
-class ILLMProviderWithModelSelection(ILLMProvider):
-    
-    
     @abstractmethod
     def executar_prompt_com_modelo(
         self,
@@ -55,22 +38,4 @@ class ILLMProviderWithModelSelection(ILLMProvider):
         job_id: Optional[str] = None,
         max_token_out: int = 15000
     ) -> Dict[str, Any]:
-       
-        pass
-
-class ILLMProviderComplete(ILLMProviderWithRAG, ILLMProviderWithModelSelection):
-    
-    
-    @abstractmethod
-    def executar_prompt(
-        self,
-        tipo_tarefa: str,          
-        prompt_principal: str,   
-        instrucoes_extras: str = "",
-        usar_rag: bool = False,
-        model_name: Optional[str] = None,
-        job_id: Optional[str] = None,
-        max_token_out: int = 15000
-    ) -> Dict[str, Any]:
-        
         pass


### PR DESCRIPTION
As interfaces intermediárias ILLMProviderWithRAG e ILLMProviderWithModelSelection foram removidas. Todos os métodos relevantes foram consolidados na interface ILLMProvider, simplificando a hierarquia e facilitando a manutenção.