### PR TITLE
Criação das interfaces IReportUrlBuilder e IReportTableParser.

### DIFF
--- a/domain/interfaces/report_table_parser_interface.py
+++ b/domain/interfaces/report_table_parser_interface.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+from typing import List, Dict, Optional
+
+class IReportTableParser(ABC):
+    @abstractmethod
+    def parse_report_table(self, report_text: str, transcricao_reuniao: Optional[str] = None) -> List[Dict]:
+        pass
+
+    @abstractmethod
+    def parse_epicos_table(self, report_text: str) -> List[Dict]:
+        pass

--- a/domain/interfaces/report_url_builder_interface.py
+++ b/domain/interfaces/report_url_builder_interface.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+class IReportUrlBuilder(ABC):
+    @abstractmethod
+    def build_report_blob_path(self, projeto, analysis_type, repository_type, repo_name, branch_name, analysis_name) -> str:
+        pass
+
+    @abstractmethod
+    def build_full_url(self, blob_path: str) -> str:
+        pass


### PR DESCRIPTION
Foram criadas as interfaces IReportUrlBuilder e IReportTableParser para abstrair a construção de URLs de relatórios do Blob Storage e o parsing de tabelas de relatórios, respectivamente. Isso permite diferentes implementações e facilita testes.