### PR TITLE
Definição da interface IWorkflowFinalizer para padronizar a finalização dos workflows.

### DIFF
--- a/services/workflow_finalizers/workflow_finalizer_interface.py
+++ b/services/workflow_finalizers/workflow_finalizer_interface.py
@@ -1,0 +1,6 @@
+from abc import ABC, abstractmethod
+
+class IWorkflowFinalizer(ABC):
+    @abstractmethod
+    def finalize(self, job_id, job_info, workflow, final_result, repository_type, repo_name):
+        pass


### PR DESCRIPTION
Criação da interface abstrata IWorkflowFinalizer com método finalize, que deve ser implementado por todos os finalizadores de workflow, garantindo um contrato único para a finalização independente do modo de workflow.