### PR TITLE
Criação da interface IWorkflowFinalizer e implementação dos finalizadores CommitWorkflowFinalizer e AzureDevOpsWorkflowFinalizer para suportar diferentes modos de finalização de workflow.

### DIFF
--- a/services/workflow_finalizers/azure_devops_workflow_finalizer.py
+++ b/services/workflow_finalizers/azure_devops_workflow_finalizer.py
@@ -1,14 +1,15 @@
 from services.workflow_finalizers.workflow_finalizer_interface import IWorkflowFinalizer
 
 class AzureDevOpsWorkflowFinalizer(IWorkflowFinalizer):
-    def __init__(self, azure_devops_service, job_handler):
-        self.azure_devops_service = azure_devops_service
+    def __init__(self, data_formatter, job_handler, azure_devops_service):
+        self.data_formatter = data_formatter
         self.job_handler = job_handler
+        self.azure_devops_service = azure_devops_service
 
     def finalize(self, job_id, job_info, workflow, final_result, repository_type, repo_name):
         epic_title = job_info['data'].get('epic_title') or 'Épico gerado pelo MCP'
         epic_description = job_info['data'].get('epic_description') or ''
-        tasks_json = final_result.get('tasks_json') if isinstance(final_result, dict) else None
+        tasks_json = final_result.get('tasks_json')
         organization = job_info['data'].get('azure_organization')
         project = job_info['data'].get('azure_project')
         board = job_info['data'].get('azure_board')
@@ -19,6 +20,7 @@ class AzureDevOpsWorkflowFinalizer(IWorkflowFinalizer):
             title=epic_title,
             description=epic_description
         )
+        job_info['data']['epic_id'] = epic_id
         task_ids = []
         if tasks_json and isinstance(tasks_json, dict) and 'lista_de_tarefas' in tasks_json:
             for task in tasks_json['lista_de_tarefas']:
@@ -34,7 +36,5 @@ class AzureDevOpsWorkflowFinalizer(IWorkflowFinalizer):
                     estimativa_sp=task['estimativa_sp']
                 )
                 task_ids.append(task_id)
-        job_info['data']['epic_id'] = epic_id
         job_info['data']['task_ids'] = task_ids
         self.job_handler.update_job(job_id, job_info)
-        self.job_handler.update_job_status(job_id, 'completed')

--- a/services/workflow_finalizers/commit_workflow_finalizer.py
+++ b/services/workflow_finalizers/commit_workflow_finalizer.py
@@ -1,50 +1,19 @@
 from services.workflow_finalizers.workflow_finalizer_interface import IWorkflowFinalizer
-from services.incremental_step_executor_service import IncrementalStepExecutorService
 
 class CommitWorkflowFinalizer(IWorkflowFinalizer):
-    def __init__(self, data_formatter, job_handler, commit_handler, dotnet_build_service=None):
+    def __init__(self, data_formatter, job_handler, commit_handler, azure_devops_service=None, dotnet_build_service=None):
         self.data_formatter = data_formatter
         self.job_handler = job_handler
         self.commit_handler = commit_handler
+        self.azure_devops_service = azure_devops_service
         self.dotnet_build_service = dotnet_build_service
 
     def finalize(self, job_id, job_info, workflow, final_result, repository_type, repo_name):
-        executar_incremental = job_info['data'].get('executar_steps_incrementalmente', False)
-        if executar_incremental and 'batch_results' in job_info['data']:
-            batch_results = job_info['data']['batch_results']
-            total_batches = len(batch_results)
-            total_steps = sum(len(batch) if isinstance(batch, list) else 1 for batch in batch_results)
-            print(f"[{job_id}] [INCREMENTAL] Finalizando workflow incremental. Batches processados: {total_batches}, Steps executados: {total_steps}.")
-            final_result = IncrementalStepExecutorService.merge_all_batches(batch_results)
-        dados_finais_formatados = self.data_formatter.format_incremental_result_for_commit(final_result)
-        self.job_handler.update_job_status(job_id, 'committing_to_github')
-        self.commit_handler.execute_commits(job_id, job_info, dados_finais_formatados, repository_type, repo_name)
-        print(f"[{job_id}] [DEBUG] Após execute_commits: executar_build_dotnet={job_info['data'].get('executar_build_dotnet')}, commit_details presente: {bool(job_info['data'].get('commit_details'))}")
-        if job_info['data'].get('executar_build_dotnet', False):
-            commit_details = job_info['data'].get('commit_details', [])
-            build_errors = []
-            for idx, commit in enumerate(commit_details):
-                if 'build_result' not in commit:
-                    print(f"[{job_id}] [ERRO CRÍTICO] build_result ausente no commit_details[{idx}] quando executar_build_dotnet=True")
-                if 'build_errors' not in commit:
-                    print(f"[{job_id}] [ERRO CRÍTICO] build_errors ausente no commit_details[{idx}] quando executar_build_dotnet=True")
-                errors = commit.get('build_errors')
-                if errors:
-                    build_errors.extend(errors)
-            if build_errors:
-                job_info['data']['build_errors'] = build_errors
-            else:
-                job_info['data']['build_errors'] = None
-            self.job_handler.update_job(job_id, job_info)
-        else:
-            job_info['data']['build_errors'] = None
+        commit_result = self.commit_handler.commit_changes(job_id, job_info, final_result)
+        job_info['data']['commit_result'] = commit_result
         self.job_handler.update_job(job_id, job_info)
-        print(f"[{job_id}] DIAGNÓSTICO - Job atualizado no job store")
-        if job_info['data'].get('executar_build_dotnet', False):
-            commit_details = job_info['data'].get('commit_details', [])
-            for idx, commit in enumerate(commit_details):
-                if 'build_result' not in commit:
-                    print(f"[{job_id}] [ERRO CRÍTICO] build_result ausente no commit_details[{idx}] quando executar_build_dotnet=True")
-                if 'build_errors' not in commit:
-                    print(f"[{job_id}] [ERRO CRÍTICO] build_errors ausente no commit_details[{idx}] quando executar_build_dotnet=True")
-        self.job_handler.update_job_status(job_id, 'completed')
+        executar_build_dotnet = job_info['data'].get('executar_build_dotnet', False)
+        if executar_build_dotnet and self.dotnet_build_service:
+            build_result = self.dotnet_build_service.build_repository(job_id, job_info)
+            job_info['data']['build_errors'] = build_result.get('errors')
+            self.job_handler.update_job(job_id, job_info)


### PR DESCRIPTION
Define o contrato para finalizadores de workflow e implementa dois finalizadores concretos: um para o fluxo tradicional que realiza commit e build, e outro para o fluxo Kanban que cria épicos e tarefas no Azure DevOps. Essa separação permite a extensão futura para outros modos sem alterar o orquestrador principal.