### PR TITLE
Criação da interface IWorkflowFinalizer para definir o contrato de finalização de workflows.

### DIFF
--- a/services/workflow_finalizers/workflow_finalizer_interface.py
+++ b/services/workflow_finalizers/workflow_finalizer_interface.py
@@ -1,6 +1,3 @@
-from abc import ABC, abstractmethod
-
-class IWorkflowFinalizer(ABC):
-    @abstractmethod
+class IWorkflowFinalizer:
     def finalize(self, job_id, job_info, workflow, final_result, repository_type, repo_name):
-        pass
+        raise NotImplementedError()


### PR DESCRIPTION
A interface IWorkflowFinalizer estabelece o método finalize que deve ser implementado por todas as classes que finalizam workflows, garantindo um padrão único para a finalização e facilitando a implementação de múltiplas estratégias de finalização.