### PR TITLE
Extensão dos modelos para suportar o novo fluxo de workflow com campos específicos para épicos e tarefas.

### DIFF
--- a/models.py
+++ b/models.py
@@ -67,6 +67,9 @@ class JobFields:
     EXECUTAR_BUILD_DOTNET = 'executar_build_dotnet'
     BUILD_ERRORS = 'build_errors'
     BUILD_RESULT = 'build_result'
+    WORKFLOW_MODE = 'workflow_mode'
+    EPIC_ID = 'epic_id'
+    TASK_IDS = 'task_ids'
 
 class JobActions:
     APPROVE = 'approve'
@@ -93,3 +96,4 @@ class StartAnalysisPayload(BaseModel):
     executar_steps_incrementalmente: bool = False
     max_steps_per_batch: Optional[int] = Field(3, description="Número máximo de steps por batch na execução incremental")
     executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")
+    workflow_mode: Optional[str] = Field(None, description="Modo do workflow: 'code_generation' ou 'epic_task_creation'.")


### PR DESCRIPTION
Incluídos os campos WORKFLOW_MODE, EPIC_ID e TASK_IDS no JobFields e o campo workflow_mode no StartAnalysisPayload, permitindo distinguir e armazenar informações específicas do fluxo de criação de épicos e tarefas, sem impactar os fluxos existentes.