### PR TITLE
Ajuste na fábrica de estratégias para suportar os novos tipos de steps do workflow Kanban.

### DIFF
--- a/services/step_strategies/step_strategy_factory.py
+++ b/services/step_strategies/step_strategy_factory.py
@@ -1,17 +1,18 @@
-from typing import Dict, Any
+from typing import Dict
 from services.step_strategies.default_step_strategy import DefaultStepStrategy
+from services.step_strategies.step_strategy_interface import IStepStrategy
+from services.step_strategies.step_strategy_factory import StepStrategyFactory as _StepStrategyFactory
+from services.job_handler import JobHandler
 
 class StepStrategyFactory:
     @staticmethod
-    def create_strategy(step: Dict[str, Any], job_handler):
-        agent_type = step.get('agent_type', 'default')
-        
-        strategies = {
-            'revisor': DefaultStepStrategy,
-            'processador': DefaultStepStrategy,
-            'comparador': DefaultStepStrategy,
-            'default': DefaultStepStrategy
-        }
-        
-        strategy_class = strategies.get(agent_type, DefaultStepStrategy)
-        return strategy_class(job_handler)
+    def create_strategy(step: Dict, job_handler: JobHandler) -> IStepStrategy:
+        step_type = step.get('step_type') or step.get('tipo_analise')
+        # Para os novos tipos, usamos a estratégia padrão (pode ser extendido no futuro)
+        if step_type in [
+            'GENERATE_TASKS', 'CREATE_EPIC_AND_TASKS',
+            'GENERATE_REPORT', 'COMMIT_CODE', 'GENERATE_CODE'
+        ]:
+            return DefaultStepStrategy(job_handler)
+        # Fallback para tipos antigos ou não especificados
+        return DefaultStepStrategy(job_handler)


### PR DESCRIPTION
Incluída lógica para que os novos tipos de steps 'GENERATE_TASKS' e 'CREATE_EPIC_AND_TASKS' sejam tratados pela estratégia padrão, garantindo suporte imediato e mantendo a arquitetura aberta para futuras extensões.