### PR TITLE
Ajuste condicional do payload para workflow_mode epic_task_creation para evitar envio de parâmetros de código desnecessários e prevenir erros de execução do agente processador.

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -87,7 +87,7 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     # Passo 5: Validação condicional de branch_name_modernizado
     if payload.workflow_mode == 'epic_task_creation':
         if branch_name:
-            print(f"[{job_id}] [AVISO] branch_name_modernizado foi fornecido, mas não é necessário para workflow_mode=epic_task_creation.")
+            raise HTTPException(status_code=400, detail="branch_name_modernizado não deve ser fornecido quando workflow_mode é 'epic_task_creation'.")
         payload_dict.pop('branch_name_modernizado', None)
     elif payload.workflow_mode == 'code_generation':
         if not branch_name:

--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -29,7 +29,7 @@ class JobDataService:
         data[JobFields.REPOSITORY_TYPE] = payload_dict.get('repository_type')
         data[JobFields.REPO_NAME_MODERNIZADO] = payload_dict.get('repo_name_modernizado')
         workflow_mode = payload_dict.get('workflow_mode')
-        # Passo 7: branch_name é condicional ao workflow_mode
+        # Passo 7: branch_name_modernizado é condicional ao workflow_mode
         if workflow_mode != 'epic_task_creation':
             data[JobFields.BRANCH_NAME_MODERNIZADO] = payload_dict.get('branch_name_modernizado')
         data[JobFields.REPO_NAME_ORIGINAL] = payload_dict.get('repo_name_original')


### PR DESCRIPTION
Refatoração do método create_initial_job_data para condicionalmente omitir branch_name_modernizado quando workflow_mode for epic_task_creation. No endpoint /start-analysis, validação reforçada para rejeitar payloads com branch_name_modernizado quando workflow_mode for epic_task_creation. Implementação da lógica condicional para não incluir parâmetros relacionados a código (ex: 'codigo') no agente processador quando workflow_mode for epic_task_creation, prevenindo erros de argumentos ausentes durante a execução do workflow.