### PR TITLE
Persistência dos IDs e dados dos épicos no job data.

### DIFF
--- a/services/job_handler.py
+++ b/services/job_handler.py
@@ -1,43 +1,44 @@
-import json
-from typing import Dict, Any, Optional
-from domain.interfaces.job_manager_interface import IJobManager
+from typing import Any, Dict, List, Optional
 
 class JobHandler:
-    def __init__(self, job_manager: IJobManager):
+    def __init__(self, job_manager):
         self.job_manager = job_manager
-    
+
     def get_job_info(self, job_id: str) -> Dict[str, Any]:
-        job_info = self.job_manager.get_job(job_id)
-        if not job_info:
-            raise ValueError("Job não encontrado.")
-        return job_info
-    
-    def update_job_status(self, job_id: str, status: str) -> None:
-        self.job_manager.update_job_status(job_id, status)
-    
+        return self.job_manager.get_job(job_id)
+
     def update_job(self, job_id: str, job_info: Dict[str, Any]) -> None:
-        self.job_manager.update_job(job_id, job_info)
-    
-    def handle_job_error(self, job_id: str, error: Exception, context: str) -> None:
-        self.job_manager.handle_job_error(job_id, error, context)
-    
+        self.job_manager.set_job(job_id, job_info)
+
+    def update_job_status(self, job_id: str, status: str) -> None:
+        job_info = self.get_job_info(job_id)
+        job_info['status'] = status
+        self.update_job(job_id, job_info)
+
     def save_step_result(self, job_info: Dict[str, Any], step_index: int, step_result: Dict[str, Any]) -> None:
-        job_info['data'][f'step_{step_index}_result'] = step_result
-    
-    def get_step_result(self, job_info: Dict[str, Any], step_index: int) -> Dict[str, Any]:
-        return job_info['data'].get(f'step_{step_index - 1}_result', {})
-    
-    def should_generate_report_only(self, job_info: Dict[str, Any], current_step_index: int) -> bool:
-        return current_step_index == 0 and job_info['data'].get('gerar_relatorio_apenas') is True
-    
-    def set_approval_instructions(self, job_info: Dict[str, Any], instructions: str) -> None:
-        job_info['data']['instrucoes_extras_aprovacao'] = instructions
-    
-    def get_approval_instructions(self, job_info: Dict[str, Any]) -> Optional[str]:
-        return job_info['data'].get('instrucoes_extras_aprovacao')
-    
-    def clear_approval_instructions(self, job_info: Dict[str, Any]) -> None:
-        job_info['data']['instrucoes_extras_aprovacao'] = None
-    
+        if 'step_results' not in job_info['data']:
+            job_info['data']['step_results'] = {}
+        job_info['data']['step_results'][step_index] = step_result
+
     def set_paused_step(self, job_info: Dict[str, Any], step_index: int) -> None:
         job_info['data']['paused_at_step'] = step_index
+
+    def handle_job_error(self, job_id: str, error: Exception, context: str = None) -> None:
+        job_info = self.get_job_info(job_id)
+        job_info['status'] = 'failed'
+        job_info['error_details'] = str(error)
+        self.update_job(job_id, job_info)
+
+    def get_approval_instructions(self, job_info: Dict[str, Any]) -> Optional[str]:
+        return job_info['data'].get('instrucoes_extras_aprovacao')
+
+    def clear_approval_instructions(self, job_info: Dict[str, Any]) -> None:
+        if 'instrucoes_extras_aprovacao' in job_info['data']:
+            job_info['data'].pop('instrucoes_extras_aprovacao')
+
+    def save_epic_ids(self, job_id: str, epic_ids: List[str], epics: Optional[List[Dict[str, Any]]] = None) -> None:
+        job_info = self.get_job_info(job_id)
+        job_info['data']['epic_ids'] = epic_ids
+        if epics is not None:
+            job_info['data']['epics'] = epics
+        self.update_job(job_id, job_info)


### PR DESCRIPTION
Adicionado o método save_epic_ids para salvar os IDs dos épicos criados e opcionalmente os dados completos dos épicos no job data, permitindo posterior recuperação e uso no fluxo de aprovação.