### PR TITLE
Método create_epic implementado para criação de épicos no Azure DevOps via API REST.

### DIFF
--- a/services/azure_devops_service.py
+++ b/services/azure_devops_service.py
@@ -1,16 +1,29 @@
+import requests
+import base64
+
 class AzureDevOpsService:
     def __init__(self):
         pass
-    def create_epic(self, organization, project, board, title, objetivo_negocio=None, criterios_aceite=None, perfis_envolvidos=None, estimativa_esforco=None, description=None):
-        epic_fields = {
-            'title': title,
-            'description': description if description is not None else objetivo_negocio,
-            'objetivo_negocio': objetivo_negocio,
-            'criterios_aceite': criterios_aceite,
-            'perfis_envolvidos': perfis_envolvidos,
-            'estimativa_esforco': estimativa_esforco
+
+    def create_epic(self, organization, project, board, title, description, token):
+        url = f"https://dev.azure.com/{organization}/{project}/_apis/wit/workitems/$Epic?api-version=7.1"
+        headers = {
+            "Content-Type": "application/json-patch+json",
+            "Authorization": f"Basic {base64.b64encode(f':{token}'.encode()).decode()}"
         }
-        epic_id = self._create_work_item(organization, project, board, epic_fields)
-        return epic_id
-    def _create_work_item(self, organization, project, board, fields):
-        return f"EPIC-{organization}-{project}-{fields['title']}"
+        payload = [
+            {"op": "add", "path": "/fields/System.Title", "value": title},
+            {"op": "add", "path": "/fields/System.Description", "value": description},
+            {"op": "add", "path": "/fields/System.AreaPath", "value": board},
+            {"op": "add", "path": "/fields/System.IterationPath", "value": board}
+        ]
+        try:
+            response = requests.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+            epic_id = data.get('id')
+            epic_url = data.get('url')
+            return {"epic_id": epic_id, "epic_url": epic_url}
+        except Exception as e:
+            print(f"[AzureDevOpsService] Erro ao criar épico: {e}")
+            raise


### PR DESCRIPTION
O método monta a URL correta para criação do work item do tipo Epic, configura os headers com autenticação básica usando o token obtido, monta o payload com os campos necessários e realiza a requisição POST. Em caso de sucesso, retorna o ID e URL do épico criado.