### PR TITLE
Remoção do parâmetro 'modo_adicao_incremental' e simplificação da função de processamento de branches por provedor.

### DIFF
--- a/tools/repo_committers/orchestrator.py
+++ b/tools/repo_committers/orchestrator.py
@@ -19,32 +19,28 @@ def processar_branch_por_provedor(
     mensagem_pr: str,
     descricao_pr: str,
     conjunto_de_mudancas: list,
-    repository_type: str,
-    modo_adicao_incremental: bool = False
+    repository_type: str
 ) -> Dict[str, Any]:
     nome_branch_sanitizado = BranchNameSanitizer.sanitize(nome_branch)
     if repository_type == 'azure':
         print(f"[DEBUG] Usando repository_type explícito: Azure DevOps")
         resultado = processar_branch_azure(
             repo, nome_branch_sanitizado, branch_de_origem, branch_alvo_do_pr,
-            mensagem_pr, descricao_pr, conjunto_de_mudancas,
-            modo_adicao_incremental=modo_adicao_incremental
+            mensagem_pr, descricao_pr, conjunto_de_mudancas
         )
         print(f"[DEBUG][orchestrator] Resultado Azure: {json.dumps(resultado, default=str)}")
     elif repository_type == 'gitlab':
         print(f"[DEBUG] Usando repository_type explícito: GitLab")
         resultado = processar_branch_gitlab(
             repo, nome_branch_sanitizado, branch_de_origem, branch_alvo_do_pr,
-            mensagem_pr, descricao_pr, conjunto_de_mudancas,
-            modo_adicao_incremental=modo_adicao_incremental
+            mensagem_pr, descricao_pr, conjunto_de_mudancas
         )
         print(f"[DEBUG][orchestrator] Resultado GitLab: {json.dumps(resultado, default=str)}")
     else:
         print(f"[DEBUG] Usando repository_type explícito: GitHub")
         resultado = processar_branch_github(
             repo, nome_branch_sanitizado, branch_de_origem, branch_alvo_do_pr,
-            mensagem_pr, descricao_pr, conjunto_de_mudancas,
-            modo_adicao_incremental=modo_adicao_incremental
+            mensagem_pr, descricao_pr, conjunto_de_mudancas
         )
         print(f"[DEBUG][orchestrator] Resultado GitHub: {json.dumps(resultado, default=str)}")
     print(f"[DEBUG][orchestrator] Resultado retornado pelo committer ({repository_type}): {json.dumps(resultado, indent=2, default=str)}")


### PR DESCRIPTION
A função processar_branch_por_provedor foi ajustada para não receber mais o parâmetro 'modo_adicao_incremental'. As chamadas para os committers específicos foram atualizadas para refletir essa mudança, simplificando o fluxo e eliminando código morto.