### PR TITLE
Remoção do parâmetro 'modo_adicao_incremental' e simplificação da lógica de commit e PR para Azure DevOps.

### DIFF
--- a/tools/repo_committers/azure_committer.py
+++ b/tools/repo_committers/azure_committer.py
@@ -31,8 +31,7 @@ def processar_branch_azure(
     branch_alvo_do_pr: str,
     mensagem_pr: str,
     descricao_pr: str,
-    conjunto_de_mudancas: list,
-    modo_adicao_incremental: bool = False
+    conjunto_de_mudancas: list
 ) -> Dict[str, Any]:
     resultado_branch = BaseCommitter._inicializar_resultado_branch(nome_branch)
     sanitized = BranchNameSanitizer.sanitize(nome_branch)
@@ -102,12 +101,6 @@ def processar_branch_azure(
                 change_item["changeType"] = "add"
                 change_item["newContent"] = {"content": conteudo or "", "contentType": "rawtext"}
             elif status == "MODIFICADO":
-                if modo_adicao_incremental:
-                    get_item_url = f"{base_url}/git/repositories/{repository_id}/items?path=/{caminho}&api-version=7.0"
-                    item_response = requests.get(get_item_url, headers=headers, timeout=30)
-                    if item_response.status_code == 200:
-                        conteudo_existente = item_response.text
-                        conteudo = BaseCommitter._mesclar_conteudo(conteudo_existente, conteudo)
                 change_item["changeType"] = "edit"
                 change_item["newContent"] = {"content": conteudo or "", "contentType": "rawtext"}
             elif status == "REMOVIDO":


### PR DESCRIPTION
O parâmetro 'modo_adicao_incremental' foi removido da função processar_branch_azure e toda a lógica condicional relacionada foi eliminada. As mudanças agora sempre sobrescrevem o conteúdo dos arquivos. Código redundante e variáveis não utilizadas foram removidos para melhorar a clareza e manutenção.