### PR TITLE
Garantia de execução do step 0, salvamento do relatório, atualização do status para 'completed' e retorno imediato do workflow quando gerar_relatorio_apenas=True.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -71,7 +71,8 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             steps_to_run = workflow.get('steps', [])[start_from_step:]
             executar_incremental = job_info['data'].get(JobFields.EXECUTAR_STEPS_INCREMENTALMENTE, False)
             max_steps_per_batch = job_info['data'].get(JobFields.MAX_STEPS_PER_BATCH, 3)
-            if not executar_incremental and not job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS, False):
+            gerar_relatorio_apenas = job_info['data'].get(JobFields.GERAR_RELATORIO_APENAS, False)
+            if not executar_incremental and not gerar_relatorio_apenas:
                 raise ValueError("Modo não-incremental descontinuado. Use executar_steps_incrementalmente=True ou gerar_relatorio_apenas=True.")
             if executar_incremental and start_from_step == 1:
                 if JobFields.STEP_BATCHES not in job_info['data'] or not job_info['data'][JobFields.STEP_BATCHES]:
@@ -126,11 +127,15 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     step_result = self._execute_step_with_strategy(
                         job_id, job_info, step, current_step_index, previous_step_result, repo_reader, i, start_from_step
                     )
-                    # Salvar relatório no step 0 assim que for gerado
                     if current_step_index == 0:
                         self._save_generated_report(job_id, job_info, step_result, current_step_index)
+                        if gerar_relatorio_apenas:
+                            self.job_handler.update_job_status(job_id, 'completed')
+                            print(f"[{job_id}] [DEBUG] gerar_relatorio_apenas=True detectado após step 0. Status atualizado para completed. Encerrando workflow.")
+                            return
                     previous_step_result = step_result
-            self._finalize_workflow(job_id, job_info, workflow, previous_step_result, repository_type, repo_name)
+            if not gerar_relatorio_apenas:
+                self._finalize_workflow(job_id, job_info, workflow, previous_step_result, repository_type, repo_name)
         except Exception as e:
             self.job_handler.handle_job_error(job_id, e, 'workflow')
             


### PR DESCRIPTION
Modificada a função execute_workflow para que, ao detectar gerar_relatorio_apenas=True, execute somente o step 0, salve o relatório, atualize o status para 'completed' e retorne imediatamente, evitando a execução dos demais steps e a chamada de _finalize_workflow.