### PR TITLE
Incluída validação no endpoint /start-analysis para exigir analysis_name quando gerar_novo_relatorio=False. O campo gerar_novo_relatorio é propagado corretamente para o job, garantindo consistência e evitando erros.

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -16,7 +16,7 @@ from services.api_service_factory import ApiServiceFactory
 from services.pull_request_extractor_service import PullRequestExtractorService
 from services.job_logging_service import JobLoggingService
 from services.response_builder_service import FinalStatusResponse
-from models import JobStatus, JobFields, JobActions
+from models import JobStatus, JobFields, JobActions, StartAnalysisPayload, ValidAnalysisTypes
 
 container = DependencyContainer()
 pr_extractor = PullRequestExtractorService()
@@ -33,28 +33,6 @@ job_data_service = api_service_factory.get_job_data_service()
 job_validation_service = api_service_factory.get_job_validation_service()
 logging_service = api_service_factory.get_logging_service()
 
-class StartAnalysisPayload(BaseModel):
-    repo_name_modernizado: str = Field(description="Nome do repositório modernizado")
-    branch_name_modernizado: Optional[str] = Field(None, description="Branch do repositório modernizado")
-    projeto: str = Field(description="Nome do projeto para agrupar atividades e organizar histórico")
-    analysis_type: ValidAnalysisTypes
-    instrucoes_extras: Optional[str] = None
-    usar_rag: bool = Field(False)
-    gerar_relatorio_apenas: bool = Field(False)
-    gerar_novo_relatorio: bool = Field(True, description="Se False, tenta ler relatório existente do Blob Storage usando analysis_name")
-    model_name: Optional[str] = Field(None, description="Nome do modelo de LLM a ser usado. Se nulo, usa o padrão.")
-    arquivos_especificos: Optional[List[str]] = Field(None, description="Lista opcional de caminhos específicos de arquivos para ler. Se fornecido, apenas esses arquivos serão processados.")
-    analysis_name: Optional[str] = Field(None, description="Nome personalizado para identificar a análise.")
-    repository_type: Literal['github', 'gitlab', 'azure'] = Field(description="Tipo do repositório: 'github', 'gitlab', 'azure'.")
-    repo_name_original: Optional[str] = Field(None, description="Nome do repositório original para comparação")
-    branch_name_original: Optional[str] = Field(None, description="Branch do repositório original")
-    retornar_lista_arquivos: bool = Field(False, description="Se True, além do código filtrado, retorna lista completa de todos os arquivos do repositório")
-    usuario_executor: Optional[str] = Field(None, description="Nome do usuário que está executando a análise")
-    executar_steps_incrementalmente: bool = Field(
-        True, description="[DEPRECATED: O valor False está descontinuado e será removido em versões futuras. Use sempre True.] Se True, os passos do relatório de implementação serão executados de forma incremental (um ou mais passos por vez, respeitando dependências), ao invés de enviar todas as mudanças de uma só vez. Útil para relatórios extensos que podem exceder limites de tokens da LLM.")
-    executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")
-    max_steps_per_batch: Optional[int] = Field(3, description="Número máximo de steps por batch na execução incremental")
-    
 class StartAnalysisResponse(BaseModel):
     job_id: str
     
@@ -93,6 +71,8 @@ def run_workflow_task(job_id: str, start_from_step: int = 0):
 def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTasks):
     if payload.executar_steps_incrementalmente is False and payload.gerar_relatorio_apenas is False:
         raise HTTPException(status_code=400, detail="Modo não-incremental descontinuado. Use executar_steps_incrementalmente=True ou gerar_relatorio_apenas=True.")
+    if payload.gerar_novo_relatorio is False and (payload.analysis_name is None or str(payload.analysis_name).strip() == ""):
+        raise HTTPException(status_code=400, detail="analysis_name é obrigatório quando gerar_novo_relatorio=False")
     job_store = container.get_job_store()
     analysis_service = container.get_analysis_name_service()
     repo_name = payload.repo_name_modernizado


### PR DESCRIPTION
No endpoint de início de análise, adicionada checagem para que, se gerar_novo_relatorio for False, o campo analysis_name seja obrigatório e não vazio. Isso assegura que a lógica de reutilização do relatório funcione corretamente, pois depende do nome da análise para buscar no Blob Storage.