### PR TITLE
Adição do campo gerar_novo_relatorio no modelo StartAnalysisPayload com comportamento condicional para reutilização de relatório existente no Blob Storage.

### DIFF
--- a/models.py
+++ b/models.py
@@ -79,7 +79,10 @@ class StartAnalysisPayload(BaseModel):
     instrucoes_extras: Optional[str] = None
     usar_rag: bool = False
     gerar_relatorio_apenas: bool = False
-    gerar_novo_relatorio: bool = True
+    gerar_novo_relatorio: bool = Field(
+        True,
+        description="Se False, tenta ler relatório existente do Blob Storage usando analysis_name antes de gerar um novo"
+    )
     model_name: Optional[str] = None
     arquivos_especificos: Optional[List[str]] = None
     analysis_name: Optional[str] = None
@@ -89,6 +92,7 @@ class StartAnalysisPayload(BaseModel):
     retornar_lista_arquivos: bool = False
     usuario_executor: Optional[str] = None
     executar_steps_incrementalmente: bool = Field(
-        True, description="[DEPRECATED: O valor False está descontinuado e será removido em versões futuras. Use sempre True.] Se True, os passos do relatório de implementação serão executados de forma incremental (um ou mais passos por vez, respeitando dependências), ao invés de enviar todas as mudanças de uma só vez. Útil para relatórios extensos que podem exceder limites de tokens da LLM.")
+        True, description="[DEPRECATED: O valor False está descontinuado e será removido em versões futuras. Use sempre True.] Se True, os passos do relatório de implementação serão executados de forma incremental (um ou mais passos por vez, respeitando dependências), ao invés de enviar todas as mudanças de uma só vez. Útil para relatórios extensos que podem exceder limites de tokens da LLM."
+    )
     max_steps_per_batch: Optional[int] = Field(3, description="Número máximo de steps por batch na execução incremental")
     executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")


### PR DESCRIPTION
Incluído o campo booleano gerar_novo_relatorio no modelo StartAnalysisPayload em models.py, com valor padrão True. Atualizada a descrição para explicitar que, se False, o sistema tentará buscar o relatório existente no Blob Storage usando o analysis_name e, se não encontrado, acionará a geração do relatório. Essa alteração atende à solicitação do usuário para otimizar a geração de relatórios evitando processamento desnecessário.