### PR TITLE
Inclusão do método singleton get_azure_board_service() para prover AzureBoardService no DependencyContainer.

### DIFF
--- a/services/dependency_container.py
+++ b/services/dependency_container.py
@@ -12,6 +12,7 @@ from tools.rag_retriever import AzureAISearchRAGRetriever
 from tools.preenchimento import ChangesetFiller
 from services.redis_cache_service import RedisCacheService
 from tools.azure_secret_manager import AzureSecretManager
+from services.azure_board_service import AzureBoardService
 
 class DependencyContainer:
     def __init__(self):
@@ -29,6 +30,7 @@ class DependencyContainer:
         self._changeset_filler = None
         self._redis_cache_service = None
         self._secret_manager = None
+        self._azure_board_service = None
     
     def get_job_store(self) -> RedisJobStore:
         if self._job_store is None:
@@ -87,7 +89,6 @@ class DependencyContainer:
     
     def get_redis_cache_service(self) -> RedisCacheService:
         if self._redis_cache_service is None:
-            # Pega a instância única do job_store e a injeta no RedisCacheService
             job_store_instance = self.get_job_store()
             self._redis_cache_service = RedisCacheService(job_store=job_store_instance)
         return self._redis_cache_service
@@ -115,3 +116,8 @@ class DependencyContainer:
             cache = AnalysisNameCache(self.get_job_store())
             self._analysis_name_service = AnalysisNameService(cache)
         return self._analysis_name_service
+
+    def get_azure_board_service(self) -> AzureBoardService:
+        if self._azure_board_service is None:
+            self._azure_board_service = AzureBoardService(secret_manager=self.get_secret_manager())
+        return self._azure_board_service


### PR DESCRIPTION
Foi adicionado o método get_azure_board_service() no DependencyContainer, seguindo o padrão dos outros serviços singleton. O AzureBoardService é instanciado com o AzureSecretManager injetado, garantindo a integração segura com o Azure DevOps para criação dos épicos conforme o novo fluxo.