### PR TITLE
Inclusão de log específico no endpoint /status/{job_id} para exibir detalhes de jobs de criação de épicos Azure finalizados.

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -224,6 +224,8 @@ def get_status(job_id: str = Path(..., title="O ID do Job a ser verificado")):
     print(f"[{job_id}] [get_status] gerar_relatorio_apenas: {gerar_relatorio_apenas}")
     print(f"[{job_id}] [get_status] Tamanho analysis_report: {len(analysis_report) if analysis_report else 0}")
     print(f"[{job_id}] [get_status] report_blob_url: {blob_url}")
+    if status == JobStatus.COMPLETED and job_data.get('criar_epicos_azure'):
+        print(f"[{job_id}] [get_status] Job de criação de épicos finalizado. Epicos criados: {job_data.get('epicos_criados')}")
     try:
         if status == JobStatus.COMPLETED:
             return response_builder_service.build_completed_response(job_id, job, blob_url)


### PR DESCRIPTION
Foi adicionado um print no endpoint get_status para quando o status do job for 'completed' e o job for de criação de épicos Azure (criar_epicos_azure=True). Esse log exibe o conteúdo de 'epicos_criados' para auxiliar no monitoramento e diagnóstico do fluxo de criação de épicos. O restante do endpoint foi mantido inalterado conforme solicitado.