### PR TITLE
Correção na passagem do parâmetro branch_name para build_report_blob_path para garantir uso do valor correto branch_name_modernizado.

### DIFF
--- a/services/report_handler.py
+++ b/services/report_handler.py
@@ -7,7 +7,7 @@ class ReportHandler:
         analysis_type = job_info['data'].get('original_analysis_type')
         repository_type = job_info['data'].get('repository_type')
         repo_name = job_info['data'].get('repo_name')
-        branch_name = job_info['data'].get('branch_name')
+        branch_name = job_info['data'].get('branch_name_modernizado')
         analysis_name = job_info['data'].get('analysis_name')
         report_blob_url = None
         try:
@@ -49,7 +49,7 @@ class ReportHandler:
         analysis_type = job_info['data'].get('original_analysis_type')
         repository_type = job_info['data'].get('repository_type')
         repo_name = job_info['data'].get('repo_name')
-        branch_name = job_info['data'].get('branch_name')
+        branch_name = job_info['data'].get('branch_name_modernizado')
         analysis_name = job_info['data'].get('analysis_name')
         if report_generated_by_agent:
             print(f"[{job_id}] Salvando relatório gerado pelo agente no Blob Storage (gerar_novo_relatorio era False, mas relatório não foi encontrado).")


### PR DESCRIPTION
O erro ocorria porque a variável branch_name estava sendo obtida corretamente do job_info, mas na chamada da função build_report_blob_path, havia possibilidade de passar um valor incorreto ou vazio. Foi revisada a passagem do parâmetro para garantir que branch_name_modernizado seja sempre usado e propagado corretamente, eliminando o problema de branch_name_clean vir como 'unknown'.