### PR TITLE
Implementa o comportamento esperado para gerar_novo_relatorio=False no step 0, buscando o relatório no Blob Storage com o caminho correto e gerando novo relatório somente se não encontrado.

### DIFF
--- a/services/report_handler.py
+++ b/services/report_handler.py
@@ -21,14 +21,22 @@ class ReportHandler:
                 report_blob_url = f"{account_url}/{container_name}/{blob_path}"
             elif container_name:
                 report_blob_url = f"/{container_name}/{blob_path}"
-            if report_blob_url:
-                try:
-                    self.blob_storage.update_job_tracker(report_blob_url, job_id)
-                except Exception as e:
-                    print(f"[ReportHandler] Warning: Failed to update job tracker after reading report: {e}")
-            return report_text
+            if report_text is not None:
+                print(f"[ReportHandler] Relatório encontrado no Blob Storage: {report_blob_url} (tamanho: {len(report_text)})")
+                if report_blob_url:
+                    try:
+                        self.blob_storage.update_job_tracker(report_blob_url, job_id)
+                    except Exception as e:
+                        print(f"[ReportHandler] Warning: Failed to update job tracker after reading report: {e}")
+                return report_text
+            else:
+                print(f"[ReportHandler] Relatório NÃO encontrado no Blob Storage: {report_blob_url}")
+                return None
         except Exception as e:
-            print(f"[ReportHandler] Warning: Failed to read report or update tracker: {e}")
+            if "BlobNotFound" in str(e) or "404" in str(e):
+                print(f"[ReportHandler] Relatório NÃO encontrado no Blob Storage (BlobNotFound/404): {report_blob_url}")
+                return None
+            print(f"[ReportHandler] Erro ao tentar ler relatório do Blob Storage: {e}")
             return None
 
     def extract_report_text(self, step_result):


### PR DESCRIPTION
Quando gerar_novo_relatorio for False e current_step_index for 0, o método try_read_existing_report é chamado para tentar obter o relatório do Blob Storage usando o caminho formatado conforme a especificação do usuário (com nomes limpos e extensão .md). Se o relatório não for encontrado (retorna None), o sistema prossegue para gerar um novo relatório. Isso previne travamentos e garante o fluxo correto. Também foram mantidos logs detalhados para rastreamento.