### PR TITLE
Adicionado utilitário para gerar chave de cache sanitizada para relatórios.

### DIFF
--- a/tools/cache_key_builder.py
+++ b/tools/cache_key_builder.py
@@ -1,0 +1,8 @@
+import re
+
+def build_cache_key_for_report(projeto, analysis_type, repository_type, repo_name, branch_name, analysis_name):
+    def sanitize(s):
+        if not s:
+            return "unknown"
+        return re.sub(r'[<>:"|?*\\\\/]', '_', str(s))
+    return f"report:{sanitize(projeto)}:{sanitize(analysis_type)}:{sanitize(repository_type)}:{sanitize(repo_name)}:{sanitize(branch_name)}:{sanitize(analysis_name)}"


### PR DESCRIPTION
Criado função build_cache_key_for_report que sanitiza os parâmetros e gera uma chave única para cache de relatórios, evitando caracteres inválidos em paths ou chaves.