### PR TITLE
Adição de campos para suporte ao novo agente de análise baseado em épicos do Azure DevOps

### DIFF
--- a/models.py
+++ b/models.py
@@ -74,6 +74,9 @@ class JobFields:
     AZURE_ORGANIZATION = 'azure_organization'
     AZURE_PROJECT = 'azure_project'
     EPICOS_CRIADOS = 'epicos_criados'
+    EPIC_ID = 'epic_id'
+    ORGANIZATION = 'organization'
+    PROJECT = 'project'
 
 class JobActions:
     APPROVE = 'approve'
@@ -83,3 +86,26 @@ class ValidAnalysisTypes(str):
     MODERNIZACAO = 'modernizacao'
     IMPLEMENTACAO = 'implementacao'
     CRIACAO_EPICOS = 'criacao_epicos'
+
+class StartAnalysisPayload(BaseModel):
+    repo_name_modernizado: str = Field(description="Nome do repositório modernizado")
+    branch_name_modernizado: Optional[str] = Field(None, description="Branch do repositório modernizado")
+    projeto: str = Field(description="Nome do projeto para agrupar atividades e organizar histórico")
+    analysis_type: ValidAnalysisTypes
+    instrucoes_extras: Optional[str] = None
+    usar_rag: bool = Field(False)
+    gerar_relatorio_apenas: bool = Field(False)
+    model_name: Optional[str] = Field(None, description="Nome do modelo de LLM a ser usado. Se nulo, usa o padrão.")
+    arquivos_especificos: Optional[List[str]] = Field(None, description="Lista opcional de caminhos específicos de arquivos para ler. Se fornecido, apenas esses arquivos serão processados.")
+    analysis_name: Optional[str] = Field(None, description="Nome personalizado para identificar a análise.")
+    repository_type: Literal['github', 'gitlab', 'azure'] = Field(description="Tipo do repositório: 'github', 'gitlab', 'azure'.")
+    repo_name_original: Optional[str] = Field(None, description="Nome do repositório original para comparação")
+    branch_name_original: Optional[str] = Field(None, description="Branch do repositório original")
+    retornar_lista_arquivos: bool = False
+    usuario_executor: Optional[str] = None
+    executar_steps_incrementalmente: bool = Field(
+        True, description="[DEPRECATED: O valor False está descontinuado e será removido em versões futuras. Use sempre True.] Se True, os passos do relatório de implementação serão executados de forma incremental (um ou mais passos por vez, respeitando dependências), ao invés de enviar todas as mudanças de uma só vez. Útil para relatórios extensos que podem exceder limites de tokens da LLM.")
+    max_steps_per_batch: Optional[int] = Field(3, description="Número máximo de steps por batch na execução incremental")
+    executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")
+    criar_epicos_azure: bool = Field(False, description="Se True, após aprovação, cria os épicos no Azure DevOps Board")
+    epic_id: Optional[str] = Field(None, description="ID do épico do Azure DevOps para geração de tarefas. Obrigatório quando analysis_type for 'criacao_tarefas_azure_devops'.")


### PR DESCRIPTION
Incluído campo opcional 'epic_id' no modelo StartAnalysisPayload para identificar épico do Azure DevOps. Adicionados campos 'EPIC_ID', 'ORGANIZATION' e 'PROJECT' na classe JobFields para armazenar dados extraídos do repo_name_modernizado. Essas alterações permitem que o novo agente utilize informações do épico e do contexto do projeto para gerar relatórios detalhados.