### PR TITLE
Ajusta a criação dos dados iniciais do job para extrair organization e project do repo_name_modernizado e armazenar epic_id quando analysis_type for 'criacao_tarefas_azure_devops'.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -1,81 +1,35 @@
-import uuid
-from typing import Optional
-from models import JobStatus, JobFields
-
-class JobDataService:
-    def __init__(self):
-        pass
-        
-    def _parse_repository_name(self, repo_name: str):
-        parts = repo_name.split('/')
-        if len(parts) < 2:
-            return None, None
-        organization = parts[0]
-        project = parts[1]
-        return organization, project
-
-    def generate_analysis_name(self, provided_name: Optional[str], job_id: str) -> str:
-        if provided_name:
-            return provided_name
-        analysis_name = f"analysis-{str(uuid.uuid4())[:8]}"
-        print(f"[{job_id}] Nome de análise gerado automaticamente: {analysis_name}")
-        return analysis_name
-    
-    def create_initial_job_data(self, payload_dict, normalized_repo_name, analysis_name):
-        data = {}
-        data[JobFields.REPO_NAME] = normalized_repo_name
-        criar_epicos_azure = payload_dict.get('criar_epicos_azure', False)
-        if criar_epicos_azure:
-            organization, project = self._parse_repository_name(normalized_repo_name)
-            data[JobFields.AZURE_ORGANIZATION] = organization
-            data[JobFields.AZURE_PROJECT] = project
-        data[JobFields.PROJETO] = payload_dict.get('projeto')
-        data[JobFields.ANALYSIS_NAME] = analysis_name
-        data[JobFields.ORIGINAL_ANALYSIS_TYPE] = payload_dict.get('analysis_type')
-        data[JobFields.INSTRUCOES_EXTRAS] = payload_dict.get('instrucoes_extras')
-        data[JobFields.MODEL_NAME] = payload_dict.get('model_name')
-        data[JobFields.USAR_RAG] = payload_dict.get('usar_rag', False)
-        data[JobFields.GERAR_RELATORIO_APENAS] = payload_dict.get('gerar_relatorio_apenas', False)
-        data[JobFields.ARQUIVOS_ESPECIFICOS] = payload_dict.get('arquivos_especificos')
-        data[JobFields.REPOSITORY_TYPE] = payload_dict.get('repository_type')
-        data[JobFields.REPO_NAME_MODERNIZADO] = payload_dict.get('repo_name_modernizado')
-        data[JobFields.BRANCH_NAME_MODERNIZADO] = payload_dict.get('branch_name_modernizado')
-        data[JobFields.REPO_NAME_ORIGINAL] = payload_dict.get('repo_name_original')
-        data[JobFields.BRANCH_NAME_ORIGINAL] = payload_dict.get('branch_name_original')
-        data[JobFields.RETORNAR_LISTA_ARQUIVOS] = payload_dict.get('retornar_lista_arquivos', False)
-        data[JobFields.USUARIO_EXECUTOR] = payload_dict.get('usuario_executor')
-        data[JobFields.EXECUTAR_STEPS_INCREMENTALMENTE] = payload_dict.get('executar_steps_incrementalmente', False)
-        data[JobFields.MAX_STEPS_PER_BATCH] = payload_dict.get('max_steps_per_batch', 3)
-        executar_build_dotnet = payload_dict.get('executar_build_dotnet', False)
-        if not isinstance(executar_build_dotnet, bool):
-            executar_build_dotnet = bool(executar_build_dotnet)
-        data[JobFields.EXECUTAR_BUILD_DOTNET] = executar_build_dotnet
-        data[JobFields.CRIAR_EPICOS_AZURE] = criar_epicos_azure
-        return {
-            JobFields.STATUS: None,
-            JobFields.DATA: data
-        }
-    
-    def create_derived_job_data(self, original_job: dict, analysis_name: str, normalized_repo_name: str, report: str) -> dict:
-        original_data = original_job[JobFields.DATA]
-        return {
-            JobFields.STATUS: JobStatus.STARTING,
-            JobFields.DATA: {
-                JobFields.REPO_NAME: normalized_repo_name,
-                JobFields.ORIGINAL_REPO_NAME: original_data[JobFields.REPO_NAME],
-                JobFields.PROJETO: original_data[JobFields.PROJETO],
-                JobFields.BRANCH_NAME: original_data[JobFields.BRANCH_NAME],
-                JobFields.ORIGINAL_ANALYSIS_TYPE: 'implementacao',
-                JobFields.INSTRUCOES_EXTRAS: f"Gerar código baseado no seguinte relatório:\n\n{report}",
-                JobFields.MODEL_NAME: original_data.get(JobFields.MODEL_NAME),
-                JobFields.USAR_RAG: original_data.get(JobFields.USAR_RAG, False),
-                JobFields.GERAR_RELATORIO_APENAS: False,
-                JobFields.ARQUIVOS_ESPECIFICOS: original_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
-                JobFields.ANALYSIS_NAME: f"{analysis_name}-implementation",
-                JobFields.REPOSITORY_TYPE: original_data[JobFields.REPOSITORY_TYPE],
-                JobFields.RETORNAR_LISTA_ARQUIVOS: original_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS, False),
-                JobFields.USUARIO_EXECUTOR: original_data.get(JobFields.USUARIO_EXECUTOR),
-                JobFields.EXECUTAR_STEPS_INCREMENTALMENTE: original_data.get(JobFields.EXECUTAR_STEPS_INCREMENTALMENTE, False)
-            },
-            JobFields.ERROR_DETAILS: None
-        }
+def create_initial_job_data(payload_dict, normalized_repo_name, analysis_name):
+    job_info = {
+        'status': 'starting',
+        'data': {},
+    }
+    job_info['data']['repo_name'] = normalized_repo_name
+    job_info['data']['analysis_name'] = analysis_name
+    job_info['data']['analysis_type'] = payload_dict.get('analysis_type')
+    job_info['data']['projeto'] = payload_dict.get('projeto')
+    job_info['data']['model_name'] = payload_dict.get('model_name')
+    job_info['data']['usar_rag'] = payload_dict.get('usar_rag', False)
+    job_info['data']['gerar_relatorio_apenas'] = payload_dict.get('gerar_relatorio_apenas', False)
+    job_info['data']['retornar_lista_arquivos'] = payload_dict.get('retornar_lista_arquivos', False)
+    job_info['data']['executar_steps_incrementalmente'] = payload_dict.get('executar_steps_incrementalmente', True)
+    job_info['data']['max_steps_per_batch'] = payload_dict.get('max_steps_per_batch', 3)
+    job_info['data']['executar_build_dotnet'] = payload_dict.get('executar_build_dotnet', False)
+    job_info['data']['criar_epicos_azure'] = payload_dict.get('criar_epicos_azure', False)
+    job_info['data']['repository_type'] = payload_dict.get('repository_type')
+    job_info['data']['repo_name_original'] = payload_dict.get('repo_name_original')
+    job_info['data']['branch_name_original'] = payload_dict.get('branch_name_original')
+    job_info['data']['branch_name_modernizado'] = payload_dict.get('branch_name_modernizado')
+    job_info['data']['usuario_executor'] = payload_dict.get('usuario_executor')
+    job_info['data']['instrucoes_extras'] = payload_dict.get('instrucoes_extras')
+    job_info['data']['arquivos_especificos'] = payload_dict.get('arquivos_especificos')
+    job_info['data']['epic_id'] = payload_dict.get('epic_id')
+    if payload_dict.get('analysis_type') == 'criacao_tarefas_azure_devops':
+        repo_name_modernizado = payload_dict.get('repo_name_modernizado', '')
+        parts = repo_name_modernizado.split('/')
+        if len(parts) == 2:
+            job_info['data']['organization'] = parts[0]
+            job_info['data']['project'] = parts[1]
+        else:
+            job_info['data']['organization'] = None
+            job_info['data']['project'] = None
+    return job_info

--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -1,35 +1,88 @@
-def create_initial_job_data(payload_dict, normalized_repo_name, analysis_name):
-    job_info = {
-        'status': 'starting',
-        'data': {},
-    }
-    job_info['data']['repo_name'] = normalized_repo_name
-    job_info['data']['analysis_name'] = analysis_name
-    job_info['data']['analysis_type'] = payload_dict.get('analysis_type')
-    job_info['data']['projeto'] = payload_dict.get('projeto')
-    job_info['data']['model_name'] = payload_dict.get('model_name')
-    job_info['data']['usar_rag'] = payload_dict.get('usar_rag', False)
-    job_info['data']['gerar_relatorio_apenas'] = payload_dict.get('gerar_relatorio_apenas', False)
-    job_info['data']['retornar_lista_arquivos'] = payload_dict.get('retornar_lista_arquivos', False)
-    job_info['data']['executar_steps_incrementalmente'] = payload_dict.get('executar_steps_incrementalmente', True)
-    job_info['data']['max_steps_per_batch'] = payload_dict.get('max_steps_per_batch', 3)
-    job_info['data']['executar_build_dotnet'] = payload_dict.get('executar_build_dotnet', False)
-    job_info['data']['criar_epicos_azure'] = payload_dict.get('criar_epicos_azure', False)
-    job_info['data']['repository_type'] = payload_dict.get('repository_type')
-    job_info['data']['repo_name_original'] = payload_dict.get('repo_name_original')
-    job_info['data']['branch_name_original'] = payload_dict.get('branch_name_original')
-    job_info['data']['branch_name_modernizado'] = payload_dict.get('branch_name_modernizado')
-    job_info['data']['usuario_executor'] = payload_dict.get('usuario_executor')
-    job_info['data']['instrucoes_extras'] = payload_dict.get('instrucoes_extras')
-    job_info['data']['arquivos_especificos'] = payload_dict.get('arquivos_especificos')
-    job_info['data']['epic_id'] = payload_dict.get('epic_id')
-    if payload_dict.get('analysis_type') == 'criacao_tarefas_azure_devops':
-        repo_name_modernizado = payload_dict.get('repo_name_modernizado', '')
-        parts = repo_name_modernizado.split('/')
-        if len(parts) == 2:
-            job_info['data']['organization'] = parts[0]
-            job_info['data']['project'] = parts[1]
-        else:
-            job_info['data']['organization'] = None
-            job_info['data']['project'] = None
-    return job_info
+import uuid
+from typing import Optional
+from models import JobStatus, JobFields
+
+class JobDataService:
+    def __init__(self):
+        pass
+        
+    def _parse_repository_name(self, repo_name: str):
+        parts = repo_name.split('/')
+        if len(parts) < 2:
+            return None, None
+        organization = parts[0]
+        project = parts[1]
+        return organization, project
+
+    def generate_analysis_name(self, provided_name: Optional[str], job_id: str) -> str:
+        if provided_name:
+            return provided_name
+        analysis_name = f"analysis-{str(uuid.uuid4())[:8]}"
+        print(f"[{job_id}] Nome de análise gerado automaticamente: {analysis_name}")
+        return analysis_name
+    
+    def create_initial_job_data(self, payload_dict, normalized_repo_name, analysis_name):
+        data = {}
+        data[JobFields.REPO_NAME] = normalized_repo_name
+        criar_epicos_azure = payload_dict.get('criar_epicos_azure', False)
+        analysis_type = payload_dict.get('analysis_type')
+        if criar_epicos_azure:
+            organization, project = self._parse_repository_name(normalized_repo_name)
+            data[JobFields.AZURE_ORGANIZATION] = organization
+            data[JobFields.AZURE_PROJECT] = project
+        # Passo 3: lógica específica para criacao_tarefas_azure_devops
+        if analysis_type == 'criacao_tarefas_azure_devops':
+            organization, project = self._parse_repository_name(normalized_repo_name)
+            data[JobFields.ORGANIZATION] = organization
+            data[JobFields.PROJECT] = project
+            data[JobFields.EPIC_ID] = payload_dict.get('epic_id')
+        data[JobFields.PROJETO] = payload_dict.get('projeto')
+        data[JobFields.ANALYSIS_NAME] = analysis_name
+        data[JobFields.ORIGINAL_ANALYSIS_TYPE] = analysis_type
+        data[JobFields.INSTRUCOES_EXTRAS] = payload_dict.get('instrucoes_extras')
+        data[JobFields.MODEL_NAME] = payload_dict.get('model_name')
+        data[JobFields.USAR_RAG] = payload_dict.get('usar_rag', False)
+        data[JobFields.GERAR_RELATORIO_APENAS] = payload_dict.get('gerar_relatorio_apenas', False)
+        data[JobFields.ARQUIVOS_ESPECIFICOS] = payload_dict.get('arquivos_especificos')
+        data[JobFields.REPOSITORY_TYPE] = payload_dict.get('repository_type')
+        data[JobFields.REPO_NAME_MODERNIZADO] = payload_dict.get('repo_name_modernizado')
+        data[JobFields.BRANCH_NAME_MODERNIZADO] = payload_dict.get('branch_name_modernizado')
+        data[JobFields.REPO_NAME_ORIGINAL] = payload_dict.get('repo_name_original')
+        data[JobFields.BRANCH_NAME_ORIGINAL] = payload_dict.get('branch_name_original')
+        data[JobFields.RETORNAR_LISTA_ARQUIVOS] = payload_dict.get('retornar_lista_arquivos', False)
+        data[JobFields.USUARIO_EXECUTOR] = payload_dict.get('usuario_executor')
+        data[JobFields.EXECUTAR_STEPS_INCREMENTALMENTE] = payload_dict.get('executar_steps_incrementalmente', False)
+        data[JobFields.MAX_STEPS_PER_BATCH] = payload_dict.get('max_steps_per_batch', 3)
+        executar_build_dotnet = payload_dict.get('executar_build_dotnet', False)
+        if not isinstance(executar_build_dotnet, bool):
+            executar_build_dotnet = bool(executar_build_dotnet)
+        data[JobFields.EXECUTAR_BUILD_DOTNET] = executar_build_dotnet
+        data[JobFields.CRIAR_EPICOS_AZURE] = criar_epicos_azure
+        return {
+            JobFields.STATUS: None,
+            JobFields.DATA: data
+        }
+    
+    def create_derived_job_data(self, original_job: dict, analysis_name: str, normalized_repo_name: str, report: str) -> dict:
+        original_data = original_job[JobFields.DATA]
+        return {
+            JobFields.STATUS: JobStatus.STARTING,
+            JobFields.DATA: {
+                JobFields.REPO_NAME: normalized_repo_name,
+                JobFields.ORIGINAL_REPO_NAME: original_data[JobFields.REPO_NAME],
+                JobFields.PROJETO: original_data[JobFields.PROJETO],
+                JobFields.BRANCH_NAME: original_data[JobFields.BRANCH_NAME],
+                JobFields.ORIGINAL_ANALYSIS_TYPE: 'implementacao',
+                JobFields.INSTRUCOES_EXTRAS: f"Gerar código baseado no seguinte relatório:\n\n{report}",
+                JobFields.MODEL_NAME: original_data.get(JobFields.MODEL_NAME),
+                JobFields.USAR_RAG: original_data.get(JobFields.USAR_RAG, False),
+                JobFields.GERAR_RELATORIO_APENAS: False,
+                JobFields.ARQUIVOS_ESPECIFICOS: original_data.get(JobFields.ARQUIVOS_ESPECIFICOS),
+                JobFields.ANALYSIS_NAME: f"{analysis_name}-implementation",
+                JobFields.REPOSITORY_TYPE: original_data[JobFields.REPOSITORY_TYPE],
+                JobFields.RETORNAR_LISTA_ARQUIVOS: original_data.get(JobFields.RETORNAR_LISTA_ARQUIVOS, False),
+                JobFields.USUARIO_EXECUTOR: original_data.get(JobFields.USUARIO_EXECUTOR),
+                JobFields.EXECUTAR_STEPS_INCREMENTALMENTE: original_data.get(JobFields.EXECUTAR_STEPS_INCREMENTALMENTE, False)
+            },
+            JobFields.ERROR_DETAILS: None
+        }


### PR DESCRIPTION
Modifica create_initial_job_data para quebrar repo_name_modernizado em organization e project, armazenando-os no job_info['data']. Também adiciona o campo epic_id ao job_info['data'] para uso posterior no fluxo de criação de tarefas a partir de épicos.