### PR TITLE
Atualização da função start_analysis para validar epic_id e extrair organization e project do repo_name_modernizado para o novo agente revisor baseado em board, garantindo integração correta com o workflow e job_data.

### DIFF
--- a/mcp_server_fastapi.py
+++ b/mcp_server_fastapi.py
@@ -16,7 +16,7 @@ from services.api_service_factory import ApiServiceFactory
 from services.pull_request_extractor_service import PullRequestExtractorService
 from services.job_logging_service import JobLoggingService
 from services.response_builder_service import FinalStatusResponse
-from models import JobStatus, JobFields, JobActions
+from models import JobStatus, JobFields, JobActions, StartAnalysisPayload
 
 container = DependencyContainer()
 pr_extractor = PullRequestExtractorService()
@@ -33,28 +33,6 @@ job_data_service = api_service_factory.get_job_data_service()
 job_validation_service = api_service_factory.get_job_validation_service()
 logging_service = api_service_factory.get_logging_service()
 
-class StartAnalysisPayload(BaseModel):
-    repo_name_modernizado: str = Field(description="Nome do repositório modernizado")
-    branch_name_modernizado: Optional[str] = Field(None, description="Branch do repositório modernizado")
-    projeto: str = Field(description="Nome do projeto para agrupar atividades e organizar histórico")
-    analysis_type: ValidAnalysisTypes
-    instrucoes_extras: Optional[str] = None
-    usar_rag: bool = Field(False)
-    gerar_relatorio_apenas: bool = Field(False)
-    model_name: Optional[str] = Field(None, description="Nome do modelo de LLM a ser usado. Se nulo, usa o padrão.")
-    arquivos_especificos: Optional[List[str]] = Field(None, description="Lista opcional de caminhos específicos de arquivos para ler. Se fornecido, apenas esses arquivos serão processados.")
-    analysis_name: Optional[str] = Field(None, description="Nome personalizado para identificar a análise.")
-    repository_type: Literal['github', 'gitlab', 'azure'] = Field(description="Tipo do repositório: 'github', 'gitlab', 'azure'.")
-    repo_name_original: Optional[str] = Field(None, description="Nome do repositório original para comparação")
-    branch_name_original: Optional[str] = Field(None, description="Branch do repositório original")
-    retornar_lista_arquivos: bool = False
-    usuario_executor: Optional[str] = None
-    executar_steps_incrementalmente: bool = Field(
-        True, description="[DEPRECATED: O valor False está descontinuado e será removido em versões futuras. Use sempre True.] Se True, os passos do relatório de implementação serão executados de forma incremental (um ou mais passos por vez, respeitando dependências), ao invés de enviar todas as mudanças de uma só vez. Útil para relatórios extensos que podem exceder limites de tokens da LLM.")
-    max_steps_per_batch: Optional[int] = Field(3, description="Número máximo de steps por batch na execução incremental")
-    executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")
-    criar_epicos_azure: bool = Field(False, description="Se True, após aprovação, cria os épicos no Azure DevOps Board")
-    
 class StartAnalysisResponse(BaseModel):
     job_id: str
     
@@ -99,6 +77,11 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     else:
         if payload.executar_steps_incrementalmente is False and payload.gerar_relatorio_apenas is False:
             raise HTTPException(status_code=400, detail="Modo não-incremental descontinuado. Use executar_steps_incrementalmente=True ou gerar_relatorio_apenas=True.")
+    # Passo 2: validação para criacao_tarefas_azure_devops
+    analysis_type_str = str(payload.analysis_type.value) if hasattr(payload.analysis_type, 'value') else str(payload.analysis_type)
+    if analysis_type_str == 'criacao_tarefas_azure_devops':
+        if not getattr(payload, 'epic_id', None):
+            raise HTTPException(status_code=400, detail="epic_id é obrigatório para análise do tipo criacao_tarefas_azure_devops.")
     workflows = workflow_registry_service.get_workflow_registry()
     workflow = workflows.get(payload.analysis_type)
     first_step = None
@@ -119,6 +102,13 @@ def start_analysis(payload: StartAnalysisPayload, background_tasks: BackgroundTa
     payload_dict = payload.dict()
     if hasattr(payload.analysis_type, 'value'):
         payload_dict['analysis_type'] = payload.analysis_type.value
+    # Passo 2: extrair organization e project para criacao_tarefas_azure_devops
+    if analysis_type_str == 'criacao_tarefas_azure_devops':
+        repo_parts = repo_name.split('/')
+        if len(repo_parts) < 2:
+            raise HTTPException(status_code=400, detail="repo_name_modernizado deve conter organização e projeto separados por '/'.")
+        payload_dict['organization'] = repo_parts[0]
+        payload_dict['project'] = repo_parts[1]
     initial_job_data = job_data_service.create_initial_job_data(
         payload_dict, normalized_repo_name, analysis_name
     )


### PR DESCRIPTION
Na função start_analysis, foi adicionada validação para garantir que epic_id esteja presente quando analysis_type for 'criacao_tarefas_azure_devops'. Também foi implementada a extração dos campos organization e project a partir do repo_name_modernizado, que são inseridos no payload_dict para uso posterior no job_data. Isso assegura que o novo agente que gera tarefas detalhadas a partir de épicos do Azure DevOps funcione corretamente, alinhado com o fluxo de trabalho existente e os serviços de orquestração e armazenamento de jobs.