### PR TITLE
Inclusão de parsing para organization e project a partir do repo_name_modernizado no método create_initial_job_data para suportar análise do tipo criacao_tarefas_azure_devops.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -25,10 +25,18 @@ class JobDataService:
         data = {}
         data[JobFields.REPO_NAME] = normalized_repo_name
         criar_epicos_azure = payload_dict.get('criar_epicos_azure', False)
+        analysis_type = payload_dict.get('analysis_type')
         if criar_epicos_azure:
             organization, project = self._parse_repository_name(normalized_repo_name)
             data[JobFields.AZURE_ORGANIZATION] = organization
             data[JobFields.AZURE_PROJECT] = project
+        # Passo 3: adicionar campos para criacao_tarefas_azure_devops
+        if analysis_type == 'criacao_tarefas_azure_devops':
+            epic_id = payload_dict.get('epic_id')
+            organization, project = self._parse_repository_name(normalized_repo_name)
+            data[JobFields.EPIC_ID] = epic_id
+            data[JobFields.ORGANIZATION] = organization
+            data[JobFields.PROJECT] = project
         data[JobFields.PROJETO] = payload_dict.get('projeto')
         data[JobFields.ANALYSIS_NAME] = analysis_name
         data[JobFields.ORIGINAL_ANALYSIS_TYPE] = payload_dict.get('analysis_type')


### PR DESCRIPTION
O método create_initial_job_data foi ajustado para extrair organization e project da variável normalized_repo_name (que corresponde ao repo_name_modernizado do payload) quando o analysis_type for criacao_tarefas_azure_devops. Isso garante que os dados necessários para o novo agente baseado no revisor_board estejam presentes no job data inicial.