### PR TITLE
Implementação do executor de passo revisor_board com validação de parâmetros obrigatórios e passagem correta de dados para o agente revisor_board.

### DIFF
--- a/services/step_executors/revisor_board_step_executor.py
+++ b/services/step_executors/revisor_board_step_executor.py
@@ -17,6 +17,12 @@ class RevisorBoardStepExecutor(BaseStepExecutor):
         epic_id = job_info['data'].get('epic_id')
         organization = job_info['data'].get('organization')
         project = job_info['data'].get('project')
+        if not epic_id:
+            raise ValueError(f"[{job_id}] Parâmetro obrigatório 'epic_id' ausente em job_info['data'].")
+        if not organization:
+            raise ValueError(f"[{job_id}] Parâmetro obrigatório 'organization' ausente em job_info['data'].")
+        if not project:
+            raise ValueError(f"[{job_id}] Parâmetro obrigatório 'project' ausente em job_info['data'].")
         instrucoes_formatadas = job_info['data'].get('instrucoes_extras', '')
         instrucoes_formatadas += "\n\n---\n\nCONTEXTO DA ETAPA ANTERIOR:\n"
         instrucoes_formatadas += json.dumps(previous_step_result, indent=2, ensure_ascii=False)


### PR DESCRIPTION
O arquivo services/step_executors/revisor_board_step_executor.py foi modificado para validar explicitamente os parâmetros epic_id, organization e project extraídos do job_info['data']. Foi garantida a passagem correta desses parâmetros para agent_params, além de incorporar instruções extras e controle de batches. O agente é criado via AgentFactory com board_reader e llm_provider, e a resposta do agente é processada com tentativas e tratamento de erros.