### PR TITLE
Atualização da fábrica de agentes para suportar criação do agente revisor_board com dependências específicas.

### DIFF
--- a/services/factories/agent_factory.py
+++ b/services/factories/agent_factory.py
@@ -27,8 +27,10 @@ class AgentFactory:
         if not agent_class:
             raise ValueError(f"Tipo de agente desconhecido '{agent_type}'.")
         if agent_type == 'revisor_board':
-            if board_reader is None or llm_provider is None:
-                raise ValueError("Para 'revisor_board', é necessário fornecer board_reader e llm_provider.")
+            if board_reader is None:
+                raise ValueError("Para 'revisor_board', é necessário fornecer board_reader.")
+            if llm_provider is None:
+                raise ValueError("Para 'revisor_board', é necessário fornecer llm_provider.")
             return agent_class(board_reader=board_reader, llm_provider=llm_provider)
         if agent_type in ["revisor", "comparador"]:
             return agent_class(repository_reader=repository_reader, llm_provider=llm_provider)


### PR DESCRIPTION
O método create_agent da classe AgentFactory foi modificado para validar a presença de board_reader e llm_provider quando o tipo de agente é 'revisor_board'. A criação do agente revisor_board passa essas dependências obrigatórias para o construtor do AgenteRevisorBoard, garantindo a correta inicialização.