### PR TITLE
Ajuste do workflow 'criacao_tarefas_azure_devops' para utilizar o novo agente 'revisor_board' com o model_name e tipo_analise corretos, garantindo a leitura de épicos do Azure DevOps para geração de tarefas detalhadas.

### DIFF
--- a/workflows.yaml
+++ b/workflows.yaml
@@ -303,8 +303,7 @@ criacao_tarefas_azure_devops:
   steps:
     - status_update: "analisando o epico"
       model_name: "claude-sonnet-4-5"
-      agent_type: "processador"
+      agent_type: "revisor_board"
       params:
         tipo_analise: "criacao_tarefas"
       requires_approval: true
-    


### PR DESCRIPTION
Modificação do arquivo workflows.yaml para configurar o workflow 'criacao_tarefas_azure_devops' com o agente 'revisor_board' no primeiro passo, incluindo a definição do model_name 'claude-sonnet-4-5' e o parâmetro tipo_analise 'criacao_tarefas'.