### PR TITLE
Adaptação do AgentFactory para uso de AzureBoardService no agente revisor_board

### DIFF
--- a/services/factories/agent_factory.py
+++ b/services/factories/agent_factory.py
@@ -5,7 +5,7 @@ from agents.agente_comparador import AgenteComparador
 from agents.agente_revisor_board import AgenteRevisorBoard
 from domain.interfaces.llm_provider_interface import ILLMProvider
 from tools.readers.reader_geral import ReaderGeral
-from domain.interfaces.board_reader_interface import IBoardReader
+from services.azure_board_service import AzureBoardService
 
 class AgentFactory:
     _agents: Dict[str, Type] = {
@@ -21,17 +21,17 @@ class AgentFactory:
         agent_type: str,
         repository_reader: ReaderGeral = None,
         llm_provider: ILLMProvider = None,
-        board_reader: IBoardReader = None
+        azure_board_service: AzureBoardService = None
     ):
         agent_class = cls._agents.get(agent_type)
         if not agent_class:
             raise ValueError(f"Tipo de agente desconhecido '{agent_type}'.")
         if agent_type == 'revisor_board':
-            if board_reader is None:
-                raise ValueError("Para 'revisor_board', é necessário fornecer board_reader.")
+            if azure_board_service is None:
+                raise ValueError("Para 'revisor_board', é necessário fornecer azure_board_service.")
             if llm_provider is None:
                 raise ValueError("Para 'revisor_board', é necessário fornecer llm_provider.")
-            return agent_class(board_reader=board_reader, llm_provider=llm_provider)
+            return agent_class(azure_board_service=azure_board_service, llm_provider=llm_provider)
         if agent_type in ["revisor", "comparador"]:
             return agent_class(repository_reader=repository_reader, llm_provider=llm_provider)
         elif agent_type == "processador":


### PR DESCRIPTION
O método create_agent foi modificado para substituir o parâmetro board_reader por azure_board_service para o agente revisor_board, com validações adequadas para garantir a passagem correta dos parâmetros.