### PR TITLE
Correção do fluxo de criação de tarefas Azure para garantir finalização do job após criação das tarefas dentro do épico, alinhando a lógica à criação de épicos.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -15,6 +15,7 @@ from models import JobFields
 from services.incremental_step_executor_service import IncrementalStepExecutorService
 from tools.azure_secret_manager import AzureSecretManager
 from services.azure_board_service import AzureBoardService
+import traceback
 
 class WorkflowOrchestrator(IWorkflowOrchestrator):
     def __init__(self, job_manager: IJobManager, blob_storage: IBlobStorageService, 
@@ -73,12 +74,22 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 report = job_info['data'].get('analysis_report')
                 azure_board_service = AzureBoardService(organization, project, self.secret_manager)
                 if job_info['data'].get('criar_tarefas_azure'):
-                    print(f"[{job_id}] [DEBUG] Chamando AzureBoardService.create_tasks_from_report: criar_tarefas_azure={job_info['data'].get('criar_tarefas_azure')}, epic_id={epic_id}")
-                    created_tasks = azure_board_service.create_tasks_from_report(epic_id, report)
-                    print(f"[{job_id}] [DEBUG] Resultado AzureBoardService.create_tasks_from_report: {created_tasks}")
-                    job_info['data']['tarefas_criadas'] = created_tasks
-                    self.job_handler.update_job(job_id, job_info)
-                    print(f"[{job_id}] [AZURE_TASKS] Tarefas criadas: {created_tasks}")
+                    print(f"[{job_id}] [DEBUG] ANTES de create_tasks_from_report: epic_id={epic_id}, len(report)={len(report) if report else 0}")
+                    try:
+                        created_tasks = azure_board_service.create_tasks_from_report(epic_id, report)
+                        print(f"[{job_id}] [DEBUG] DEPOIS de create_tasks_from_report: created_tasks={created_tasks}")
+                        job_info['data']['tarefas_criadas'] = created_tasks
+                        self.job_handler.update_job(job_id, job_info)
+                        print(f"[{job_id}] [AZURE_TASKS] Tarefas criadas: {created_tasks}")
+                        print(f"[{job_id}] [DEBUG] Atualizando status do job para 'completed' após criação de tarefas Azure.")
+                        self.job_handler.update_job_status(job_id, 'completed')
+                        print(f"[{job_id}] [DEBUG] Workflow finalizado após criação de tarefas/épicos Azure.")
+                        return
+                    except Exception as e:
+                        print(f"[{job_id}] [ERROR] Exception ao criar tarefas Azure: {str(e)}")
+                        traceback.print_exc()
+                        self.job_handler.update_job_status(job_id, 'failed')
+                        return
                 if job_info['data'].get('criar_epicos_azure'):
                     print(f"[{job_id}] [DEBUG] Chamando AzureBoardService.create_epics: criar_epicos_azure={job_info['data'].get('criar_epicos_azure')}")
                     created_epics = azure_board_service.create_epics(report)
@@ -86,9 +97,9 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                     job_info['data']['epicos_criados'] = created_epics
                     self.job_handler.update_job(job_id, job_info)
                     print(f"[{job_id}] [AZURE_EPICS] Épicos criados: {created_epics}")
-                self.job_handler.update_job_status(job_id, 'completed')
-                print(f"[{job_id}] [DEBUG] Workflow finalizado após criação de tarefas/épicos Azure.")
-                return
+                    self.job_handler.update_job_status(job_id, 'completed')
+                    print(f"[{job_id}] [DEBUG] Workflow finalizado após criação de tarefas/épicos Azure.")
+                    return
             if start_from_step == 0:
                 report_from_blob = self.report_handler.blob_storage.read_report(
                     projeto=projeto,
@@ -312,18 +323,32 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             report = job_info['data'].get('analysis_report')
             azure_board_service = AzureBoardService(organization, project, self.secret_manager)
             if job_info['data'].get('criar_tarefas_azure'):
-                created_tasks = azure_board_service.create_tasks_from_report(epic_id, report)
-                job_info['data']['tarefas_criadas'] = created_tasks
-                self.job_handler.update_job(job_id, job_info)
-                print(f"[{job_id}] [AZURE_TASKS] Tarefas criadas: {created_tasks}")
+                print(f"[{job_id}] [DEBUG] ANTES de create_tasks_from_report: epic_id={epic_id}, len(report)={len(report) if report else 0}")
+                try:
+                    created_tasks = azure_board_service.create_tasks_from_report(epic_id, report)
+                    print(f"[{job_id}] [DEBUG] DEPOIS de create_tasks_from_report: created_tasks={created_tasks}")
+                    job_info['data']['tarefas_criadas'] = created_tasks
+                    self.job_handler.update_job(job_id, job_info)
+                    print(f"[{job_id}] [AZURE_TASKS] Tarefas criadas: {created_tasks}")
+                    print(f"[{job_id}] [DEBUG] Atualizando status do job para 'completed' após criação de tarefas Azure.")
+                    self.job_handler.update_job_status(job_id, 'completed')
+                    print(f"[{job_id}] [DEBUG] Workflow finalizado após criação de tarefas/épicos Azure.")
+                    return
+                except Exception as e:
+                    print(f"[{job_id}] [ERROR] Exception ao criar tarefas Azure: {str(e)}")
+                    traceback.print_exc()
+                    self.job_handler.update_job_status(job_id, 'failed')
+                    return
             if job_info['data'].get('criar_epicos_azure'):
+                print(f"[{job_id}] [DEBUG] Chamando AzureBoardService.create_epics: criar_epicos_azure={job_info['data'].get('criar_epicos_azure')}")
                 created_epics = azure_board_service.create_epics(report)
+                print(f"[{job_id}] [DEBUG] Resultado AzureBoardService.create_epics: {created_epics}")
                 job_info['data']['epicos_criados'] = created_epics
                 self.job_handler.update_job(job_id, job_info)
                 print(f"[{job_id}] [AZURE_EPICS] Épicos criados: {created_epics}")
-            self.job_handler.update_job_status(job_id, 'completed')
-            print(f"[{job_id}] [DEBUG] Workflow finalizado após criação de tarefas/épicos Azure.")
-            return
+                self.job_handler.update_job_status(job_id, 'completed')
+                print(f"[{job_id}] [DEBUG] Workflow finalizado após criação de tarefas/épicos Azure.")
+                return
         else:
             batch_results = job_info['data'][JobFields.BATCH_RESULTS]
             total_batches = len(batch_results)


### PR DESCRIPTION
Ajustado o método execute_workflow para que, após aprovação do relatório e quando criar_tarefas_azure=True, o fluxo invoque create_tasks_from_report do AzureBoardService, atualize o job com as tarefas criadas, atualize o status para 'completed' e finalize o workflow corretamente, evitando que o job fique em estado pendente. A lógica segue o padrão já utilizado para criação de épicos, garantindo consistência e robustez.