### PR TITLE
Inclusão de print de debug na criação do AzureBoardService no DependencyContainer.

### DIFF
--- a/services/dependency_container.py
+++ b/services/dependency_container.py
@@ -124,6 +124,7 @@ class DependencyContainer:
     def get_azure_board_service(self) -> AzureBoardService:
         if self._azure_board_service is None:
             self._azure_board_service = AzureBoardService(secret_manager=self.get_secret_manager())
+            print(f"[DependencyContainer-DEBUG] Criando AzureBoardService. organization={self._azure_board_service.organization if self._azure_board_service else 'N/A'}, project={self._azure_board_service.project if self._azure_board_service else 'N/A'}")
         return self._azure_board_service
 
     def get_board_reader(self) -> IBoardReader:


### PR DESCRIPTION
No método get_azure_board_service da classe DependencyContainer, foi adicionado um print de debug que exibe a organização e projeto do AzureBoardService criado, para facilitar o rastreamento da criação da instância do serviço.