### PR TITLE
Adicionada a propagação correta do campo criar_tarefas_azure no job_info['data'] para garantir que o valor passado na payload seja mantido durante o fluxo de trabalho.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -25,6 +25,7 @@ class JobDataService:
         data = {}
         data[JobFields.REPO_NAME] = normalized_repo_name
         criar_epicos_azure = payload_dict.get('criar_epicos_azure', False)
+        criar_tarefas_azure = payload_dict.get('criar_tarefas_azure', False)
         analysis_type = payload_dict.get('analysis_type')
         if criar_epicos_azure:
             organization, project = self._parse_repository_name(normalized_repo_name)
@@ -59,6 +60,7 @@ class JobDataService:
             executar_build_dotnet = bool(executar_build_dotnet)
         data[JobFields.EXECUTAR_BUILD_DOTNET] = executar_build_dotnet
         data[JobFields.CRIAR_EPICOS_AZURE] = criar_epicos_azure
+        data['criar_tarefas_azure'] = criar_tarefas_azure
         return {
             JobFields.STATUS: None,
             JobFields.DATA: data


### PR DESCRIPTION
Foi corrigida a criação dos dados iniciais do job para incluir explicitamente o campo 'criar_tarefas_azure' no dicionário de dados, garantindo que o valor booleano seja propagado corretamente para uso posterior no workflow.