### PR TITLE
Inclusão do campo CRIAR_TAREFAS_AZURE na classe JobFields para reconhecimento global do campo no sistema.

### DIFF
--- a/models.py
+++ b/models.py
@@ -71,6 +71,7 @@ class JobFields:
     BUILD_RESULT = 'build_result'
     REQUIRES_APPROVAL = 'requires_approval'
     CRIAR_EPICOS_AZURE = 'criar_epicos_azure'
+    CRIAR_TAREFAS_AZURE = 'criar_tarefas_azure'
     AZURE_ORGANIZATION = 'azure_organization'
     AZURE_PROJECT = 'azure_project'
     EPICOS_CRIADOS = 'epicos_criados'


### PR DESCRIPTION
Adicionado o campo CRIAR_TAREFAS_AZURE na enumeração JobFields para garantir que o campo seja reconhecido e utilizado em todo o código, permitindo a propagação correta do valor 'criar_tarefas_azure' durante o fluxo de criação de tarefas Azure DevOps.