### PR TITLE
Garantia da propagação correta do campo criar_tarefas_azure no job data com validação de tipo booleano.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -31,7 +31,6 @@ class JobDataService:
             organization, project = self._parse_repository_name(normalized_repo_name)
             data[JobFields.AZURE_ORGANIZATION] = organization
             data[JobFields.AZURE_PROJECT] = project
-        # Passo 3: adicionar campos para criacao_tarefas_azure_devops
         if analysis_type == 'criacao_tarefas_azure_devops':
             epic_id = payload_dict.get('epic_id')
             organization, project = self._parse_repository_name(normalized_repo_name)
@@ -60,6 +59,10 @@ class JobDataService:
             executar_build_dotnet = bool(executar_build_dotnet)
         data[JobFields.EXECUTAR_BUILD_DOTNET] = executar_build_dotnet
         data[JobFields.CRIAR_EPICOS_AZURE] = criar_epicos_azure
+        # Passo 3: garantir que criar_tarefas_azure seja propagado corretamente
+        if not isinstance(criar_tarefas_azure, bool):
+            criar_tarefas_azure = bool(criar_tarefas_azure)
+        data[JobFields.CRIAR_TAREFAS_AZURE] = criar_tarefas_azure
         data['criar_tarefas_azure'] = criar_tarefas_azure
         return {
             JobFields.STATUS: None,


### PR DESCRIPTION
No método create_initial_job_data, extraído o campo criar_tarefas_azure do payload_dict e armazenado em data[JobFields.CRIAR_TAREFAS_AZURE] e também em data['criar_tarefas_azure'], com validação para garantir que o valor seja booleano. Isso assegura que o campo esteja disponível e consistente durante toda a execução do job.