### PR TITLE
Modificado agente RevisorBoard para aceitar task_id, ler dados do épico e da tarefa, e concatenar ambos em instrucoes_extras para envio ao LLM.

### DIFF
--- a/agents/agente_revisor_board.py
+++ b/agents/agente_revisor_board.py
@@ -11,14 +11,15 @@ class AgenteRevisorBoard:
         self.llm_provider = llm_provider
         init_logger()
 
-    def _get_epic_data(self, epic_id: str) -> Dict[str, Any]:
+    def _get_epic_and_task_data(self, epic_id: str, task_id: Optional[str] = None) -> Dict[str, Any]:
         if not epic_id:
             raise ValueError("epic_id é obrigatório para leitura do épico.")
-        try:
-            return self.azure_board_service.read_epic(epic_id)
-        except Exception as e:
-            print(f"[AgenteRevisorBoard] ERRO durante leitura do épico: {e}")
-            raise RuntimeError(f"Falha ao ler o épico: {e}") from e
+        epic_data = self.azure_board_service.read_epic(epic_id)
+        if task_id:
+            task_data = self.azure_board_service.read_task(task_id)
+            return {'epic': epic_data, 'task': task_data}
+        else:
+            return {'epic': epic_data}
 
     def main(
         self,
@@ -33,16 +34,22 @@ class AgenteRevisorBoard:
         status_update: Optional[str] = None,
         usuario_executor: Optional[str] = None,
         current_batch: Optional[List[Dict[str, Any]]] = None,
+        task_id: Optional[str] = None,
         **kwargs
     ) -> Dict[str, Any]:
         if not epic_id:
             raise ValueError("epic_id é obrigatório para execução do agente revisor_board.")
-        epic_data = self._get_epic_data(epic_id=epic_id)
-        if not epic_data:
+        data = self._get_epic_and_task_data(epic_id=epic_id, task_id=task_id)
+        epic_data = data.get('epic')
+        task_data = data.get('task')
+        if epic_data is None:
             print(f"[AgenteRevisorBoard] AVISO: Nenhum dado encontrado para o épico '{epic_id}'.")
             print(f"[AgenteRevisorBoard] Retornando resposta vazia devido à ausência de dados do épico")
             return {"resultado": {"reposta_final": {}}}
-        epic_data_str = json.dumps(epic_data, indent=2, ensure_ascii=False)
+        if task_data is not None:
+            instrucoes_extras = (instrucoes_extras or "") + '\n\n--- DADOS DO ÉPICO ---\n' + json.dumps(epic_data, indent=2, ensure_ascii=False) + '\n\n--- DADOS DA TAREFA ---\n' + json.dumps(task_data, indent=2, ensure_ascii=False)
+        else:
+            instrucoes_extras = (instrucoes_extras or "") + '\n\n--- DADOS DO ÉPICO ---\n' + json.dumps(epic_data, indent=2, ensure_ascii=False)
         if current_batch is not None and isinstance(current_batch, list) and len(current_batch) > 0:
             batch_instrucao = "ATENÇÃO: Processar APENAS os passos listados abaixo. Ignorar todos os outros passos do relatório original.\n"
             batch_instrucao += json.dumps(current_batch, indent=2, ensure_ascii=False)
@@ -52,7 +59,7 @@ class AgenteRevisorBoard:
                 instrucoes_extras = batch_instrucao
         resultado_da_ia = self.llm_provider.executar_prompt(
             tipo_tarefa=tipo_analise,
-            prompt_principal=epic_data_str,
+            prompt_principal=None,
             instrucoes_extras=instrucoes_extras,
             usar_rag=usar_rag,
             model_name=model_name,


### PR DESCRIPTION
O agente agora recebe opcionalmente o ID da tarefa, utiliza o método read_task para obter seus dados, e concatena os dados do épico e da tarefa em instrucoes_extras. Também mantém suporte para processamento incremental via current_batch.