### PR TITLE
Inclusão do campo task_id no método create_initial_job_data do JobDataService.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -59,11 +59,11 @@ class JobDataService:
             executar_build_dotnet = bool(executar_build_dotnet)
         data[JobFields.EXECUTAR_BUILD_DOTNET] = executar_build_dotnet
         data[JobFields.CRIAR_EPICOS_AZURE] = criar_epicos_azure
-        # Passo 3: garantir que criar_tarefas_azure seja propagado corretamente
         if not isinstance(criar_tarefas_azure, bool):
             criar_tarefas_azure = bool(criar_tarefas_azure)
         data[JobFields.CRIAR_TAREFAS_AZURE] = criar_tarefas_azure
         data['criar_tarefas_azure'] = criar_tarefas_azure
+        data[JobFields.TASK_ID] = payload_dict.get('task_id')
         return {
             JobFields.STATUS: None,
             JobFields.DATA: data


### PR DESCRIPTION
Adicionado o campo task_id no dicionário data retornado pelo método create_initial_job_data para suportar a nova feature que utiliza task_id no fluxo de criação de relatórios e tarefas.