### PR TITLE
Passagem do task_id para agent_params no método _execute_step_with_strategy do WorkflowOrchestrator.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -273,6 +273,7 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
             agent_params['epic_id'] = epic_id
             agent_params['organization'] = organization
             agent_params['project'] = project
+            agent_params['task_id'] = job_info['data'].get('task_id')
         elif agent_type == 'comparador':
             agent_params.update({
                 'repo_name_modernizado': job_info['data'].get('repo_name_modernizado'),


### PR DESCRIPTION
No método _execute_step_with_strategy, ao identificar o agente revisor_board, foi adicionado agent_params['task_id'] = job_info['data'].get('task_id') para suportar a nova feature que utiliza task_id para leitura e geração de relatórios.