### PR TITLE
Validação condicional do campo task_id em StartAnalysisPayload para obrigatoriedade apenas quando analysis_type é 'revisor_tarefas'.

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, validator, root_validator
 from typing import List, Dict, Any, Optional, Literal
 
 class EpicCreationPayload(BaseModel):
@@ -88,3 +88,42 @@ class ValidAnalysisTypes(str):
     MODERNIZACAO = 'modernizacao'
     IMPLEMENTACAO = 'implementacao'
     CRIACAO_EPICOS = 'criacao_epicos'
+    REVISOR_TAREFAS = 'revisor_tarefas'
+
+class StartAnalysisPayload(BaseModel):
+    repo_name_modernizado: str = Field(description="Nome do repositório modernizado")
+    branch_name_modernizado: Optional[str] = Field(None, description="Branch do repositório modernizado")
+    projeto: str = Field(description="Nome do projeto para agrupar atividades e organizar histórico")
+    analysis_type: ValidAnalysisTypes
+    instrucoes_extras: Optional[str] = None
+    usar_rag: bool = Field(False)
+    gerar_relatorio_apenas: bool = Field(False)
+    model_name: Optional[str] = Field(None, description="Nome do modelo de LLM a ser usado. Se nulo, usa o padrão.")
+    arquivos_especificos: Optional[List[str]] = Field(None, description="Lista opcional de caminhos específicos de arquivos para ler. Se fornecido, apenas esses arquivos serão processados.")
+    analysis_name: Optional[str] = Field(None, description="Nome personalizado para identificar a análise.")
+    repository_type: Literal['github', 'gitlab', 'azure'] = Field(description="Tipo do repositório: 'github', 'gitlab', 'azure'.")
+    repo_name_original: Optional[str] = Field(None, description="Nome do repositório original para comparação")
+    branch_name_original: Optional[str] = Field(None, description="Branch do repositório original")
+    retornar_lista_arquivos: bool = False
+    usuario_executor: Optional[str] = None
+    executar_steps_incrementalmente: bool = Field(
+        True, description="[DEPRECATED: O valor False está descontinuado e será removido em versões futuras. Use sempre True.] Se True, os passos do relatório de implementação serão executados de forma incremental (um ou mais passos por vez, respeitando dependências), ao invés de enviar todas as mudanças de uma só vez. Útil para relatórios extensos que podem exceder limites de tokens da LLM.")
+    max_steps_per_batch: Optional[int] = Field(3, description="Número máximo de steps por batch na execução incremental")
+    executar_build_dotnet: bool = Field(False, description="Se True, executa o build do projeto .NET após o commit e retorna os erros de compilação, se houver.")
+    criar_epicos_azure: bool = Field(False, description="Se True, após aprovação, cria os épicos no Azure DevOps Board")
+    criar_tarefas_azure: bool = Field(False, description="Se True, após aprovação do relatório de tarefas, cria os Work Items no Azure DevOps Board dentro do épico especificado.")
+    epic_id: Optional[str] = Field(None, description="ID do épico do Azure DevOps para geração de tarefas. Obrigatório quando analysis_type for 'criacao_tarefas_azure_devops'.")
+    task_id: Optional[str] = Field(None, description="ID da tarefa do Azure DevOps. Obrigatório apenas quando analysis_type for 'revisor_tarefas'.")
+
+    @root_validator
+    def check_task_id_for_revisor_tarefas(cls, values):
+        analysis_type = values.get('analysis_type')
+        task_id = values.get('task_id')
+        if analysis_type == 'revisor_tarefas':
+            if not task_id or (isinstance(task_id, str) and not task_id.strip()):
+                raise ValueError('task_id é obrigatório quando analysis_type for "revisor_tarefas".')
+        else:
+            if task_id is not None:
+                # Para outros analysis_type, task_id deve ser None
+                values['task_id'] = None
+        return values


### PR DESCRIPTION
Adicionado campo task_id como Optional[str] em StartAnalysisPayload e incluído root_validator que exige task_id quando analysis_type for 'revisor_tarefas', e zera task_id para outros tipos.