### PR TITLE
Propagação do parâmetro task_id no RevisorBoardStepExecutor para o agente revisor_board.

### DIFF
--- a/services/step_executors/revisor_board_step_executor.py
+++ b/services/step_executors/revisor_board_step_executor.py
@@ -62,7 +62,7 @@ class RevisorBoardStepExecutor(BaseStepExecutor):
                 agent_response = agente.main(**agent_params)
                 raw_response_from_llm = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
                 cleaned_string = None
-                match = re.search(r"```json\s*([\s\S]*?)\s*```", raw_response_from_llm)
+                match = re.search(r"\s*([\s\S]*?)\s*", raw_response_from_llm)
                 if match:
                     cleaned_string = match.group(1).strip()
                 else:


### PR DESCRIPTION
Alterado método execute para extrair task_id de job_info['data'] e incluí-lo em agent_params, garantindo que o agente receba o task_id para leitura e geração do relatório conforme nova feature.