### PR TITLE
No executor do step revisor_board, extração e propagação correta do task_id para o agente, garantindo leitura de épico e tarefa.

### DIFF
--- a/services/step_executors/revisor_board_step_executor.py
+++ b/services/step_executors/revisor_board_step_executor.py
@@ -62,7 +62,7 @@ class RevisorBoardStepExecutor(BaseStepExecutor):
                 agent_response = agente.main(**agent_params)
                 raw_response_from_llm = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
                 cleaned_string = None
-                match = re.search(r"```json\s*([\s\S]*?)\s*```", raw_response_from_llm)
+                match = re.search(r"\s*([\s\S]*?)\s*", raw_response_from_llm)
                 if match:
                     cleaned_string = match.group(1).strip()
                 else:


### PR DESCRIPTION
O método execute extrai task_id de job_info['data'], adiciona no agent_params e passa para o agente revisor_board. Logs de debug foram adicionados para confirmar passagem dos IDs. Tentativas de execução com retry foram mantidas para robustez.