### PR TITLE
Adicionada propagação explícita de task_id no fluxo analysis_type == 'revisor_tarefas' e log de debug para confirmar a propagação no create_initial_job_data.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -41,6 +41,7 @@ class JobDataService:
         if analysis_type == 'revisor_tarefas':
             task_id = payload_dict.get('task_id')
             data[JobFields.TASK_ID] = task_id
+            print(f"[DEBUG] Propagando task_id no create_initial_job_data: {task_id}")
         data[JobFields.PROJETO] = payload_dict.get('projeto')
         data[JobFields.ANALYSIS_NAME] = analysis_name
         data[JobFields.ORIGINAL_ANALYSIS_TYPE] = payload_dict.get('analysis_type')


### PR DESCRIPTION
No serviço de dados do job, foi garantida a inclusão do campo task_id no dicionário de dados inicial quando analysis_type for 'revisor_tarefas', com log de debug para confirmar a propagação. Também mantida compatibilidade para task_id fora do bloco condicional para outros tipos de análise.