### PR TITLE
Adicionada validação da resposta da LLM para garantir que contenha a chave 'reposta_final' e que não esteja vazia, com exceção clara em caso de falha.

### DIFF
--- a/agents/agente_revisor_board.py
+++ b/agents/agente_revisor_board.py
@@ -40,7 +40,6 @@ class AgenteRevisorBoard:
         print(f"[AgenteRevisorBoard] [DEBUG] Entrando no main. epic_id={epic_id}, task_id={task_id}")
         if not epic_id:
             raise ValueError("epic_id é obrigatório para execução do agente revisor_board.")
-        # Validação específica para revisor_tarefas
         if tipo_analise == 'revisor_tarefas':
             if not task_id:
                 raise ValueError("task_id é obrigatório quando analysis_type == 'revisor_tarefas'.")
@@ -87,6 +86,9 @@ class AgenteRevisorBoard:
             modo_adicao_incremental=False,
             usuario_executor=usuario_executor
         )
+        # PASSO 7: Validação para garantir que a resposta contém a chave 'reposta_final' e que não está vazia
+        if not isinstance(resultado_da_ia, dict) or 'reposta_final' not in resultado_da_ia or not resultado_da_ia['reposta_final']:
+            raise ValueError(f"[AgenteRevisorBoard] ERRO: A resposta da LLM está vazia ou malformada. resultado_da_ia: {resultado_da_ia}")
         return {
             "resultado": {
                 "reposta_final": resultado_da_ia


### PR DESCRIPTION
No arquivo 'agents/agente_revisor_board.py', após a execução do prompt na LLM, foi implementada uma verificação para assegurar que a resposta contém a chave 'reposta_final' e que esta não está vazia. Caso contrário, é lançada uma exceção clara. Essa melhoria atende ao passo 7 do plano de ação, garantindo a integridade da resposta do agente.