### PR TITLE
Adição de logs de debug no método get_azure_board_service e injeção explícita do AzureBoardService no WorkflowOrchestrator.

### DIFF
--- a/services/dependency_container.py
+++ b/services/dependency_container.py
@@ -99,7 +99,8 @@ class DependencyContainer:
     def get_workflow_orchestrator(self) -> WorkflowOrchestrator:
         if self._workflow_orchestrator is None:
             workflow_registry = self.get_workflow_registry_service().get_workflow_registry()
-            
+            # Passo 9: garantir que AzureBoardService seja injetado explicitamente se necessário
+            azure_board_service = self.get_azure_board_service()
             self._workflow_orchestrator = WorkflowOrchestrator(
                 job_manager=self.get_job_manager(), 
                 blob_storage=self.get_blob_storage(), 
@@ -111,7 +112,9 @@ class DependencyContainer:
                 data_formatter=self.get_data_formatter(),
                 secret_manager=self.get_secret_manager(),
                 cache_service=self.get_redis_cache_service(),
-                dependency_container=self
+                dependency_container=self,
+                # Injetar explicitamente o AzureBoardService se o WorkflowOrchestrator aceitar
+                azure_board_service=azure_board_service
             )
         return self._workflow_orchestrator
     
@@ -125,6 +128,8 @@ class DependencyContainer:
         if self._azure_board_service is None:
             self._azure_board_service = AzureBoardService(secret_manager=self.get_secret_manager())
             print(f"[DependencyContainer-DEBUG] Criando AzureBoardService. organization={self._azure_board_service.organization if self._azure_board_service else 'N/A'}, project={self._azure_board_service.project if self._azure_board_service else 'N/A'}")
+        else:
+            print(f"[DependencyContainer-DEBUG] AzureBoardService já existente. organization={self._azure_board_service.organization if self._azure_board_service else 'N/A'}, project={self._azure_board_service.project if self._azure_board_service else 'N/A'}")
         return self._azure_board_service
 
     def get_board_reader(self) -> IBoardReader:


### PR DESCRIPTION
Incluídos prints para debug no método get_azure_board_service para confirmar criação e configuração da instância do AzureBoardService. Ajustado o método get_workflow_orchestrator para garantir que o AzureBoardService seja passado explicitamente ao criar o WorkflowOrchestrator, conforme passo 9 do plano. Essa alteração visa garantir a correta injeção de dependências para o serviço de board do Azure. Não foram feitas alterações relacionadas ao problema do status estagnado no workflow 'revisor_tarefas', pois a investigação indicou que a configuração atual do DependencyContainer está adequada.