### PR TITLE
Integrado fluxo para 'criacao_tarefas_azure_devops' para atualizar discussion da task após aprovação ou avanço do step 0 para 1.

### DIFF
--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -16,6 +16,7 @@ from services.incremental_step_executor_service import IncrementalStepExecutorSe
 from tools.azure_secret_manager import AzureSecretManager
 from services.azure_board_service import AzureBoardService
 import traceback
+from services.task_discussion_updater_service import TaskDiscussionUpdaterService
 
 class WorkflowOrchestrator(IWorkflowOrchestrator):
     def __init__(self, job_manager: IJobManager, blob_storage: IBlobStorageService, 
@@ -123,6 +124,26 @@ class WorkflowOrchestrator(IWorkflowOrchestrator):
                 self.job_handler.update_job_status(job_id, 'completed')
                 print(f"[{job_id}] [DEBUG] Workflow finalizado após criação de épicos Azure.")
                 return
+            # INICIO DO NOVO FLUXO PARA criacao_tarefas_azure_devops
+            if analysis_type == 'criacao_tarefas_azure_devops' and start_from_step > 0:
+                print(f"[{job_id}] [DEBUG] Fluxo de update_task_discussion para criacao_tarefas_azure_devops iniciado.")
+                task_id = job_info['data'].get('task_id')
+                report = job_info['data'].get('analysis_report')
+                organization = job_info['data'].get('organization') or job_info['data'].get('azure_organization')
+                project = job_info['data'].get('project') or job_info['data'].get('azure_project')
+                azure_board_service = AzureBoardService(organization, project, self.secret_manager)
+                task_discussion_updater_service = TaskDiscussionUpdaterService()
+                update_result = task_discussion_updater_service.update_task_from_report(task_id, report, azure_board_service)
+                job_info['data']['task_discussion_update_result'] = update_result
+                self.job_handler.update_job(job_id, job_info)
+                if update_result.get('error') or (not update_result.get('success', True)):
+                    print(f"[{job_id}] [ERROR] Falha ao atualizar discussion da task: {update_result}")
+                    self.job_handler.update_job_status(job_id, 'failed')
+                    return
+                print(f"[{job_id}] [DEBUG] Discussion da task atualizada com sucesso: {update_result}")
+                self.job_handler.update_job_status(job_id, 'completed')
+                return
+            # FIM DO NOVO FLUXO
             if start_from_step == 0:
                 print(f"[{job_id}] [DEBUG] Entrando no step 0. analysis_type={analysis_type}")
                 if analysis_type == 'revisor_tarefas':


### PR DESCRIPTION
No método execute_workflow, após aprovação (pending_approval) ou se não houver necessidade de aprovação e start_from_step > 0, faz parsing do relatório salvo, cria instância AzureBoardService e TaskDiscussionUpdaterService, chama update_task_from_report para atualizar discussion da task existente, atualiza job_info e status do job conforme resultado.