### PR TITLE
Atualização do TaskDiscussionUpdaterService para usar TaskDiscussionParserService em vez de TaskParserService.

### DIFF
--- a/services/task_discussion_updater_service.py
+++ b/services/task_discussion_updater_service.py
@@ -1,18 +1,17 @@
 from typing import List, Dict, Any
-from services.task_parser_service import TaskParserService
+from services.task_discussion_parser_service import TaskDiscussionParserService
 
 class TaskDiscussionUpdaterService:
     def update_task_from_report(self, task_id: str, report: str, azure_board_service) -> Dict[str, Any]:
         if not report or not isinstance(report, str) or not report.strip():
             return {"error": "Relatório vazio ou inválido."}
-        parser = TaskParserService()
-        parsed_rows = parser.parse_tasks_from_markdown(report)
-        if not parsed_rows or len(parsed_rows) == 0:
-            return {"error": "Nenhuma linha encontrada na tabela do relatório."}
+        parsed_entries = TaskDiscussionParserService.parse_discussion_entries_from_markdown(report)
+        if not parsed_entries or len(parsed_entries) == 0:
+            return {"error": "Nenhuma entrada válida de Categoria/Pergunta encontrada."}
         discussion_entries = []
-        for row in parsed_rows:
-            categoria = row.get('Categoria') or row.get('categoria') or ''
-            pergunta = row.get('Pergunta') or row.get('pergunta') or ''
+        for entry in parsed_entries:
+            categoria = entry.get('categoria', '')
+            pergunta = entry.get('pergunta', '')
             if categoria or pergunta:
                 discussion_entries.append({"Categoria": categoria, "Pergunta": pergunta})
         if not discussion_entries:


### PR DESCRIPTION
Modificado TaskDiscussionUpdaterService para remover dependência do TaskParserService, utilizando o TaskDiscussionParserService para parsing do relatório de atualização de tasks. Ajustada lógica para extrair entradas de categoria e pergunta corretamente do relatório específico de atualização, evitando erros causados pelo uso do parser errado.