### PR TITLE
Implementação do serviço PriorityMapperService para mapear valores MoSCoW para prioridade do Azure DevOps.

### DIFF
--- a/services/priority_mapper_service.py
+++ b/services/priority_mapper_service.py
@@ -1,0 +1,18 @@
+class PriorityMapperService:
+    @staticmethod
+    def map_moscow_to_azure_priority(moscow_value: str) -> int:
+        if not moscow_value:
+            return 2
+        value = moscow_value.strip().lower()
+        moscow_map = {
+            'm': 1,
+            'must': 1,
+            's': 2,
+            'should': 2,
+            'c': 3,
+            'could': 3,
+            "w": 4,
+            "won't": 4,
+            "wont": 4
+        }
+        return moscow_map.get(value, 2)


### PR DESCRIPTION
Criado o serviço PriorityMapperService com método estático map_moscow_to_azure_priority que converte valores MoSCoW para inteiros de prioridade do Azure DevOps, conforme o passo 8 do plano de ação.