### PR TITLE
Ajustado agente_revisor_board para obrigar leitura de epic_id e feature_id quando analysis_type é 'criacao_tarefas_azure_devops', incluindo dados da feature nas instrucoes_extras.

### DIFF
--- a/agents/agente_revisor_board.py
+++ b/agents/agente_revisor_board.py
@@ -11,15 +11,18 @@ class AgenteRevisorBoard:
         self.llm_provider = llm_provider
         init_logger()
 
-    def _get_epic_and_task_data(self, epic_id: str, task_id: Optional[str] = None) -> Dict[str, Any]:
+    def _get_epic_and_task_data(self, epic_id: str, task_id: Optional[str] = None, feature_id: Optional[str] = None) -> Dict[str, Any]:
         if not epic_id:
             raise ValueError("epic_id é obrigatório para leitura do épico.")
         epic_data = self.azure_board_service.read_epic(epic_id)
+        result = {'epic': epic_data}
         if task_id:
             task_data = self.azure_board_service.read_task(task_id)
-            return {'epic': epic_data, 'task': task_data}
-        else:
-            return {'epic': epic_data}
+            result['task'] = task_data
+        if feature_id:
+            feature_data = self.azure_board_service.read_feature(feature_id)
+            result['feature'] = feature_data
+        return result
 
     def main(
         self,
@@ -35,23 +38,38 @@ class AgenteRevisorBoard:
         usuario_executor: Optional[str] = None,
         current_batch: Optional[List[Dict[str, Any]]] = None,
         task_id: Optional[str] = None,
+        feature_id: Optional[str] = None,
         **kwargs
     ) -> Dict[str, Any]:
-        print(f"[AgenteRevisorBoard] [DEBUG] Entrando no main. epic_id={epic_id}, task_id={task_id}")
+        print(f"[AgenteRevisorBoard] [DEBUG] Entrando no main. epic_id={epic_id}, task_id={task_id}, feature_id={feature_id}")
         if not epic_id:
             raise ValueError("epic_id é obrigatório para execução do agente revisor_board.")
         if tipo_analise == 'revisor_tarefas':
             if not task_id:
                 raise ValueError("task_id é obrigatório quando analysis_type == 'revisor_tarefas'.")
-        data = self._get_epic_and_task_data(epic_id=epic_id, task_id=task_id)
+        if tipo_analise == 'criacao_tarefas_azure_devops':
+            if not feature_id:
+                raise ValueError("feature_id é obrigatório quando analysis_type == 'criacao_tarefas_azure_devops'.")
+        data = self._get_epic_and_task_data(epic_id=epic_id, task_id=task_id, feature_id=feature_id)
         epic_data = data.get('epic')
         task_data = data.get('task')
+        feature_data = data.get('feature')
         if tipo_analise == 'criacao_features_azure_devops':
             if epic_data is None:
                 print(f"[AgenteRevisorBoard] AVISO: Nenhum dado encontrado para o épico '{epic_id}'.")
                 print(f"[AgenteRevisorBoard] Retornando resposta vazia devido à ausência de dados do épico")
                 return {"resultado": {"reposta_final": {}}}
             instrucoes_extras = (instrucoes_extras or "") + '\n\n--- DADOS DO ÉPICO ---\n' + json.dumps(epic_data, indent=2, ensure_ascii=False)
+        elif tipo_analise == 'criacao_tarefas_azure_devops':
+            if epic_data is None:
+                print(f"[AgenteRevisorBoard] AVISO: Nenhum dado encontrado para o épico '{epic_id}'.")
+                print(f"[AgenteRevisorBoard] Retornando resposta vazia devido à ausência de dados do épico")
+                return {"resultado": {"reposta_final": {}}}
+            if feature_data is None:
+                print(f"[AgenteRevisorBoard] AVISO: Nenhum dado encontrado para a feature '{feature_id}'.")
+                print(f"[AgenteRevisorBoard] Retornando resposta vazia devido à ausência de dados da feature")
+                return {"resultado": {"reposta_final": {}}}
+            instrucoes_extras = (instrucoes_extras or "") + '\n\n--- DADOS DO ÉPICO ---\n' + json.dumps(epic_data, indent=2, ensure_ascii=False) + '\n\n--- DADOS DA FEATURE ---\n' + json.dumps(feature_data, indent=2, ensure_ascii=False)
         else:
             if epic_data is None:
                 print(f"[AgenteRevisorBoard] AVISO: Nenhum dado encontrado para o épico '{epic_id}'.")


### PR DESCRIPTION
Modificado método _get_epic_and_task_data para aceitar feature_id e retornar dados da feature. No método main, validado epic_id e feature_id obrigatórios para 'criacao_tarefas_azure_devops' e incluídos dados do épico e da feature nas instrucoes_extras para contexto completo.