### PR TITLE
Adicionada extração e armazenamento do feature_id no create_initial_job_data para analysis_type 'criacao_tarefas_azure_devops'.

### DIFF
--- a/services/job_data_service.py
+++ b/services/job_data_service.py
@@ -31,8 +31,10 @@ class JobDataService:
             data[JobFields.AZURE_PROJECT] = project
         if analysis_type == 'criacao_tarefas_azure_devops':
             epic_id = payload_dict.get('epic_id')
+            feature_id = payload_dict.get('feature_id')
             organization, project = self._parse_repository_name(normalized_repo_name)
             data[JobFields.EPIC_ID] = epic_id
+            data[JobFields.FEATURE_ID] = feature_id
             data[JobFields.ORGANIZATION] = organization
             data[JobFields.PROJECT] = project
         if analysis_type == 'criacao_features_azure_devops':
@@ -41,7 +43,6 @@ class JobDataService:
             data[JobFields.EPIC_ID] = epic_id
             data[JobFields.ORGANIZATION] = organization
             data[JobFields.PROJECT] = project
-        # Passo 7: garantir task_id para revisor_tarefas
         if analysis_type == 'revisor_tarefas':
             task_id = payload_dict.get('task_id')
             epic_id = payload_dict.get('epic_id')


### PR DESCRIPTION
No método create_initial_job_data, foi incluída a captura do feature_id do payload e seu armazenamento no dicionário de dados quando o tipo de análise é 'criacao_tarefas_azure_devops', garantindo que o feature_id seja tratado junto com epic_id, organização e projeto.