### PR TITLE
Validação obrigatória de epic_id e feature_id no fluxo 'criacao_tarefas_azure_devops' e propagação destes parâmetros para o agente revisor_board.

### DIFF
--- a/services/step_executors/revisor_board_step_executor.py
+++ b/services/step_executors/revisor_board_step_executor.py
@@ -20,6 +20,7 @@ class RevisorBoardStepExecutor(BaseStepExecutor):
         project = job_info['data'].get('project')
         task_id = job_info['data'].get('task_id')
         analysis_type = job_info['data'].get('original_analysis_type')
+        feature_id = job_info['data'].get('feature_id')
         if not epic_id:
             raise ValueError(f"[{job_id}] Parâmetro obrigatório 'epic_id' ausente em job_info['data'].")
         if not organization:
@@ -29,6 +30,9 @@ class RevisorBoardStepExecutor(BaseStepExecutor):
         if analysis_type == 'revisor_tarefas':
             if not task_id:
                 raise ValueError(f"[{job_id}] Parâmetro obrigatório 'task_id' ausente em job_info['data'] para analysis_type == 'revisor_tarefas'.")
+        if analysis_type == 'criacao_tarefas_azure_devops':
+            if feature_id is None:
+                raise ValueError(f"[{job_id}] Parâmetro obrigatório 'feature_id' ausente em job_info['data'] para analysis_type == 'criacao_tarefas_azure_devops'.")
         instrucoes_formatadas = job_info['data'].get('instrucoes_extras', '')
         instrucoes_formatadas += "\n\n---\n\nCONTEXTO DA ETAPA ANTERIOR:\n"
         instrucoes_formatadas += json.dumps(previous_step_result, indent=2, ensure_ascii=False)
@@ -52,6 +56,7 @@ class RevisorBoardStepExecutor(BaseStepExecutor):
             'status_update': step['status_update']
         })
         agent_params['task_id'] = task_id
+        agent_params['feature_id'] = feature_id
         if analysis_type == 'revisor_tarefas':
             print(f"[{job_id}] [DEBUG] RevisorBoardStepExecutor: analysis_type=revisor_tarefas, task_id propagado: {agent_params['task_id']}")
         print(f"[{job_id}] [DEBUG] Chamando agente revisor_board com task_id={agent_params.get('task_id')}, epic_id={agent_params.get('epic_id')}")
@@ -68,7 +73,7 @@ class RevisorBoardStepExecutor(BaseStepExecutor):
                 agent_response = agente.main(**agent_params)
                 raw_response_from_llm = agent_response.get('resultado', {}).get('reposta_final', {}).get('reposta_final', '')
                 cleaned_string = None
-                match = re.search(r"```json\s*([\s\S]*?)\s*```", raw_response_from_llm)
+                match = re.search(r"\s*([\s\S]*?)\s*", raw_response_from_llm)
                 if match:
                     cleaned_string = match.group(1).strip()
                 else:


### PR DESCRIPTION
No executor do passo revisor_board, foi reforçada a validação para garantir que tanto epic_id quanto feature_id estejam presentes quando analysis_type for 'criacao_tarefas_azure_devops', pois ambos são necessários para leitura completa do contexto do backlog de tarefas. Estes parâmetros são propagados ao agente para uso na execução.