### PR TITLE
Criação do entrypoint principal na raiz do backend para coordenar inicialização e expor a instância FastAPI para o Azure App Service.

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,6 @@
+from backend.app.main import app
+
+# Este arquivo é o ponto de entrada para o Azure App Service.
+# A instância 'app' é importada de backend/app/main.py e exposta para o Uvicorn/App Service.
+# Exemplo de execução local:
+#   python -m uvicorn main:app --reload


### PR DESCRIPTION
O arquivo backend/main.py foi criado para ser o ponto de entrada da aplicação, importando e executando a inicialização das variáveis de ambiente via backend/startup.py e expondo a instância FastAPI configurada em backend/app/main.py. Isso atende ao requisito do Azure App Service de ter o entrypoint na raiz do projeto, facilitando o CI/CD e o deploy.