### PR TITLE
Correção da rota do endpoint get_auth_config para evitar duplicidade e garantir URL final correta /auth/config.

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -12,7 +12,7 @@ class AuthConfigResponse(BaseModel):
     redirect_uri: str
     scope: str
 
-@router.get("/auth/config", response_model=AuthConfigResponse, tags=["Auth"])
+@router.get("/config", response_model=AuthConfigResponse, tags=["Auth"])
 def get_auth_config():
     """
     Endpoint público para o frontend obter as configurações necessárias para MSAL.js.


### PR DESCRIPTION
Ajuste no arquivo backend/app/api/auth.py para que o endpoint de configuração de autenticação seja exposto na rota /config, evitando a duplicidade que causava a URL /auth/auth/config. Mantém o endpoint público para o frontend obter configurações MSAL.js sem expor segredos.