### PR TITLE
Remoção do AuthMiddleware e refatoração para uso de dependência get_current_user com erros claros.

### DIFF
--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -1,32 +1,24 @@
-from fastapi import Request, HTTPException, status
+from fastapi import Request, HTTPException, status, Depends
 from fastapi.security.utils import get_authorization_scheme_param
-from starlette.middleware.base import BaseHTTPMiddleware
 from backend.app.services.azure_ad_service import AzureADService, AzureADTokenData
 
 azure_ad_service = AzureADService()
 
-class TokenData(AzureADTokenData):
-    pass
-
-def get_current_user(request: Request) -> AzureADTokenData:
+def get_current_user(request: Request) -> dict:
     auth: str = request.headers.get("Authorization")
     scheme, param = get_authorization_scheme_param(auth)
-    if not auth or scheme.lower() != "bearer":
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Cabeçalho Authorization ausente ou inválido.")
-    # Validação segura do token JWT usando assinatura e chaves públicas (PyJWKClient, RS256)
-    return azure_ad_service.validate_token(param)
-
-class AuthMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        auth: str = request.headers.get("Authorization")
-        scheme, param = get_authorization_scheme_param(auth)
-        if not auth or scheme.lower() != "bearer":
-            return await call_next(request)
-        try:
-            # Validação segura do token JWT usando assinatura e chaves públicas (PyJWKClient, RS256)
-            user = azure_ad_service.validate_token(param)
-            request.state.user = user
-        except HTTPException:
-            return await call_next(request)
-        response = await call_next(request)
-        return response
+    if not auth:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Cabeçalho Authorization ausente.")
+    if scheme.lower() != "bearer":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Tipo de autenticação inválido. Use Bearer.")
+    try:
+        user = azure_ad_service.validate_token(param)
+        # Retorna claims como dict para compatibilidade
+        if hasattr(user, "claims"):
+            return user.claims
+        return user
+    except HTTPException as exc:
+        # Propaga o erro com mensagem detalhada (ex: Token expirado, assinatura inválida)
+        raise exc
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Erro inesperado na validação do token: {str(exc)}")


### PR DESCRIPTION
Removida a classe AuthMiddleware que engolia erros de autenticação, substituindo-a pela função get_current_user que valida o token JWT e lança HTTPException com mensagens detalhadas. Isso permite que o FastAPI interrompa a requisição e retorne erros específicos para o frontend, facilitando o debug e melhorando a segurança.