### PR TITLE
Inclusão do campo session_id no payload MCPStartAnalysisPayload para rastreamento da sessão no MCP.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -9,6 +9,7 @@ class MCPStartAnalysisPayload(BaseModel):
     projeto: str
     analysis_name: str
     usuario_executor: str
+    session_id: str
 
 class MCPStartAnalysisResponse(BaseModel):
     job_id: str


### PR DESCRIPTION
Modificado o modelo MCPStartAnalysisPayload para incluir session_id e garantir que o MCPClientService envie esse campo ao MCP Server em todas as requisições de início de análise, permitindo rastreabilidade completa da sessão.