### PR TITLE
O método validate_redis_connection agora exige que todos os segredos do Redis estejam presentes e reporta falha se algum estiver ausente, garantindo que o backend não use variáveis de ambiente para o Redis.

### DIFF
--- a/backend/app/services/startup_validator.py
+++ b/backend/app/services/startup_validator.py
@@ -93,18 +93,36 @@ class StartupValidator:
     def validate_redis_connection(self):
         try:
             host = getattr(settings, 'REDIS_HOST', None)
-            port = int(getattr(settings, 'REDIS_PORT', 6379))
+            port = getattr(settings, 'REDIS_PORT', None)
             password = getattr(settings, 'REDIS_PASSWORD', None)
-            db = int(getattr(settings, 'REDIS_DB', 0))
-            use_ssl = getattr(settings, 'REDIS_USE_SSL', True)
-            ssl_cert_reqs = getattr(settings, 'REDIS_SSL_CERT_REQS', 'required')
+            db = getattr(settings, 'REDIS_DB', None)
+            use_ssl = getattr(settings, 'REDIS_USE_SSL', None)
+            ssl_cert_reqs = getattr(settings, 'REDIS_SSL_CERT_REQS', None)
+            missing = []
             if not host:
-                raise ValueError("REDIS_HOST não configurado.")
+                missing.append('REDIS_HOST')
+            if not port:
+                missing.append('REDIS_PORT')
+            if not password:
+                missing.append('REDIS_PASSWORD')
+            if db is None:
+                missing.append('REDIS_DB')
+            if use_ssl is None:
+                missing.append('REDIS_USE_SSL')
+            if ssl_cert_reqs is None:
+                missing.append('REDIS_SSL_CERT_REQS')
+            if missing:
+                self.status_report['redis'] = {
+                    'status': 'fail',
+                    'detail': f'Segredos do Redis não carregados do Key Vault: {', '.join(missing)}'
+                }
+                self.logger.error(f"Redis secrets missing: {missing}")
+                return
             client = redis.Redis(
                 host=host,
-                port=port,
+                port=int(port),
                 password=password,
-                db=db,
+                db=int(db),
                 ssl=use_ssl,
                 ssl_cert_reqs=ssl_cert_reqs,
                 socket_connect_timeout=5,


### PR DESCRIPTION
A validação da conexão Redis no StartupValidator foi reforçada para garantir que os segredos do Redis sejam carregados exclusivamente do Key Vault. Caso algum segredo esteja ausente, o método reporta falha e não tenta fallback para variáveis de ambiente.