### PR TITLE
Atualização da documentação para reforçar que AZURE_STORAGE_CONNECTION_STRING deve estar no Key Vault kv-codeai-azure-dev-usc.

### DIFF
--- a/backend/docs/KEY_VAULT_SECRETS_MAPPING.md
+++ b/backend/docs/KEY_VAULT_SECRETS_MAPPING.md
@@ -19,12 +19,6 @@
 ## Como criar segredos no Key Vault
 
 ### Usando Azure CLI:
-```text
 text
-az keyvault secret set --vault-name kv-codeai-azure-dev-usc --name redis-host --value "your-redis-cache.redis.cache.windows.net"
-az keyvault secret set --vault-name kv-codeai-azure-dev-usc --name redis-port --value "6380"
-az keyvault secret set --vault-name kv-codeai-azure-dev-usc --name redis-password --value "<obtido-no-portal-azure>"
-az keyvault secret set --vault-name kv-codeai-azure-dev-usc --name redis-db --value "0"
-az keyvault secret set --vault-name kv-codeai-azure-dev-usc --name redis-use-ssl --value "True"
-az keyvault secret set --vault-name kv-codeai-azure-dev-usc --name redis-ssl-cert-reqs --value "required"
-```
+az keyvault secret set --vault-name kv-codeai-azure-dev-usc --name azure-storage-connection-string --value "<sua-string-de-conexao>"
+


### PR DESCRIPTION
Modificada a tabela de mapeamento de segredos e adicionada instrução clara com exemplo de comando Azure CLI para criação do segredo azure-storage-connection-string no Key Vault kv-codeai-azure-dev-usc.