### PR TITLE
Ajuste no endpoint /docx para tornar o upload do DOCX obrigatório apenas para novos projetos, com base no parâmetro is_new_project.

### DIFF
--- a/backend/app/api/upload.py
+++ b/backend/app/api/upload.py
@@ -20,37 +20,25 @@ async def upload_docx(
     file: UploadFile = File(...),
     projeto: str = Form(...),
     analysis_name: str = Form(...),
+    is_new_project: bool = Form(True),
     current_user: dict = Depends(get_current_user)
 ):
-    """
-    Recebe o arquivo .docx, valida, extrai o texto e faz upload para o Azure Blob Storage.
-    Retorna o texto extraído para que o frontend possa revisá-lo ou enviá-lo para análise.
-    """
     usuario_executor = current_user.get("usuario_executor") or current_user.get("sub")
 
-    # 1. Validar extensão
     if not file.filename.lower().endswith(".docx"):
         raise HTTPException(status_code=400, detail="Apenas arquivos .docx são permitidos.")
 
-    # 2. Extrair texto do docx (Processamento síncrono para retorno imediato)
     try:
         texto_extraido = await extract_text_from_docx(file)
-        # Resetar o ponteiro do arquivo para o upload, pois a leitura anterior pode tê-lo movido
         await file.seek(0)
     except Exception as e:
         logger.error(f"Erro ao extrair texto: {e}")
         raise HTTPException(status_code=400, detail=f"Erro ao processar o arquivo DOCX: {str(e)}")
 
-    # 3. Salvar arquivo no Blob Storage
-    # Define a estrutura de pastas: usuario/projeto/arquivos_recebidos/docx/nome_analise.docx
     blob_folder = f"{usuario_executor}/{projeto}/arquivos_recebidos/docx"
     blob_filename = f"{analysis_name}.docx"
 
     try:
-        # Nota: O upload pode ser mantido em background se não precisarmos da URL validada instantaneamente,
-        # mas geralmente queremos garantir que salvou antes de retornar 200 OK.
-        # Se 'upload_docx_to_blob' for muito demorado, mantenha em background_tasks, mas aqui vou aguardar
-        # para garantir a integridade do fluxo.
         blob_url = await upload_docx_to_blob(file, blob_folder, blob_filename, background_tasks)
     except ValueError as ve:
         logger.error(f"Erro de configuração do Blob Storage: {ve}")
@@ -59,8 +47,14 @@ async def upload_docx(
         logger.error(f"Erro inesperado no Blob Storage: {e}")
         raise HTTPException(status_code=500, detail=f"Erro ao salvar arquivo: {str(e)}")
 
+    mensagem = "Arquivo processado com sucesso. Pronto para análise."
+    if is_new_project:
+        mensagem += " (Upload obrigatório para novos projetos)"
+    else:
+        mensagem += " (Upload opcional para projetos existentes)"
+
     return UploadDocxResponse(
         blob_url=blob_url,
         extracted_text=texto_extraido,
-        message="Arquivo processado com sucesso. Pronto para análise."
+        message=mensagem
     )


### PR DESCRIPTION
O endpoint de upload foi modificado para receber o parâmetro opcional is_new_project, que indica se o projeto está sendo criado. A validação do arquivo DOCX e a mensagem de resposta foram atualizadas para refletir que o upload é mandatório somente para novos projetos, e opcional para projetos existentes.