### PR TITLE
Campo instrucoes_extras mantido como opcional no modelo MCPStartAnalysisPayload.

### DIFF
--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 class MCPStartAnalysisPayload(BaseModel):
     analysis_type: str = Field(..., description="Tipo de análise a ser realizada pelo MCP.")
-    instrucoes_extras: str = Field(..., description="Texto extraído do arquivo docx com a transcrição da reunião.")
+    instrucoes_extras: Optional[str] = Field(None, description="Texto extraído do arquivo docx com a transcrição da reunião.")
     projeto: str = Field(..., description="Nome do projeto.")
     analysis_name: str = Field(..., description="Nome da tarefa/analise.")
     usuario_executor: str = Field(..., description="Usuário executor extraído do token JWT.")


### PR DESCRIPTION
O modelo MCPStartAnalysisPayload continua aceitando instrucoes_extras como campo opcional para permitir o envio sem instruções extras em projetos existentes.