### PR TITLE
Criação de documentação com exemplos de payload para o endpoint /analysis/start contemplando a nova lógica de obrigatoriedade do DOCX.

### DIFF
--- a/backend/docs/API_PAYLOAD_EXAMPLES.md
+++ b/backend/docs/API_PAYLOAD_EXAMPLES.md
@@ -1,0 +1,78 @@
+# Exemplos de Payloads: /analysis/start
+
+## 1. Iniciar Análise com DOCX (Novo Projeto)
+
+**Requisição:**
+
+{
+  "projeto": "ProjetoNovo",
+  "analysis_name": "Sprint 1",
+  "analysis_type": "criacao_epicos_azure_devops",
+  "extracted_text": "Texto extraído do DOCX da reunião"
+}
+
+
+**Resposta de Sucesso:**
+
+{
+  "job_id": "123456",
+  "message": "Análise solicitada com sucesso ao agente.",
+  "session_id": "abcdef-uuid"
+}
+
+
+**Resposta de Erro (faltando DOCX para novo projeto):**
+
+{
+  "detail": "O upload do DOCX é obrigatório para novos projetos."
+}
+
+
+---
+
+## 2. Iniciar Análise sem DOCX (Projeto Existente)
+
+**Requisição:**
+
+{
+  "projeto": "ProjetoExistente",
+  "analysis_name": "Sprint 2",
+  "analysis_type": "criacao_epicos_azure_devops"
+}
+
+
+**Resposta de Sucesso:**
+
+{
+  "job_id": "789012",
+  "message": "Análise solicitada com sucesso ao agente.",
+  "session_id": "ghijkl-uuid"
+}
+
+
+---
+
+## 3. Iniciar Análise sem DOCX para Projeto Inexistente (Erro)
+
+**Requisição:**
+
+{
+  "projeto": "ProjetoInexistente",
+  "analysis_name": "Sprint 3",
+  "analysis_type": "criacao_epicos_azure_devops"
+}
+
+
+**Resposta de Erro:**
+
+{
+  "detail": "O upload do DOCX é obrigatório para novos projetos."
+}
+
+
+---
+
+## Observações
+- O campo `extracted_text` só é obrigatório se o projeto não existir previamente para o usuário.
+- Para projetos existentes, basta informar o nome do projeto, analysis_name e analysis_type.
+- O backend faz a verificação automática do estado do projeto no Blob Storage.


### PR DESCRIPTION
Foi criado um arquivo com exemplos claros de requisições e respostas para o endpoint /analysis/start, incluindo cenários para novo projeto (upload obrigatório do DOCX), projeto existente (upload opcional) e erro quando o DOCX não é enviado para novo projeto. A documentação orienta o uso correto da API conforme a nova regra de negócio.