### PR TITLE
Inclusão de exemplos de payload e resposta para o novo endpoint de consulta dos arquivos DOCX enviados em uma sessão.

### DIFF
--- a/backend/docs/API_PAYLOAD_EXAMPLES.md
+++ b/backend/docs/API_PAYLOAD_EXAMPLES.md
@@ -3,72 +3,98 @@
 ## 1. Iniciar Análise com DOCX (Novo Projeto)
 
 **Requisição:**
-```json
+
 {
   "projeto": "ProjetoNovo",
   "analysis_name": "Sprint 1",
   "analysis_type": "criacao_epicos_azure_devops",
   "extracted_text": "Texto extraído do DOCX da reunião"
 }
-```
+
 
 **Resposta de Sucesso:**
-```json
+
 {
   "job_id": "123456",
   "message": "Análise solicitada com sucesso ao agente.",
   "session_id": "abcdef-uuid"
 }
-```
+
 
 **Resposta de Erro (faltando DOCX para novo projeto):**
-```json
+
 {
   "detail": "O upload do DOCX é obrigatório para novos projetos."
 }
-```
+
 
 ---
 
 ## 2. Iniciar Análise sem DOCX (Projeto Existente)
 
 **Requisição:**
-```json
+
 {
   "projeto": "ProjetoExistente",
   "analysis_name": "Sprint 2",
   "analysis_type": "criacao_epicos_azure_devops"
 }
-```
+
 
 **Resposta de Sucesso:**
-```json
+
 {
   "job_id": "789012",
   "message": "Análise solicitada com sucesso ao agente.",
   "session_id": "ghijkl-uuid"
 }
-```
+
 
 ---
 
 ## 3. Iniciar Análise sem DOCX para Projeto Inexistente (Erro)
 
 **Requisição:**
-```json
+
 {
   "projeto": "ProjetoInexistente",
   "analysis_name": "Sprint 3",
   "analysis_type": "criacao_epicos_azure_devops"
 }
-```
+
 
 **Resposta de Erro:**
-```json
+
 {
   "detail": "O upload do DOCX é obrigatório para novos projetos."
 }
-```
+
+
+---
+
+## 4. Consultar arquivos DOCX enviados para uma sessão
+
+**Endpoint:**
+
+GET /session/{session_id}/docx-files
+
+
+**Exemplo de resposta com lista vazia:**
+
+{
+  "docx_files": []
+}
+
+
+**Exemplo de resposta com múltiplos arquivos:**
+
+{
+  "docx_files": [
+    "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint1.docx",
+    "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx"
+  ]
+}
+
 
 ---
 
@@ -76,3 +102,5 @@
 - O campo `extracted_text` só é obrigatório se o projeto não existir previamente para o usuário.
 - Para projetos existentes, basta informar o nome do projeto, analysis_name e analysis_type.
 - O backend faz a verificação automática do estado do projeto no Blob Storage.
+- Todo arquivo DOCX enviado tem seu caminho salvo no campo `docx_files` do estado da sessão, permitindo rastreabilidade e recuperação de todas as histórias geradas.
+- O endpoint `GET /session/{session_id}/docx-files` retorna o histórico completo de arquivos DOCX enviados para a sessão.


### PR DESCRIPTION
Adicionados exemplos de payload e resposta para o endpoint GET /session/{session_id}/docx-files, além de observações atualizadas para refletir o histórico completo de arquivos DOCX salvos no estado da sessão, garantindo rastreabilidade e recuperação das histórias geradas.