### PR TITLE
Ajuste no endpoint /analysis/start para aceitar apenas o nome do projeto para projetos existentes, tornando analysis_name e analysis_type opcionais. Implementação da lógica para buscar metadados do projeto existente no Blob Storage quando necessário.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -1,6 +1,6 @@
 import logging
 from fastapi import APIRouter, HTTPException, Depends, Body, BackgroundTasks
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 from typing import Optional
 
 from ..middleware.auth_middleware import get_current_user
@@ -14,11 +14,21 @@ logger = logging.getLogger("analysis_api")
 
 class StartAnalysisRequest(BaseModel):
     projeto: str
-    analysis_name: str
-    analysis_type: str
+    analysis_name: Optional[str] = None
+    analysis_type: Optional[str] = None
     extracted_text: Optional[str] = None
     blob_url: Optional[str] = None
     session_id: Optional[str] = None
+
+    @root_validator
+    def validate_fields(cls, values):
+        projeto = values.get("projeto")
+        analysis_name = values.get("analysis_name")
+        analysis_type = values.get("analysis_type")
+        extracted_text = values.get("extracted_text")
+        session_id = values.get("session_id")
+        # Validação será feita na lógica do endpoint, pois depende do estado do projeto
+        return values
 
 class StartAnalysisResponse(BaseModel):
     job_id: str
@@ -32,20 +42,36 @@ async def start_analysis(
     current_user: dict = Depends(get_current_user)
 ):
     usuario_executor = current_user.get("usuario_executor") or current_user.get("sub")
-    logger.info(f"Iniciando análise '{payload_request.analysis_name}' do tipo '{payload_request.analysis_type}' para usuário {usuario_executor}")
+    logger.info(f"Iniciando análise para projeto '{payload_request.projeto}' (analysis_name: '{payload_request.analysis_name}', analysis_type: '{payload_request.analysis_type}') para usuário {usuario_executor}")
     redis_service = RedisSessionService()
     session_id = payload_request.session_id
     project_state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, payload_request.projeto)
     if project_state:
+        # Projeto existe: analysis_name e analysis_type podem ser omitidos
+        # Se não fornecidos, buscar do estado mais recente
+        if not payload_request.analysis_name or not payload_request.analysis_type:
+            metadata = await ProjectStateService.get_latest_analysis_metadata(usuario_executor, payload_request.projeto)
+            analysis_name = payload_request.analysis_name or metadata.get("analysis_name")
+            analysis_type = payload_request.analysis_type or metadata.get("analysis_type")
+            if not analysis_name or not analysis_type:
+                logger.error("Metadados do projeto existente não encontrados no estado. Informe analysis_name e analysis_type.")
+                raise HTTPException(status_code=400, detail="Metadados do projeto existente não encontrados. Informe analysis_name e analysis_type.")
+        else:
+            analysis_name = payload_request.analysis_name
+            analysis_type = payload_request.analysis_type
         session_id = redis_service.restore_session_from_state(
             usuario_executor,
             payload_request.projeto,
-            payload_request.analysis_name,
-            payload_request.analysis_type,
+            analysis_name,
+            analysis_type,
             project_state
         )
         instrucoes_extras = payload_request.extracted_text if payload_request.extracted_text is not None else ""
     else:
+        # Projeto não existe: analysis_name e analysis_type obrigatórios
+        if not payload_request.analysis_name or not payload_request.analysis_type:
+            logger.error("Para criar um novo projeto, os campos 'analysis_name' e 'analysis_type' são obrigatórios.")
+            raise HTTPException(status_code=400, detail="Os campos 'analysis_name' e 'analysis_type' são obrigatórios para novos projetos.")
         if not payload_request.extracted_text:
             logger.error("Para criar um novo projeto, o campo 'extracted_text' (texto extraído do DOCX) é obrigatório.")
             raise HTTPException(status_code=400, detail="O upload do DOCX é obrigatório para novos projetos.")
@@ -55,6 +81,8 @@ async def start_analysis(
             payload_request.analysis_name,
             payload_request.analysis_type
         )
+        analysis_name = payload_request.analysis_name
+        analysis_type = payload_request.analysis_type
         instrucoes_extras = payload_request.extracted_text
         if payload_request.blob_url:
             try:
@@ -63,10 +91,10 @@ async def start_analysis(
                 logger.error(f"Erro ao adicionar arquivo DOCX à sessão durante análise: {e}")
     BackgroundStateSaver.schedule_periodic_save(session_id)
     mcp_payload = MCPStartAnalysisPayload(
-        analysis_type=payload_request.analysis_type,
+        analysis_type=analysis_type,
         instrucoes_extras=instrucoes_extras,
         projeto=payload_request.projeto,
-        analysis_name=payload_request.analysis_name,
+        analysis_name=analysis_name,
         usuario_executor=usuario_executor,
         session_id=session_id
     )

--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -39,3 +39,15 @@ class ProjectStateService:
         state_bytes = blob_client.download_blob().readall()
         state = json.loads(state_bytes.decode("utf-8"))
         return state
+
+    @staticmethod
+    async def get_latest_analysis_metadata(usuario_executor: str, projeto: str) -> Dict[str, str]:
+        state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, projeto)
+        if not state:
+            return {}
+        analysis_name = state.get("analysis_name")
+        analysis_type = state.get("analysis_type")
+        return {
+            "analysis_name": analysis_name,
+            "analysis_type": analysis_type
+        }


### PR DESCRIPTION
Modificado o modelo StartAnalysisRequest para tornar analysis_name e analysis_type opcionais. Na lógica do endpoint, ao detectar projeto existente, busca os metadados no Blob Storage para preencher analysis_name e analysis_type caso não informados. Para novos projetos, mantém a obrigatoriedade desses campos e do extracted_text. A sessão Redis é restaurada ou criada conforme o caso. Adicionada chamada para agendamento de salvamento periódico do estado. Comunicação com MCP para iniciar análise foi mantida com tratamento de exceções.