### PR TITLE
Atualização dos modelos Pydantic para remover analysis_name e padronizar o payload MCP conforme os três formatos definidos.

### DIFF
--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -2,12 +2,12 @@ from pydantic import BaseModel, Field, validator
 from typing import Optional
 
 class MCPStartAnalysisPayload(BaseModel):
-    analysis_type: str = Field(..., description="Tipo de análise a ser realizada pelo MCP.")
-    instrucoes_extras: Optional[str] = Field(None, description="Texto extraído do arquivo docx com a transcrição da reunião.")
-    comentario_usuario: Optional[str] = Field(None, description="Comentário adicional enviado pelo usuário.")
     projeto: str = Field(..., description="Nome do projeto.")
-    analysis_name: str = Field(..., description="Nome da tarefa/analise.")
+    analysis_type: str = Field(..., description="Tipo de análise a ser realizada pelo MCP.")
+    arquivo_docx: Optional[str] = Field(None, description="Texto extraído do arquivo docx com a transcrição da reunião.")
+    comentario_usuario: Optional[str] = Field(None, description="Comentário adicional enviado pelo usuário.")
     usuario_executor: str = Field(..., description="Usuário executor extraído do token JWT.")
+    session_id: str = Field(..., description="Identificador da sessão.")
 
     @validator('analysis_type')
     def analysis_type_must_not_be_empty(cls, v):


### PR DESCRIPTION
O modelo MCPStartAnalysisPayload foi ajustado para conter apenas projeto, analysis_type, arquivo_docx (opcional), comentario_usuario (opcional), usuario_executor e session_id. Foi removido o campo analysis_name e renomeado instrucoes_extras para arquivo_docx para refletir o texto extraído do arquivo docx.