### PR TITLE
Padronização do payload enviado ao MCP e ajuste dos serviços de sessão e estado para remover analysis_name e aceitar apenas os três formatos únicos de payload com os campos especificados.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -1,15 +1,21 @@
 import httpx
-from typing import Any, Dict
-from pydantic import BaseModel
-from app.core.config import settings
+from typing import Any, Dict, Optional
+from pydantic import BaseModel, Field, validator
+from backend.app.core.config import settings
 
 class MCPStartAnalysisPayload(BaseModel):
-    analysis_type: str
-    instrucoes_extras: str = None
-    projeto: str
-    analysis_name: str
-    usuario_executor: str
-    session_id: str
+    projeto: str = Field(...)
+    analysis_type: str = Field(...)
+    arquivo_docx: Optional[str] = Field(None)
+    comentario_usuario: Optional[str] = Field(None)
+    usuario_executor: str = Field(...)
+    session_id: str = Field(...)
+
+    @validator('analysis_type')
+    def analysis_type_must_not_be_empty(cls, v):
+        if not v or not isinstance(v, str) or not v.strip():
+            raise ValueError('analysis_type deve ser uma string não vazia')
+        return v
 
 class MCPStartAnalysisResponse(BaseModel):
     job_id: str
@@ -28,8 +34,6 @@ class MCPClientService:
         url = f"{self.get_mcp_endpoint(payload.analysis_type)}/start-analysis"
         try:
             payload_dict = payload.dict()
-            if payload_dict.get('instrucoes_extras', None) is None:
-                payload_dict.pop('instrucoes_extras', None)
             async with httpx.AsyncClient(timeout=30) as client:
                 response = await client.post(
                     url,

--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -17,7 +17,7 @@ class ProjectStateService:
         blob_path = f"{blob_folder}/{blob_filename}"
         _, container_client = _get_blob_clients()
         blob_client = container_client.get_blob_client(blob_path)
-        state_bytes = json.dumps(state, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        state_bytes = json.dumps(state, ensure_ascii=False, separators=(',', ':')).encode("utf-8")
         blob_client.upload_blob(state_bytes, overwrite=True, content_settings=None)
         return blob_client.url
 
@@ -51,10 +51,8 @@ class ProjectStateService:
         state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, projeto)
         if not state:
             return {}
-        analysis_name = state.get("analysis_name")
         analysis_type = state.get("analysis_type")
         return {
-            "analysis_name": analysis_name,
             "analysis_type": analysis_type
         }
 
@@ -82,7 +80,6 @@ class ProjectStateService:
                 state = json.loads(state_bytes.decode("utf-8"))
                 item = {
                     "projeto": state.get("projeto", projeto),
-                    "analysis_name": state.get("analysis_name"),
                     "analysis_type": state.get("analysis_type"),
                     "created_at": state.get("created_at"),
                     "last_saved_to_blob": state.get("last_saved_to_blob")

--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -27,14 +27,13 @@ class RedisSessionService:
         )
         self.session_ttl = int(getattr(settings, 'REDIS_SESSION_TTL', 86400))
 
-    def create_session(self, usuario_executor: str, projeto: str, analysis_name: str, analysis_type: str, comentario_usuario: Optional[str] = None) -> str:
+    def create_session(self, usuario_executor: str, projeto: str, analysis_type: str, comentario_usuario: Optional[str] = None) -> str:
         session_id = str(uuid.uuid4())
         created_at = datetime.utcnow().isoformat()
         session_data = {
             "session_id": session_id,
             "usuario_executor": usuario_executor,
             "projeto": projeto,
-            "analysis_name": analysis_name,
             "analysis_type": analysis_type,
             "created_at": created_at,
             "steps": [],
@@ -98,9 +97,9 @@ class RedisSessionService:
         session_data[REPORT_TYPES[report_type]] = report_data
         self.redis_client.setex(key, self.session_ttl, json.dumps(session_data))
 
-    def restore_session_from_state(self, usuario_executor: str, projeto: str, analysis_name: str, analysis_type: str, project_state: Dict[str, Any]) -> str:
+    def restore_session_from_state(self, usuario_executor: str, projeto: str, analysis_type: str, project_state: Dict[str, Any]) -> str:
         comentario_usuario = project_state.get("comentario_usuario")
-        session_id = self.create_session(usuario_executor, projeto, analysis_name, analysis_type, comentario_usuario=comentario_usuario)
+        session_id = self.create_session(usuario_executor, projeto, analysis_type, comentario_usuario=comentario_usuario)
         key = f"session:{session_id}"
         session_json = self.redis_client.get(key)
         if not session_json:


### PR DESCRIPTION
Este PR implementa a padronização dos fluxos de dados entre front, backend e MCP, removendo o campo analysis_name de toda a lógica. O backend agora aceita do front apenas três formatos únicos de payload e envia para o MCP payloads correspondentes com os campos projeto, analysis_type, arquivo_docx (texto extraído), comentario_usuario, usuario_executor e session_id conforme o caso. Ajustes foram feitos no MCPClientService para refletir a nova estrutura do payload, no RedisSessionService para criar e restaurar sessões sem analysis_name e no ProjectStateService para carregar e salvar estados sem dependência de analysis_name.