### PR TITLE
Remoção do campo analysis_name da classe SessionData e ajustes nos métodos de serialização para padronizar o payload enviado e recebido, conforme nova especificação.

### DIFF
--- a/backend/app/models/session_models.py
+++ b/backend/app/models/session_models.py
@@ -13,7 +13,6 @@ class SessionData(BaseModel):
     session_id: str = Field(...)
     usuario_executor: str = Field(...)
     projeto: str = Field(...)
-    analysis_name: str = Field(...)
     analysis_type: str = Field(...)
     created_at: datetime = Field(...)
     steps: List[SessionStep] = Field(default_factory=list)
@@ -30,7 +29,6 @@ class SessionData(BaseModel):
         return {
             "usuario_executor": self.usuario_executor,
             "projeto": self.projeto,
-            "analysis_name": self.analysis_name,
             "analysis_type": self.analysis_type,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "last_saved_to_blob": self.last_saved_to_blob.isoformat() if self.last_saved_to_blob else None,
@@ -49,7 +47,6 @@ class SessionData(BaseModel):
             session_id=state.get("session_id", ""),
             usuario_executor=state.get("usuario_executor", ""),
             projeto=state.get("projeto", ""),
-            analysis_name=state.get("analysis_name", ""),
             analysis_type=state.get("analysis_type", ""),
             created_at=datetime.fromisoformat(state["created_at"]) if state.get("created_at") else datetime.utcnow(),
             steps=[],


### PR DESCRIPTION
O campo analysis_name foi removido da classe SessionData e dos métodos to_project_state e from_project_state para alinhar o modelo com a nova padronização dos payloads. Isso evita o envio e recebimento desse campo, que não será mais utilizado no fluxo atual.