### PR TITLE
Remoção do campo analysis_name da classe ProjectListItem para padronização dos payloads retornados pela API.

### DIFF
--- a/backend/app/models/project_models.py
+++ b/backend/app/models/project_models.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 class ProjectListItem(BaseModel):
     projeto: str = Field(...)
-    analysis_name: Optional[str] = Field(None)
     analysis_type: Optional[str] = Field(None)
     created_at: Optional[datetime] = Field(None)
     last_saved_to_blob: Optional[datetime] = Field(None)


### PR DESCRIPTION
O campo analysis_name foi removido da classe ProjectListItem para garantir que as respostas da API estejam alinhadas com a nova padronização, evitando o envio desse campo desnecessário.