### PR TITLE
Ajuste dos endpoints /projects/check e /projects/list para não retornarem mais o campo analysis_name, garantindo padronização dos payloads e respostas.

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -18,6 +18,8 @@ async def check_project(
     try:
         state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, projeto)
         if state:
+            # Remove analysis_name do estado se existir
+            state.pop("analysis_name", None)
             logger.info(f"Projeto '{projeto}' encontrado para usuario_executor='{usuario_executor}'. Estado retornado.")
             return {"exists": True, "state": state}
         else:
@@ -32,6 +34,10 @@ async def list_projects(current_user: dict = Depends(get_current_user)):
     usuario_executor = current_user.get("usuario_executor") or current_user.get("sub")
     try:
         projects = await ProjectStateService.list_user_projects(usuario_executor)
+        # Remove analysis_name de cada projeto se existir
+        for p in projects:
+            if isinstance(p, dict):
+                p.pop("analysis_name", None)
         return projects
     except Exception as e:
         logger.error(f"Erro ao listar projetos do usuário {usuario_executor}: {e}")


### PR DESCRIPTION
Os endpoints foram modificados para remover o campo analysis_name dos dados retornados, tanto no estado do projeto quanto na lista de projetos, alinhando-se à nova especificação que exclui esse campo do fluxo.