### PR TITLE
Atualização da documentação dos payloads para refletir a remoção do campo 'analysis_name' e padronização dos três formatos aceitos tanto no envio do frontend para o backend quanto do backend para o MCP.

### DIFF
--- a/backend/docs/API_PAYLOAD_EXAMPLES.md
+++ b/backend/docs/API_PAYLOAD_EXAMPLES.md
@@ -6,93 +6,92 @@ Este documento apresenta exemplos práticos de payloads enviados pelo frontend p
 
 ## 1. Exemplos de Payloads por Cenário de Uso
 
-### 1.1 Iniciar Análise com DOCX e Comentário em Projeto Novo
+### 1.1 Iniciar Análise - Três Formatos de Payload
 
-**Endpoint:**
-POST /analysis/start
+**O campo `analysis_name` NÃO é mais utilizado.**
 
-**Headers:**
-- Authorization: Bearer <token_jwt_azure_ad>
-- Content-Type: application/json
+O backend aceita apenas um dos três formatos de payload abaixo (todos os campos obrigatórios, exceto onde indicado como opcional):
 
-**Body:**
-```json
+**Exemplo 1:**
+
 {
   "projeto": "ProjetoNovo",
-  "analysis_name": "Sprint 1",
   "analysis_type": "criacao_epicos_azure_devops",
-  "extracted_text": "Texto extraído do DOCX da reunião",
+  "arquivo_docx": "<arquivo .docx>",
   "comentario_usuario": "Este é um comentário adicional do usuário."
 }
-```
+
+
+**Exemplo 2:**
+
+{
+  "projeto": "ProjetoNovo",
+  "analysis_type": "criacao_epicos_azure_devops",
+  "arquivo_docx": "<arquivo .docx>"
+}
+
+
+**Exemplo 3:**
+
+{
+  "projeto": "ProjetoNovo",
+  "analysis_type": "criacao_epicos_azure_devops",
+  "comentario_usuario": "Comentário sem arquivo."
+}
+
+
 **Resposta de Sucesso:**
-```json
+
 {
   "job_id": "123456",
   "message": "Análise solicitada com sucesso ao agente.",
   "session_id": "abcdef-uuid"
 }
-```
+
 
 ---
 
-### 1.2 Iniciar Análise em Projeto Existente apenas com Nome do Projeto
+### 1.2 Payload enviado do Backend para o MCP
 
-**Endpoint:**
-POST /analysis/start
+O backend sempre envia para o MCP um dos três payloads abaixo, conforme o recebido do frontend:
 
-**Headers:**
-- Authorization: Bearer <token_jwt_azure_ad>
-- Content-Type: application/json
+**Exemplo 1:**
 
-**Body:**
-```json
 {
-  "projeto": "ProjetoExistente",
-  "comentario_usuario": "Comentário para análise apenas com nome do projeto."
-}
-```
-**Resposta de Sucesso:**
-```json
-{
-  "job_id": "789012",
-  "message": "Análise solicitada com sucesso ao agente.",
-  "session_id": "ghijkl-uuid"
-}
-```
-
----
-
-### 1.3 Iniciar Análise em Projeto Existente informando analysis_name e analysis_type
-
-**Endpoint:**
-POST /analysis/start
-
-**Headers:**
-- Authorization: Bearer <token_jwt_azure_ad>
-- Content-Type: application/json
-
-**Body:**
-```json
-{
-  "projeto": "ProjetoExistente",
-  "analysis_name": "Sprint 2",
+  "projeto": "ProjetoNovo",
   "analysis_type": "criacao_epicos_azure_devops",
-  "comentario_usuario": "Comentário para análise existente."
+  "arquivo_docx": "Texto extraído do arquivo .docx",
+  "comentario_usuario": "Este é um comentário adicional do usuário.",
+  "usuario_executor": "user@example.com",
+  "session_id": "abcdef-uuid"
 }
-```
-**Resposta de Sucesso:**
-```json
+
+
+**Exemplo 2:**
+
 {
-  "job_id": "789012",
-  "message": "Análise solicitada com sucesso ao agente.",
-  "session_id": "ghijkl-uuid"
+  "projeto": "ProjetoNovo",
+  "analysis_type": "criacao_epicos_azure_devops",
+  "arquivo_docx": "Texto extraído do arquivo .docx",
+  "usuario_executor": "user@example.com",
+  "session_id": "abcdef-uuid"
 }
-```
+
+
+**Exemplo 3:**
+
+{
+  "projeto": "ProjetoNovo",
+  "analysis_type": "criacao_epicos_azure_devops",
+  "comentario_usuario": "Comentário sem arquivo.",
+  "usuario_executor": "user@example.com",
+  "session_id": "abcdef-uuid"
+}
+
 
 ---
 
-### 1.4 Upload de DOCX Adicional em Projeto Existente
+### 1.3 Upload de DOCX Adicional em Projeto Existente (Opcional)
 
 **Endpoint:**
 POST /upload/docx
@@ -104,159 +103,19 @@ POST /upload/docx
 **Form Data:**
 - file: arquivo .docx
 - projeto: "ProjetoExistente"
-- analysis_name: "Sprint 2"
+- analysis_type: "criacao_epicos_azure_devops"
 - session_id: "ghijkl-uuid"
 - is_new_project: false
 
 **Resposta:**
-```json
+
 {
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
   "message": "Arquivo processado com sucesso. Pronto para análise. (Upload opcional para projetos existentes)",
   "session_id": "ghijkl-uuid"
 }
-```
 
----
-
-### 1.5 Consulta de Relatórios de Sessão
-
-**Endpoint:**
-GET /session/{session_id}/reports
-
-**Headers:**
-- Authorization: Bearer <token_jwt_azure_ad>
-
-**Resposta:**
-```json
-{
-  "epicos_report": {...},
-  "features_report": {...},
-  "times_descricao_report": {...},
-  "alocacao_times_report": {...},
-  "premissas_riscos_report": {...}
-}
-```
-
----
-
-### 1.6 Atualização de Relatório Específico
-
-**Endpoint:**
-PUT /session/{session_id}/report
-
-**Headers:**
-- Authorization: Bearer <token_jwt_azure_ad>
-- Content-Type: application/json
-
-**Body:**
-```json
-{
-  "report_type": "epicos",
-  "report_data": { "campo": "valor" }
-}
-```
-**Resposta:**
-```json
-{
-  "status": "ok"
-}
-```
-
----
-
-### 1.7 Salvamento Manual de Estado da Sessão
-
-**Endpoint:**
-POST /session/{session_id}/save-state
-
-**Headers:**
-- Authorization: Bearer <token_jwt_azure_ad>
-
-**Resposta:**
-```json
-{
-  "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/estados/estado_20240601T130000Z.json"
-}
-```
-
----
-
-### 1.8 Verificação de Projeto com Resposta de Estado Completo
-
-**Endpoint:**
-GET /projects/check?projeto=ProjetoExistente
-
-**Headers:**
-- Authorization: Bearer <token_jwt_azure_ad>
-
-**Resposta para projeto existente:**
-```json
-{
-  "exists": true,
-  "state": {
-    "usuario_executor": "user@example.com",
-    "projeto": "ProjetoExistente",
-    "analysis_name": "Sprint 2",
-    "analysis_type": "criacao_epicos_azure_devops",
-    "created_at": "2024-06-01T12:34:56Z",
-    "last_saved_to_blob": "2024-06-01T13:00:00Z",
-    "epicos_report": null,
-    "features_report": null,
-    "times_descricao_report": null,
-    "alocacao_times_report": null,
-    "premissas_riscos_report": null,
-    "docx_files": ["https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx"],
-    "comentario_usuario": "Comentário salvo no estado."
-  }
-}
-```
-**Resposta para projeto inexistente:**
-```json
-{
-  "exists": false
-}
-```
-
----
-
-### 1.9 Listagem de Projetos após Login
-
-**Endpoint:**
-POST /auth/login
-
-**Headers:**
-- Authorization: Bearer <token_jwt_azure_ad>
-
-**Resposta:**
-```json
-{
-  "user_info": {
-    "sub": "user-teste-id-123",
-    "usuario_executor": "dev_tester_local",
-    "name": "Desenvolvedor Teste",
-    "email": "dev@peers.com.br",
-    "roles": ["admin"]
-  },
-  "projects": [
-    {
-      "projeto": "ProjetoExistente",
-      "analysis_name": "Sprint 2",
-      "analysis_type": "criacao_epicos_azure_devops",
-      "created_at": "2024-06-01T12:34:56Z",
-      "last_saved_to_blob": "2024-06-01T13:00:00Z"
-    },
-    {
-      "projeto": "ProjetoNovo",
-      "analysis_name": "Sprint 1",
-      "analysis_type": "criacao_epicos_azure_devops",
-      "created_at": "2024-06-02T09:00:00Z",
-      "last_saved_to_blob": "2024-06-02T09:30:00Z"
-    }
-  ]
-}
-```
 
 ---
 
@@ -273,18 +132,14 @@ POST /auth/login
    - GET /projects/check?projeto=ProjetoX
    - Header: Authorization: Bearer <token>
 
-4. **Upload de DOCX (se novo projeto)**
-   - POST /upload/docx
-   - FormData: file, projeto, analysis_name, analysis_type, comentario_usuario
-
-5. **Iniciar análise**
+4. **Iniciar análise**
    - POST /analysis/start
-   - Body: conforme exemplos acima
+   - Body: um dos três formatos acima
 
-6. **Consulta de status/relatórios**
+5. **Consulta de status/relatórios**
    - GET /session/{session_id}/reports
 
-7. **Salvamento de estado**
+6. **Salvamento de estado**
    - POST /session/{session_id}/save-state
 
 ---
@@ -299,11 +154,11 @@ POST /auth/login
 
 **Resposta:**
 HTTP 401
-```json
+
 {
   "detail": "Usuário não autenticado."
 }
-```
+
 
 ---
 
@@ -311,19 +166,19 @@ HTTP 401
 
 **Exemplo:**
 POST /analysis/start
-```json
+
 {
   "projeto": "ProjetoNovo"
-  // Faltando analysis_name, analysis_type e extracted_text
+  // Faltando analysis_type e arquivo_docx/comentario_usuario
 }
-```
+
 **Resposta:**
 HTTP 400
-```json
+
 {
-  "detail": "Os campos 'analysis_name' e 'analysis_type' são obrigatórios para novos projetos."
+  "detail": "Os campos 'analysis_type' e pelo menos um de 'arquivo_docx' ou 'comentario_usuario' são obrigatórios."
 }
-```
+
 
 ---
 
@@ -334,11 +189,11 @@ GET /projects/check?projeto=ProjetoInexistente
 
 **Resposta:**
 HTTP 200
-```json
+
 {
   "exists": false
 }
-```
+
 
 ---
 
@@ -346,21 +201,20 @@ HTTP 200
 
 **Exemplo:**
 POST /analysis/start
-```json
+
 {
   "projeto": "ProjetoNovo",
-  "analysis_name": "Sprint 1",
   "analysis_type": "criacao_epicos_azure_devops"
-  // Faltando extracted_text
+  // Faltando arquivo_docx e comentario_usuario
 }
-```
+
 **Resposta:**
 HTTP 400
-```json
+
 {
-  "detail": "O upload do DOCX é obrigatório para novos projetos."
+  "detail": "O upload do DOCX ou um comentário é obrigatório para novos projetos."
 }
-```
+
 
 ---
 
@@ -372,11 +226,11 @@ POST /analysis/start
 
 **Resposta:**
 HTTP 502
-```json
+
 {
   "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): ..."
 }
-```
+
 
 ---
 
@@ -388,11 +242,11 @@ POST /session/{session_id}/save-state
 
 **Resposta:**
 HTTP 500
-```json
+
 {
   "detail": "Erro ao salvar estado: ..."
 }
-```
+
 
 ---
 
@@ -404,11 +258,11 @@ GET /session/{session_id}/reports
 
 **Resposta:**
 HTTP 404
-```json
+
 {
   "detail": "Sessão não encontrada: ..."
 }
-```
+
 
 ---
 
@@ -419,17 +273,18 @@ HTTP 404
 
 **Resposta:**
 HTTP 403
-```json
+
 {
   "detail": "Acesso negado. IP <ip> não autorizado."
 }
-```
+
 
 ---
 
 ## Observações Gerais
+- O campo `analysis_name` foi removido de todos os fluxos.
 - O campo opcional `comentario_usuario` pode ser enviado tanto no upload do DOCX quanto na solicitação de análise.
-- O campo `extracted_text` é obrigatório apenas para novos projetos.
-- Para projetos existentes, basta informar o nome do projeto ou, opcionalmente, analysis_name e analysis_type.
+- O campo `arquivo_docx` é obrigatório apenas se não houver `comentario_usuario`.
+- Para projetos existentes, basta informar o nome do projeto e o tipo de análise, com pelo menos um dos campos opcionais.
 - O header Authorization é obrigatório para todos os endpoints protegidos.
 - Todos os exemplos de resposta seguem o padrão JSON.


### PR DESCRIPTION
Este PR atualiza o arquivo API_PAYLOAD_EXAMPLES.md para remover todas as referências ao campo 'analysis_name' e detalhar os três formatos únicos de payload aceitos e enviados, conforme os exemplos fornecidos. Também inclui uma seção de observação sobre os fluxos de comunicação e a padronização do payload.