### PR TITLE
Refatoração do endpoint POST /auth/login para aceitar apenas token no header Authorization e retornar informações do usuário autenticado e seus projetos.

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 import os
 from backend.app.core.config import settings
@@ -40,7 +40,6 @@ async def auth_login(current_user: dict = Depends(get_current_user)):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não autenticado.")
     try:
         projects = await ProjectStateService.list_user_projects(usuario_executor)
-        # Remove analysis_name de cada projeto se existir
         for p in projects:
             if isinstance(p, dict):
                 p.pop("analysis_name", None)


### PR DESCRIPTION
O endpoint POST /auth/login foi modificado para não aceitar mais corpo na requisição, apenas o token no header Authorization. O backend valida o token, obtém as claims do usuário, busca os projetos associados e retorna um objeto contendo user_info e a lista de projetos. Essa mudança melhora a comunicação entre front e back, alinhando o fluxo onde o front envia somente o token na primeira requisição após autenticação.