### PR TITLE
Remoção do modelo LoginRequest e manutenção do TokenData para uso interno.

### DIFF
--- a/backend/app/models/auth_models.py
+++ b/backend/app/models/auth_models.py
@@ -8,7 +8,3 @@ class TokenData(BaseModel):
     iss: Optional[str] = Field(None, description="Issuer do token.")
     aud: Optional[str] = Field(None, description="Audience do token.")
     additional_claims: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Outros claims presentes no JWT.")
-
-class LoginRequest(BaseModel):
-    username: str = Field(..., description="Nome de usuário para login.")
-    password: str = Field(..., description="Senha do usuário.")


### PR DESCRIPTION
O modelo LoginRequest foi removido pois o endpoint de login não recebe mais corpo de requisição. Mantida a classe TokenData que representa os dados do token JWT para uso interno no backend.