### PR TITLE
Endpoint de upload modificado para extrair texto do arquivo DOCX, salvar o texto extraído na sessão Redis e retornar o texto extraído na resposta.

### DIFF
--- a/backend/app/api/upload.py
+++ b/backend/app/api/upload.py
@@ -50,7 +50,8 @@ async def upload_docx(
         usuario_executor,
         projeto,
         analysis_type,
-        comentario_usuario=comentario_usuario
+        comentario_usuario=comentario_usuario,
+        extracted_text=texto_extraido
     )
     try:
         redis_service.add_docx_file(session_id, blob_url)


### PR DESCRIPTION
No endpoint /upload/docx, o arquivo DOCX enviado é processado para extrair seu texto via docx_parser_service. O arquivo é salvo no Blob Storage e o texto extraído é salvo na sessão Redis (usando create_session e update_session_extracted_text). A resposta inclui a URL do blob, o texto extraído, mensagem de sucesso e o ID da sessão. Isso permite que o cliente envie para o MCP o texto extraído diretamente, sem precisar da URL do arquivo, conforme passos 4, 5 e 6.