### PR TITLE
Alteração no endpoint POST /analysis/start para usar texto extraído do DOCX armazenado na sessão Redis no payload enviado ao MCP.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -37,7 +37,6 @@ async def start_analysis(
     redis_service = RedisSessionService()
     session_id = None
     texto_extraido = None
-    # Criação ou restauração de sessão
     project_state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, projeto)
     if project_state:
         session_id = redis_service.restore_session_from_state(


### PR DESCRIPTION
O endpoint agora busca o texto extraído do DOCX da sessão Redis (campo extracted_text) e envia este conteúdo no campo arquivo_docx do payload para o MCP. Caso o texto seja enviado diretamente no payload, usa este valor. Não envia mais a URL do arquivo DOCX.