### PR TITLE
Adição do campo project_id ao modelo ProjectListItem para identificação única do projeto.

### DIFF
--- a/backend/app/models/project_models.py
+++ b/backend/app/models/project_models.py
@@ -7,3 +7,4 @@ class ProjectListItem(BaseModel):
     analysis_type: Optional[str] = Field(None)
     created_at: Optional[datetime] = Field(None)
     last_saved_to_blob: Optional[datetime] = Field(None)
+    project_id: Optional[str] = Field(default=None)


### PR DESCRIPTION
Incluído o campo project_id no modelo ProjectListItem para garantir que cada projeto listado tenha um identificador único, facilitando a comunicação com o frontend.