### PR TITLE
Ajustes no endpoint de análise para aceitar project_id e atualizar estado automaticamente.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -9,6 +9,8 @@ from ..services.redis_session_service import RedisSessionService
 from ..services.project_state_service import ProjectStateService
 from ..services.background_state_saver import BackgroundStateSaver
 
+import uuid
+
 router = APIRouter()
 logger = logging.getLogger("analysis_api")
 
@@ -16,12 +18,14 @@ class StartAnalysisRequest(BaseModel):
     projeto: str
     analysis_type: str
     comentario_usuario: Optional[str] = None
-    arquivo_docx: Optional[str] = None  # Agora é texto extraído
+    arquivo_docx: Optional[str] = None
+    project_id: Optional[str] = None
 
 class StartAnalysisResponse(BaseModel):
     job_id: str
     message: str
     session_id: str
+    project_id: Optional[str] = None
 
 @router.post("/start", response_model=StartAnalysisResponse, tags=["Analysis"])
 async def start_analysis(
@@ -29,7 +33,8 @@ async def start_analysis(
     projeto: str = Body(...),
     analysis_type: str = Body(...),
     comentario_usuario: Optional[str] = Body(None),
-    arquivo_docx: Optional[str] = Body(None),  # Texto extraído
+    arquivo_docx: Optional[str] = Body(None),
+    project_id: Optional[str] = Body(None),
     current_user: dict = Depends(get_current_user)
 ):
     usuario_executor = current_user.get("usuario_executor") or current_user.get("sub")
@@ -45,15 +50,18 @@ async def start_analysis(
             analysis_type,
             project_state
         )
+        project_id_final = project_state.get("project_id")
     else:
+        project_id_final = project_id or str(uuid.uuid4())
         session_id = redis_service.create_session(
             usuario_executor,
             projeto,
             analysis_type,
-            comentario_usuario=comentario_usuario
+            comentario_usuario=comentario_usuario,
+            extracted_text=arquivo_docx,
+            project_id=project_id_final
         )
     BackgroundStateSaver.schedule_periodic_save(session_id)
-    # Busca o texto extraído da sessão Redis, a menos que seja enviado diretamente
     if arquivo_docx is not None:
         texto_extraido = arquivo_docx
     else:
@@ -75,11 +83,13 @@ async def start_analysis(
     try:
         mcp_response = await mcp_client.start_analysis(mcp_payload)
         job_id = mcp_response.job_id
+        redis_service.update_session_on_state_change(session_id, {"last_mcp_job_id": job_id})
     except Exception as e:
         logger.error(f"Erro na comunicação com MCP: {e}")
         raise HTTPException(status_code=502, detail=f"Erro ao comunicar com o servidor de Inteligência (MCP): {str(e)}")
     return StartAnalysisResponse(
         job_id=job_id,
         message="Análise solicitada com sucesso ao agente.",
-        session_id=session_id
+        session_id=session_id,
+        project_id=project_id_final
     )


### PR DESCRIPTION
O endpoint /analysis/start foi modificado para aceitar o campo project_id na requisição e retorná-lo na resposta. Além disso, o estado do projeto/sessão é criado ou restaurado conforme a existência do projeto, e o salvamento automático do estado é agendado para ocorrer periodicamente após interações com o MCP, garantindo atualização constante do estado do projeto.