### PR TITLE
Refatora endpoints de projetos para usar extração centralizada de usuario_executor e busca sanitizada de projetos.

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,7 +1,7 @@
 import logging
 from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List
-from backend.app.middleware.auth_middleware import get_current_user
+from backend.app.middleware.auth_middleware import get_current_user, _extract_usuario_executor
 from backend.app.services.project_state_service import ProjectStateService
 from backend.app.models.project_models import ProjectListItem
 
@@ -13,7 +13,7 @@ async def check_project(
     projeto: str = Query(..., description="Nome do projeto a ser verificado"),
     current_user: dict = Depends(get_current_user)
 ):
-    usuario_executor = current_user.get("usuario_executor") or current_user.get("sub")
+    usuario_executor = _extract_usuario_executor(current_user)
     logger.info(f"Verificando existência do projeto '{projeto}' para usuario_executor='{usuario_executor}'")
     try:
         state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, projeto)
@@ -31,18 +31,6 @@ async def check_project(
 
 @router.get("/list", response_model=List[ProjectListItem], tags=["Projects"])
 async def list_projects(current_user: dict = Depends(get_current_user)):
-    usuario_executor = current_user.get("usuario_executor") or current_user.get("sub")
-    try:
-        projects = await ProjectStateService.list_user_projects(usuario_executor)
-        for p in projects:
-            if isinstance(p, dict):
-                p.pop("analysis_name", None)
-        for p in projects:
-            if isinstance(p, dict):
-                if "project_id" not in p:
-                    p["project_id"] = p.get("project_id")
-        projects = [p for p in projects if "project_id" in p]
-        return projects
-    except Exception as e:
-        logger.error(f"Erro ao listar projetos do usuário {usuario_executor}: {e}")
-        raise HTTPException(status_code=500, detail="Erro ao buscar lista de projetos.")
+    usuario_executor = _extract_usuario_executor(current_user)
+    projects = await ProjectStateService._fetch_and_sanitize_projects(usuario_executor)
+    return projects


### PR DESCRIPTION
Nos endpoints /check e /list, utiliza _extract_usuario_executor para obter usuario_executor e ProjectStateService._fetch_and_sanitize_projects para obter lista de projetos filtrada, garantindo consistência e redução de código duplicado.