### PR TITLE
Remoção do modelo UploadDocxRequest e ajustes relacionados no endpoint de upload.

### DIFF
--- a/backend/app/api/upload.py
+++ b/backend/app/api/upload.py
@@ -6,15 +6,10 @@ from typing import Optional
 from ..middleware.auth_middleware import get_current_user, _extract_usuario_executor
 from ..services.blob_storage_service import upload_and_extract_docx
 from ..services.redis_session_service import RedisSessionService
+from ..models.docx_models import UploadDocxResponse
 
 router = APIRouter()
 logger = logging.getLogger("upload_api")
-
-class UploadDocxResponse(BaseModel):
-    blob_url: str
-    extracted_text: str
-    message: str
-    session_id: Optional[str] = None
 
 @router.post("/docx", response_model=UploadDocxResponse, tags=["Upload"])
 async def upload_docx(

--- a/backend/app/models/docx_models.py
+++ b/backend/app/models/docx_models.py
@@ -2,11 +2,6 @@ from typing import Optional
 from pydantic import BaseModel, Field
 from fastapi import UploadFile
 
-class UploadDocxRequest(BaseModel):
-    projeto: str = Field(..., description="Nome do projeto ao qual o arquivo pertence.")
-    analysis_name: str = Field(..., description="Nome da tarefa/analise para identificação.")
-    # O campo 'file' será tratado diretamente no endpoint FastAPI como UploadFile, não como campo Pydantic.
-
 class UploadDocxResponse(BaseModel):
     message: str = Field(..., description="Mensagem de status do upload.")
     blob_url: str = Field(..., description="URL do arquivo salvo no blob storage.")


### PR DESCRIPTION
Foi removido o modelo UploadDocxRequest do código, mantendo apenas UploadDocxResponse para simplificar o upload de arquivos DOCX. O endpoint de upload foi ajustado para refletir essa mudança, removendo imports e usos desnecessários.