### PR TITLE
Remoção de campos não utilizados do modelo AzureADTokenData para simplificação e foco nos dados essenciais.

### DIFF
--- a/backend/app/models/azure_ad_models.py
+++ b/backend/app/models/azure_ad_models.py
@@ -7,7 +7,3 @@ class AzureADTokenData(BaseModel):
     email: Optional[str] = Field(None, description="Email do usuário.")
     roles: Optional[List[str]] = Field(default_factory=list, description="Lista de roles do usuário.")
     name: Optional[str] = Field(None, description="Nome completo do usuário.")
-    exp: Optional[int] = Field(None, description="Timestamp de expiração do token.")
-    iss: Optional[str] = Field(None, description="Issuer do token.")
-    aud: Optional[str] = Field(None, description="Audience do token.")
-    sub: Optional[str] = Field(None, description="Subject do token.")


### PR DESCRIPTION
Campos exp, iss, aud e sub foram removidos do modelo AzureADTokenData, mantendo apenas os campos que são realmente utilizados na aplicação, reduzindo complexidade e potencial confusão.