### PR TITLE
Implementação da classe MCPConfigService para carregar configuração dinâmica dos agentes MCP a partir de arquivo JSON.

### DIFF
--- a/backend/app/services/mcp_config_service.py
+++ b/backend/app/services/mcp_config_service.py
@@ -1,0 +1,17 @@
+import os
+import json
+from typing import Optional
+from backend.app.models.mcp_config_models import MCPConfigRegistry
+
+class MCPConfigService:
+    @staticmethod
+    def load_config(config_path: Optional[str] = None) -> MCPConfigRegistry:
+        if config_path is None:
+            base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+            config_path = os.path.join(base_dir, 'config', 'mcp_agents.json')
+        if os.path.exists(config_path):
+            with open(config_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            return MCPConfigRegistry.parse_obj(data)
+        # Fallback: retorna config vazia
+        return MCPConfigRegistry(agents={})


### PR DESCRIPTION
Criada a classe MCPConfigService com método estático load_config() que lê a configuração dos agentes MCP do arquivo backend/config/mcp_agents.json, retornando um MCPConfigRegistry. Essa configuração será usada para suportar múltiplos MCPs de forma dinâmica.