### PR TITLE
Atualização do modelo SessionData para manter campo dinâmico 'reports' e garantir migração dos campos legados para compatibilidade.

### DIFF
--- a/backend/app/models/session_models.py
+++ b/backend/app/models/session_models.py
@@ -16,16 +16,12 @@ class SessionData(BaseModel):
     analysis_type: str = Field(...)
     created_at: datetime = Field(...)
     steps: List[SessionStep] = Field(default_factory=list)
-    epicos_report: Optional[Any] = Field(default=None)
-    features_report: Optional[Any] = Field(default=None)
-    times_descricao_report: Optional[Any] = Field(default=None)
-    alocacao_times_report: Optional[Any] = Field(default=None)
-    premissas_riscos_report: Optional[Any] = Field(default=None)
     last_saved_to_blob: Optional[datetime] = Field(default=None)
     docx_files: List[str] = Field(default_factory=list)
     comentario_usuario: Optional[str] = Field(default=None)
     extracted_text: Optional[str] = Field(default=None)
     project_id: Optional[str] = Field(default=None)
+    reports: Dict[str, Any] = Field(default_factory=dict)
 
     def to_project_state(self) -> Dict[str, Any]:
         return {
@@ -34,19 +30,24 @@ class SessionData(BaseModel):
             "analysis_type": self.analysis_type,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "last_saved_to_blob": self.last_saved_to_blob.isoformat() if self.last_saved_to_blob else None,
-            "epicos_report": self.epicos_report,
-            "features_report": self.features_report,
-            "times_descricao_report": self.times_descricao_report,
-            "alocacao_times_report": self.alocacao_times_report,
-            "premissas_riscos_report": self.premissas_riscos_report,
             "docx_files": self.docx_files,
             "comentario_usuario": self.comentario_usuario,
             "extracted_text": self.extracted_text,
-            "project_id": self.project_id
+            "project_id": self.project_id,
+            "reports": self.reports
         }
 
     @classmethod
     def from_project_state(cls, state: Dict[str, Any]) -> "SessionData":
+        reports = state.get("reports", {})
+        # Migração: se vier de estado antigo, converte campos antigos para o novo formato
+        migrated_reports = dict(reports) if reports else {}
+        legacy_fields = [
+            "epicos_report", "features_report", "times_descricao_report", "alocacao_times_report", "premissas_riscos_report"
+        ]
+        for field in legacy_fields:
+            if field in state and state[field] is not None:
+                migrated_reports[field] = state[field]
         return cls(
             session_id=state.get("session_id", ""),
             usuario_executor=state.get("usuario_executor", ""),
@@ -54,14 +55,10 @@ class SessionData(BaseModel):
             analysis_type=state.get("analysis_type", ""),
             created_at=datetime.fromisoformat(state["created_at"]) if state.get("created_at") else datetime.utcnow(),
             steps=[],
-            epicos_report=state.get("epicos_report"),
-            features_report=state.get("features_report"),
-            times_descricao_report=state.get("times_descricao_report"),
-            alocacao_times_report=state.get("alocacao_times_report"),
-            premissas_riscos_report=state.get("premissas_riscos_report"),
             last_saved_to_blob=datetime.fromisoformat(state["last_saved_to_blob"]) if state.get("last_saved_to_blob") else None,
             docx_files=state.get("docx_files", []),
             comentario_usuario=state.get("comentario_usuario"),
             extracted_text=state.get("extracted_text"),
-            project_id=state.get("project_id")
+            project_id=state.get("project_id"),
+            reports=migrated_reports
         )


### PR DESCRIPTION
O modelo SessionData foi mantido com o campo 'reports' como dicionário dinâmico para armazenar múltiplos tipos de relatórios. O método from_project_state foi ajustado para migrar os campos legados para o novo formato, garantindo compatibilidade com estados antigos. Removidos os campos hardcoded de relatório do modelo para evitar redundância e facilitar a generalização.