### PR TITLE
Refatoração da modelagem SessionData para suportar múltiplos MCP endpoints e manter compatibilidade retroativa dos relatórios antigos migrando-os para o campo dinâmico 'reports'.

### DIFF
--- a/backend/app/models/session_models.py
+++ b/backend/app/models/session_models.py
@@ -40,7 +40,6 @@ class SessionData(BaseModel):
     @classmethod
     def from_project_state(cls, state: Dict[str, Any]) -> "SessionData":
         reports = state.get("reports", {})
-        # Migração: se vier de estado antigo, converte campos antigos para o novo formato
         migrated_reports = dict(reports) if reports else {}
         legacy_fields = [
             "epicos_report", "features_report", "times_descricao_report", "alocacao_times_report", "premissas_riscos_report"


### PR DESCRIPTION
A classe SessionData foi atualizada para manter o campo 'reports' como dicionário dinâmico que armazena todos os relatórios. O método from_project_state migra os campos legados para o dicionário 'reports' respeitando a correspondência entre os campos antigos e os MCPs de criação e refinamento. O método to_project_state serializa somente o campo 'reports'.