### PR TITLE
Atualizada documentação interna do método start_analysis para referenciar o novo formato de webhook.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -39,6 +39,17 @@ class MCPClientService:
         return self.base_url
 
     async def start_analysis(self, payload: MCPStartAnalysisPayload) -> MCPStartAnalysisResponse:
+        # O MCP deve responder à chamada POST /start e, após processar, enviar webhooks para o endpoint /webhooks/mcp do backend.
+        # O formato do webhook deve seguir a documentação em backend/docs/MCP_WEBHOOK_RESPONSE_FORMAT.md.
+        # O webhook deve conter os campos: job_id (str), status ("in_progress", "done", "error"),
+        # report_type (str), report_data (dict), progress (opcional), error_type (opcional), error_message (opcional).
+        # Exemplo de payload de webhook:
+        # {
+        #   "job_id": "123456",
+        #   "status": "done",
+        #   "report_type": "epicos",
+        #   "report_data": {"epicos": [{"id": 1, "titulo": "Como usuário..."}]}
+        # }
         raw_base = self.get_mcp_endpoint(payload.analysis_type)
         logging.info(f"🕵️ [DEBUG URL] Bruta vinda da env: '[{raw_base}]'")
         base = raw_base.strip().rstrip("/")


### PR DESCRIPTION
A documentação interna do método start_analysis foi atualizada para explicitar que o MCP deve enviar webhooks para o endpoint /webhooks/mcp do backend, seguindo o formato definido em backend/docs/MCP_WEBHOOK_RESPONSE_FORMAT.md, incluindo campos obrigatórios e opcionais.