### PR TITLE
Implementação do utilitário de validação da estrutura de report_data e integração no endpoint /webhooks/mcp.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -2,6 +2,7 @@ import logging
 from fastapi import APIRouter, HTTPException, status, Request, Depends
 from backend.app.models.mcp_webhook_models import MCPWebhookPayload
 from backend.app.services.redis_session_service import RedisSessionService
+from backend.app.utils.webhook_validator import validate_report_data_structure
 
 router = APIRouter()
 logger = logging.getLogger("webhooks_api")
@@ -19,6 +20,9 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
             if not payload.report_type:
                 logger.error(f"Webhook sem report_type para job_id {payload.job_id}")
                 raise HTTPException(status_code=400, detail="report_type é obrigatório quando status é 'in_progress' ou 'done'")
+            if not validate_report_data_structure(payload.report_type, payload.report_data, analysis_type):
+                logger.error(f"Estrutura de report_data inválida para report_type '{payload.report_type}', analysis_type '{analysis_type}' e job_id '{payload.job_id}'")
+                raise HTTPException(status_code=400, detail=f"Estrutura de report_data inválida para report_type '{payload.report_type}' e analysis_type '{analysis_type}'")
             redis_service.update_report(
                 session.session_id,
                 payload.report_type,

--- a/backend/app/utils/webhook_validator.py
+++ b/backend/app/utils/webhook_validator.py
@@ -1,0 +1,28 @@
+import logging
+from backend.app.core.config import settings
+
+def validate_report_data_structure(report_type: str, report_data: dict, analysis_type: str) -> bool:
+    logger = logging.getLogger("webhook_validator")
+    if not isinstance(report_data, dict):
+        logger.error(f"report_data não é um dicionário: {type(report_data)}")
+        return False
+    mcp_config_registry = getattr(settings, "mcp_config_registry", None)
+    if not mcp_config_registry or not hasattr(mcp_config_registry, "agents"):
+        logger.warning("mcp_config_registry não está configurado corretamente. Validação ignorada.")
+        return True
+    agents = mcp_config_registry.agents
+    if analysis_type not in agents:
+        logger.warning(f"analysis_type '{analysis_type}' não encontrado em mcp_config_registry. Validação ignorada.")
+        return True
+    agent_cfg = agents[analysis_type]
+    if not hasattr(agent_cfg, "report_mapping"):
+        logger.warning(f"Agent config para '{analysis_type}' não possui report_mapping. Validação ignorada.")
+        return True
+    expected_field = agent_cfg.report_mapping.get(report_type)
+    if not expected_field:
+        logger.warning(f"report_type '{report_type}' não mapeado para analysis_type '{analysis_type}'. Validação ignorada.")
+        return True
+    if expected_field not in report_data:
+        logger.error(f"Campo '{expected_field}' ausente em report_data para report_type '{report_type}' e analysis_type '{analysis_type}'.")
+        return False
+    return True


### PR DESCRIPTION
Criado o utilitário validate_report_data_structure que verifica se o report_data recebido no webhook do MCP possui o campo esperado conforme o analysis_type e report_type, conforme configuração dinâmica em mcp_config_registry. Integrado este utilitário no endpoint /webhooks/mcp para validar antes de atualizar o relatório, retornando erro 400 em caso de estrutura inválida.