### PR TITLE
Adição do campo last_mcp_job_id no modelo SessionData para rastrear o último job MCP associado à sessão.

### DIFF
--- a/backend/app/models/session_models.py
+++ b/backend/app/models/session_models.py
@@ -22,6 +22,7 @@ class SessionData(BaseModel):
     extracted_text: Optional[str] = Field(default=None)
     project_id: Optional[str] = Field(default=None)
     reports: Dict[str, Any] = Field(default_factory=dict)
+    last_mcp_job_id: Optional[str] = Field(default=None)
 
     def to_project_state(self) -> Dict[str, Any]:
         return {
@@ -34,7 +35,8 @@ class SessionData(BaseModel):
             "comentario_usuario": self.comentario_usuario,
             "extracted_text": self.extracted_text,
             "project_id": self.project_id,
-            "reports": self.reports
+            "reports": self.reports,
+            "last_mcp_job_id": self.last_mcp_job_id
         }
 
     @classmethod
@@ -59,5 +61,6 @@ class SessionData(BaseModel):
             comentario_usuario=state.get("comentario_usuario"),
             extracted_text=state.get("extracted_text"),
             project_id=state.get("project_id"),
-            reports=migrated_reports
+            reports=migrated_reports,
+            last_mcp_job_id=state.get("last_mcp_job_id")
         )


### PR DESCRIPTION
Incluído o campo last_mcp_job_id como Optional[str] no modelo SessionData. Atualizados os métodos to_project_state e from_project_state para serializar e desserializar esse campo, garantindo persistência e compatibilidade com estados legados.