### PR TITLE
Persistência da relação job_id -> session_id no Redis ao iniciar análise

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -90,6 +90,7 @@ async def start_analysis(
         mcp_response = await mcp_client.start_analysis(mcp_payload)
         job_id = mcp_response.job_id
         redis_service.update_session_on_state_change(session_id, {"last_mcp_job_id": job_id})
+        redis_service.update_session_job_id(session_id, job_id)
     except Exception as e:
         logger.error(f"Erro na comunicação com MCP: {e}")
         raise HTTPException(status_code=502, detail=f"Erro ao comunicar com o servidor de Inteligência (MCP): {str(e)}")


### PR DESCRIPTION
Após receber o job_id do MCP, o backend persiste a relação job_id -> session_id no Redis chamando update_session_job_id para evitar perda da associação e garantir rastreabilidade do job.