### PR TITLE
Atualização do serviço de estado do projeto para garantir a persistência do campo last_mcp_job_id no Blob Storage.

### DIFF
--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -17,8 +17,10 @@ class ProjectStateService:
         blob_path = f"{blob_folder}/{blob_filename}"
         _, container_client = _get_blob_clients()
         blob_client = container_client.get_blob_client(blob_path)
-        state_bytes = json.dumps(state, ensure_ascii=False, separators=(',', ':')).encode("utf-8")
-        blob_client.upload_blob(state_bytes, overwrite=True, content_settings=None)
+        # Garante que last_mcp_job_id está presente no estado salvo
+        if hasattr(session_data, "last_mcp_job_id"):
+            state["last_mcp_job_id"] = getattr(session_data, "last_mcp_job_id")
+        blob_client.upload_blob(json.dumps(state, ensure_ascii=False, separators=(',', ':')).encode("utf-8"), overwrite=True, content_settings=None)
         return blob_client.url
 
     @staticmethod
@@ -43,6 +45,9 @@ class ProjectStateService:
         blob_client = container_client.get_blob_client(latest_blob.name)
         state_bytes = blob_client.download_blob().readall()
         state = json.loads(state_bytes.decode("utf-8"))
+        # Garante que last_mcp_job_id é carregado se existir
+        if "last_mcp_job_id" in state:
+            state["last_mcp_job_id"] = state["last_mcp_job_id"]
         logger.info(f"Estado carregado com sucesso para usuario_executor={usuario_executor}, projeto={projeto}")
         return state
 


### PR DESCRIPTION
Modificações no backend/app/services/project_state_service.py para incluir o campo last_mcp_job_id ao salvar e carregar o estado do projeto no Blob Storage, conforme passo 7 do plano de ação.