### PR TITLE
Atualização da documentação de arquitetura para explicitar o fluxo de persistência do job_id no Redis e a busca da sessão no webhook.

### DIFF
--- a/backend/docs/ARCHITECTURE_FLOW.md
+++ b/backend/docs/ARCHITECTURE_FLOW.md
@@ -6,7 +6,7 @@ Este documento detalha o fluxo completo do backend Peers CodeAI, desde o recebim
 
 ## Diagrama Geral do Fluxo (Mermaid)
 
-```mermaid
+mermaid
 flowchart TD
     subgraph Frontend
         Z[Usuário/Frontend]
@@ -47,7 +47,7 @@ flowchart TD
     AD -->|Salva Estado| AE
     AG -->|Salvamento Periódico| AE
     AC -->|Carrega Segredos| AA
-```
+
 
 ---
 
@@ -95,17 +95,21 @@ flowchart TD
   - `backend/app/core/config.py` (`Settings`)
 
 ### 7. Configuração Dinâmica de Agentes MCP
-- **Descrição:** O arquivo `backend/config/mcp_agents.json` define agentes MCP, URLs e mapeamentos de relatórios. O backend roteia requisições para o MCP correto baseado no `analysis_type`.
-- **Código:**
-  - `backend/app/services/mcp_config_service.py` (`MCPConfigService.load_config`)
-  - `backend/app/services/mcp_client_service.py` (`MCPClientService.get_mcp_endpoint`)
-  - `backend/app/services/redis_session_service.py` (`update_report`)
+- **Arquivo:** `backend/config/mcp_agents.json` define agentes MCP, URLs, campos de relatório e mapeamentos.
+- **Carregamento:** `MCPConfigService.load_config` carrega o JSON na inicialização.
+- **Roteamento:** `MCPClientService.get_mcp_endpoint` seleciona a URL do MCP conforme `analysis_type`.
+- **Mapeamento de Relatórios:** `RedisSessionService.update_report` usa `report_mapping` para salvar relatórios no campo correto.
+- **Extensibilidade:** Novos agentes podem ser adicionados apenas editando o JSON.
 
 ### 8. Comunicação Backend ↔ MCP (Incluindo Webhooks)
 - **Descrição:** O backend envia payloads para o MCP (sempre com texto extraído, nunca URL). MCP responde com `job_id` e envia webhooks de progresso/conclusão, que atualizam relatórios na sessão Redis.
+- **Persistência do job_id:** Após receber o `job_id` do MCP no endpoint `/analysis/start`, o backend persiste imediatamente a relação `job_id -> session_id` no Redis, garantindo que, quando o webhook do MCP chegar, a sessão possa ser encontrada rapidamente usando o `job_id`.
+- **Busca do job_id no webhook:** O endpoint `/webhooks/mcp` recebe o webhook do MCP, busca a sessão correspondente usando o `job_id` persistido no Redis, e atualiza os relatórios da sessão. Se o `job_id` não for encontrado, retorna 404 e loga o erro detalhadamente.
 - **Código:**
   - `backend/app/services/mcp_client_service.py` (`start_analysis`)
-  - Webhook handler (não mostrado, mas esperado)
+  - `backend/app/services/redis_session_service.py` (`update_session_job_id`, `get_session_by_job_id`)
+  - `backend/app/api/analysis.py` (chama `update_session_job_id` após início da análise)
+  - `backend/app/api/webhooks.py` (busca sessão por `job_id` no webhook)
 
 ### 9. Atualização de Relatórios e Propagação de Estado
 - **Descrição:** Relatórios são atualizados via endpoint ou webhook. Toda atualização aciona o salvamento automático do estado no Blob Storage.
@@ -124,7 +128,7 @@ flowchart TD
 ## Fluxos Críticos de Negócio
 
 ### 1. Fluxo de Novo Projeto
-```mermaid
+mermaid
 sequenceDiagram
     participant FE as Frontend
     participant BE as Backend
@@ -144,13 +148,13 @@ sequenceDiagram
     FE->>BE: POST /analysis/start (projeto, analysis_type, session_id)
     BE->>MCP: Envia payload (texto extraído)
     MCP-->>BE: job_id
-    BE->>RS: Atualiza sessão (job_id)
+    BE->>RS: Atualiza sessão (job_id) e persiste relação job_id -> session_id no Redis
     BE->>BS: Salva estado inicial
     BE-->>FE: job_id, session_id, project_id
-```
+
 
 ### 2. Fluxo de Projeto Existente
-```mermaid
+mermaid
 sequenceDiagram
     FE->>BE: GET /projects/check
     BE->>BS: Busca estado
@@ -159,21 +163,22 @@ sequenceDiagram
     BE->>RS: Restaura sessão do estado
     BE->>MCP: Envia payload (texto extraído do estado)
     MCP-->>BE: job_id
-    BE->>RS: Atualiza sessão (job_id)
+    BE->>RS: Atualiza sessão (job_id) e persiste relação job_id -> session_id no Redis
     BE->>BS: Salva estado
     BE-->>FE: job_id, session_id, project_id
-```
+
 
 ### 3. Fluxo de Atualização de Relatório
-```mermaid
+mermaid
 sequenceDiagram
     MCP->>BE: Webhook (job_id, status, report_type, report_data)
+    BE->>RS: Busca sessão por job_id (usando relação persistida job_id -> session_id)
     BE->>RS: Atualiza relatório na sessão
     BE->>BS: Salva estado
-```
+
 
 ### 4. Fluxo de Erro e Recuperação
-```mermaid
+mermaid
 sequenceDiagram
     BE->>MCP: start_analysis
     MCP-->>BE: status: error, error_message
@@ -184,7 +189,7 @@ sequenceDiagram
     BE->>RS: get_session
     RS-->>BE: erro
     BE-->>FE: 503 Service Unavailable, detail
-```
+
 
 ---
 
@@ -196,7 +201,7 @@ sequenceDiagram
 - **Fallback:** Se um segredo não for encontrado no Key Vault, o backend tenta variável de ambiente.
 - **Validação:** Campos obrigatórios são validados por `settings.validate_required_fields`.
 
-```mermaid
+mermaid
 flowchart LR
     Start((Startup)) --> LoadSecrets[ConfigLoaderService.load_secrets_from_key_vault]
     LoadSecrets -->|Por tipo| AzureSecretManager
@@ -205,7 +210,7 @@ flowchart LR
     KeyVaults -->|Retorna segredo| AzureSecretManager
     AzureSecretManager -->|Fallback| EnvVars[Variáveis de Ambiente]
     AzureSecretManager -->|Seta no settings| Settings
-```
+
 
 ---
 
@@ -218,7 +223,7 @@ flowchart LR
 - **Extensibilidade:** Novos agentes podem ser adicionados apenas editando o JSON.
 
 **Exemplo de configuração de agente:**
-```json
+
 {
   "agents": {
     "criacao_epicos_azure_devops": {
@@ -235,7 +240,7 @@ flowchart LR
     }
   }
 }
-```
+
 
 ---
 
@@ -250,3 +255,4 @@ flowchart LR
 - Para ambientes com Redis em subrede privada, o App Service deve estar integrado à mesma VNET.
 - O sistema pode operar em modo de teste com autenticação mockada (`SKIP_AUTH_FOR_TESTING`), útil para desenvolvimento local.
 - Todos os exemplos de payload e resposta estão detalhados em `backend/docs/API_PAYLOAD_EXAMPLES.md`.
+- Após o início da análise, a relação job_id -> session_id é persistida no Redis para garantir que o webhook do MCP encontre a sessão correta.


### PR DESCRIPTION
Modificações no arquivo backend/docs/ARCHITECTURE_FLOW.md para refletir o fluxo correto de persistência da relação job_id -> session_id no Redis após o início da análise, e a busca da sessão pelo job_id no webhook MCP, conforme passo 10 do plano de ação.