### PR TITLE
Validação reforçada na persistência do estado no Blob Storage para garantir consistência total com o Redis, evitando salvar estado com dados antigos.

### DIFF
--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -17,9 +17,21 @@ class ProjectStateService:
         blob_path = f"{blob_folder}/{blob_filename}"
         _, container_client = _get_blob_clients()
         blob_client = container_client.get_blob_client(blob_path)
-        # Garante que last_mcp_job_id está presente no estado salvo
         if hasattr(session_data, "last_mcp_job_id"):
             state["last_mcp_job_id"] = getattr(session_data, "last_mcp_job_id")
+        try:
+            from backend.app.services.redis_session_service import RedisSessionService
+            redis_service = RedisSessionService()
+            session_id = getattr(session_data, "session_id", None)
+            if session_id:
+                session_redis = redis_service.get_session(session_id)
+                reports_redis = getattr(session_redis, "reports", None)
+                if reports_redis != state.get("reports"):
+                    logging.error(f"Validação de consistência falhou: reports do estado não correspondem ao Redis para session_id={session_id}. Reports Redis: {reports_redis} | Reports estado: {state.get('reports')}")
+                    raise Exception("O campo 'reports' do estado não corresponde ao valor atual no Redis. Abortando persistência.")
+        except Exception as e:
+            logging.error(f"Erro na validação de consistência antes de salvar estado no Blob: {e}")
+            raise
         blob_client.upload_blob(json.dumps(state, ensure_ascii=False, separators=(',', ':')).encode("utf-8"), overwrite=True, content_settings=None)
         return blob_client.url
 
@@ -45,7 +57,6 @@ class ProjectStateService:
         blob_client = container_client.get_blob_client(latest_blob.name)
         state_bytes = blob_client.download_blob().readall()
         state = json.loads(state_bytes.decode("utf-8"))
-        # Garante que last_mcp_job_id é carregado se existir
         if "last_mcp_job_id" in state:
             state["last_mcp_job_id"] = state["last_mcp_job_id"]
         logger.info(f"Estado carregado com sucesso para usuario_executor={usuario_executor}, projeto={projeto}")


### PR DESCRIPTION
Na função save_state_to_blob foi adicionada uma validação que compara o campo 'reports' do estado a ser salvo com o valor atual no Redis. Caso haja discrepância, a persistência é abortada e um erro é logado. Isso reforça a garantia de que o estado salvo no Blob Storage reflete exatamente o último relatório recebido do MCP, evitando manter dados antigos.