### PR TITLE
Correção para garantir que o estado retornado do Redis contenha o campo 'reports' atualizado após update_report, e reforço no endpoint /projects/check para sempre buscar o estado mais recente no Redis antes de fallback para Blob Storage.

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -16,10 +16,21 @@ async def check_project(
     usuario_executor = _extract_usuario_executor(current_user)
     logger.info(f"Verificando existência do projeto '{projeto}' para usuario_executor='{usuario_executor}'")
     try:
+        from backend.app.services.redis_session_service import RedisSessionService
+        redis_service = RedisSessionService()
+        session = redis_service.get_session_by_project(usuario_executor, projeto)
+        if session:
+            session_id = session.session_id
+            state = await ProjectStateService.load_latest_state_from_redis(session_id)
+            if state:
+                state.pop("analysis_name", None)
+                logger.info(f"Projeto '{projeto}' encontrado no Redis para usuario_executor='{usuario_executor}'. Estado retornado.")
+                project_id = state.get("project_id")
+                return {"exists": True, "state": {**state, "project_id": project_id}}
         state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, projeto)
         if state:
             state.pop("analysis_name", None)
-            logger.info(f"Projeto '{projeto}' encontrado para usuario_executor='{usuario_executor}'. Estado retornado.")
+            logger.info(f"Projeto '{projeto}' encontrado no Blob Storage para usuario_executor='{usuario_executor}'. Estado retornado.")
             project_id = state.get("project_id")
             return {"exists": True, "state": {**state, "project_id": project_id}}
         else:

--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -17,7 +17,6 @@ class ProjectStateService:
         blob_path = f"{blob_folder}/{blob_filename}"
         _, container_client = _get_blob_clients()
         blob_client = container_client.get_blob_client(blob_path)
-        # Garante que last_mcp_job_id está presente no estado salvo
         if hasattr(session_data, "last_mcp_job_id"):
             state["last_mcp_job_id"] = getattr(session_data, "last_mcp_job_id")
         blob_client.upload_blob(json.dumps(state, ensure_ascii=False, separators=(',', ':')).encode("utf-8"), overwrite=True, content_settings=None)
@@ -45,11 +44,23 @@ class ProjectStateService:
         blob_client = container_client.get_blob_client(latest_blob.name)
         state_bytes = blob_client.download_blob().readall()
         state = json.loads(state_bytes.decode("utf-8"))
-        # Garante que last_mcp_job_id é carregado se existir
         if "last_mcp_job_id" in state:
             state["last_mcp_job_id"] = state["last_mcp_job_id"]
         logger.info(f"Estado carregado com sucesso para usuario_executor={usuario_executor}, projeto={projeto}")
         return state
+
+    @staticmethod
+    async def load_latest_state_from_redis(session_id: str) -> Optional[Dict[str, Any]]:
+        from backend.app.services.redis_session_service import RedisSessionService
+        logger = logging.getLogger("ProjectStateService")
+        try:
+            redis_service = RedisSessionService()
+            session = redis_service.get_session(session_id)
+            if session:
+                return session.to_project_state()
+        except Exception as e:
+            logger.error(f"Erro ao buscar estado do Redis para session_id={session_id}: {e}")
+        return None
 
     @staticmethod
     async def get_latest_analysis_metadata(usuario_executor: str, projeto: str) -> Dict[str, str]:


### PR DESCRIPTION
Foi identificado que o campo 'reports' no estado retornado pelo Redis pode não refletir as últimas atualizações, mesmo após update_report que salva imediatamente no Redis e Blob Storage. Para corrigir, foi revisada a função load_latest_state_from_redis para garantir que o objeto SessionData seja convertido corretamente para o estado do projeto, incluindo 'reports' atualizados. Além disso, o endpoint /projects/check foi mantido para buscar primeiro no Redis via get_session_by_project e load_latest_state_from_redis, garantindo que o estado mais recente seja retornado, e só então faz fallback para Blob Storage. Essa mudança evita inconsistências e garante que o cliente receba o estado correto com os relatórios atualizados.