### PR TITLE
Inclusão exclusiva do session_id nos payloads e respostas MCP, removendo qualquer referência a job_id.

### DIFF
--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -7,7 +7,7 @@ class MCPStartAnalysisPayload(BaseModel):
     arquivo_docx: Optional[str] = Field(None, description="Texto extraído do arquivo docx com a transcrição da reunião. NÃO é a URL do Blob Storage.")
     comentario_usuario: Optional[str] = Field(None, description="Comentário adicional enviado pelo usuário.")
     usuario_executor: str = Field(..., description="Usuário executor extraído do token JWT.")
-    session_id: str = Field(..., description="Identificador da sessão.")
+    session_id: str = Field(..., description="Identificador único da sessão. Deve ser enviado ao MCP e usado em todas as comunicações.")
 
     @validator('analysis_type')
     def analysis_type_must_not_be_empty(cls, v):
@@ -16,4 +16,5 @@ class MCPStartAnalysisPayload(BaseModel):
         return v
 
 class MCPStartAnalysisResponse(BaseModel):
-    job_id: str = Field(..., description="Identificador do job criado no MCP.")
+    status: str = Field(..., description="Status da solicitação de análise. Pode ser 'accepted', 'started', etc.")
+    session_id: str = Field(..., description="Identificador único da sessão, igual ao enviado no payload.")


### PR DESCRIPTION
Os modelos MCPStartAnalysisPayload e MCPStartAnalysisResponse foram modificados para incluir apenas o campo session_id como identificador único da sessão. O MCP receberá e retornará o session_id, alinhado à política de unificação de IDs. Isso evita geração ou uso de IDs distintos pelo MCP.