### PR TITLE
Substituição completa do job_id por session_id no modelo de webhook MCP.

### DIFF
--- a/backend/app/models/mcp_webhook_models.py
+++ b/backend/app/models/mcp_webhook_models.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, Field, validator
 from typing import Optional, Any, Literal
 
 class MCPWebhookPayload(BaseModel):
-    job_id: str = Field(...)
+    session_id: str = Field(..., description="Identificador único da sessão. Deve ser o mesmo enviado pelo backend ao MCP.")
     status: Literal['in_progress', 'done', 'error'] = Field(...)
     progress: Optional[int] = Field(None)
     report_type: Optional[str] = Field(None)


### PR DESCRIPTION
O modelo MCPWebhookPayload foi ajustado para usar exclusivamente session_id como identificador único da sessão. Todos os validadores e campos foram atualizados para refletir essa mudança, garantindo que o backend e MCP estejam alinhados no uso do session_id para rastreamento e comunicação.