### PR TITLE
Remoção de referências a job_id e last_mcp_job_id. Uso exclusivo de session_id como identificador único. Ajustes para criar, atualizar e recuperar sessões usando session_id. Métodos de atualização e recuperação de sessão adaptados para refletir a unificação do ID.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -45,8 +45,7 @@ class RedisSessionService:
             "comentario_usuario": comentario_usuario,
             "extracted_text": extracted_text,
             "project_id": project_id,
-            "reports": {},
-            "last_mcp_job_id": None
+            "reports": {}
         }
         self.redis_client.setex(f"session:{session_id}", self.session_ttl, self._serialize_session(session_data))
         return session_id
@@ -126,7 +125,6 @@ class RedisSessionService:
         comentario_usuario = project_state.get("comentario_usuario")
         extracted_text = project_state.get("extracted_text")
         project_id = project_state.get("project_id")
-        last_mcp_job_id = project_state.get("last_mcp_job_id") if "last_mcp_job_id" in project_state else None
         session_id = self.create_session(usuario_executor, projeto, analysis_type, comentario_usuario=comentario_usuario, extracted_text=extracted_text, project_id=project_id)
         key = f"session:{session_id}"
         session_json = self.redis_client.get(key)
@@ -140,7 +138,6 @@ class RedisSessionService:
         session_data["comentario_usuario"] = comentario_usuario
         session_data["extracted_text"] = extracted_text
         session_data["project_id"] = project_id
-        session_data["last_mcp_job_id"] = last_mcp_job_id
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
         return session_id
 
@@ -176,46 +173,6 @@ class RedisSessionService:
         session_data["last_modified"] = datetime.utcnow().isoformat()
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
         BackgroundStateSaver.schedule_periodic_save(session_id)
-
-    def update_session_job_id(self, session_id: str, job_id: str):
-        key = f"session:{session_id}"
-        session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Sessão {session_id} não encontrada no Redis.")
-        session_data = self._deserialize_session(session_json)
-        session_data["last_mcp_job_id"] = job_id
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
-        try:
-            self.redis_client.setex(f"jobid:{job_id}", self.session_ttl, session_id)
-            self.logger.info(f"Persistida relação job_id -> session_id: {job_id} -> {session_id}")
-        except Exception as e:
-            self.logger.error(f"Erro ao persistir job_id -> session_id no Redis: {e}")
-
-    def get_session_by_job_id(self, job_id: str) -> Optional[SessionData]:
-        self.logger.info(f"Buscando sessão por job_id: {job_id}")
-        session_id = None
-        try:
-            session_id = self.redis_client.get(f"jobid:{job_id}")
-            if session_id:
-                self.logger.info(f"Encontrado session_id '{session_id}' para job_id '{job_id}' via chave direta.")
-                return self.get_session(session_id)
-        except Exception as e:
-            self.logger.error(f"Erro ao buscar session_id por job_id no Redis: {e}")
-        self.logger.warning(f"Chave direta jobid:{job_id} não encontrada. Buscando por varredura em todas as sessões.")
-        try:
-            for key in self.redis_client.scan_iter(match="session:*"):
-                session_json = self.redis_client.get(key)
-                if not session_json:
-                    continue
-                session_data = self._deserialize_session(session_json)
-                if session_data.get("last_mcp_job_id") == job_id:
-                    session_id_found = session_data.get("session_id")
-                    self.logger.info(f"Encontrado session_id '{session_id_found}' para job_id '{job_id}' por varredura.")
-                    return SessionData(**session_data)
-        except Exception as e:
-            self.logger.error(f"Erro ao varrer sessões para job_id '{job_id}': {e}")
-        self.logger.error(f"Sessão não encontrada para job_id: {job_id}")
-        return None
 
     def get_session_by_project(self, usuario_executor: str, projeto: str) -> Optional[SessionData]:
         self.logger.info(f"Buscando sessão por usuario_executor='{usuario_executor}', projeto='{projeto}'")


### PR DESCRIPTION
O serviço RedisSessionService foi modificado para eliminar qualquer uso de job_id e last_mcp_job_id, utilizando apenas session_id para identificar sessões. A criação de sessão gera um novo session_id apenas no login. Métodos como add_step, get_session, update_session_status, update_report, restore_session_from_state, add_docx_file, update_session_extracted_text e update_session_on_state_change foram ajustados para operar exclusivamente com session_id. O método get_session_by_project foi mantido para buscar sessões ativas por usuário e projeto, retornando a sessão identificada por session_id.