### PR TITLE
Geração única de session_id no login e criação de sessão inicial no Redis.

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 import os
+import uuid
 from backend.app.core.config import settings
 from backend.app.middleware.auth_middleware import get_current_user, _extract_usuario_executor
 from backend.app.services.project_state_service import ProjectStateService
+from backend.app.services.redis_session_service import RedisSessionService
 
 router = APIRouter()
 
@@ -17,6 +19,7 @@ class AuthConfigResponse(BaseModel):
 class AuthLoginResponse(BaseModel):
     user_info: dict
     projects: list
+    session_id: str
 
 @router.get("/config", response_model=AuthConfigResponse, tags=["Auth"])
 def get_auth_config():
@@ -39,4 +42,17 @@ async def auth_login(current_user: dict = Depends(get_current_user)):
     if not usuario_executor:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não autenticado.")
     projects = await ProjectStateService._fetch_and_sanitize_projects(usuario_executor)
-    return AuthLoginResponse(user_info=current_user, projects=projects)
+    # Gera um novo session_id a cada login
+    session_id = str(uuid.uuid4())
+    redis_service = RedisSessionService()
+    # Cria uma sessão inicial vazia para o usuário
+    redis_service.create_session(
+        usuario_executor=usuario_executor,
+        projeto="__login__",
+        analysis_type="__login__",
+        comentario_usuario=None,
+        extracted_text=None,
+        project_id=None,
+        session_id=session_id
+    )
+    return AuthLoginResponse(user_info=current_user, projects=projects, session_id=session_id)


### PR DESCRIPTION
No endpoint de login, um novo session_id é gerado a cada autenticação bem-sucedida. Uma sessão inicial vazia é criada no Redis para garantir unicidade e rastreabilidade do session_id. O session_id é retornado ao frontend para uso em todos os fluxos subsequentes.