### PR TITLE
Geração do session_id único no endpoint de login e retorno para o front-end junto com user_info e lista de projetos.

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -42,10 +42,8 @@ async def auth_login(current_user: dict = Depends(get_current_user)):
     if not usuario_executor:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não autenticado.")
     projects = await ProjectStateService._fetch_and_sanitize_projects(usuario_executor)
-    # Gera um novo session_id a cada login
     session_id = str(uuid.uuid4())
     redis_service = RedisSessionService()
-    # Cria uma sessão inicial vazia para o usuário
     redis_service.create_session(
         usuario_executor=usuario_executor,
         projeto="__login__",


### PR DESCRIPTION
No endpoint /auth/login, o session_id é gerado uma única vez por sessão de usuário autenticado. Este session_id é armazenado no Redis e retornado para o front-end para ser usado em todas as interações subsequentes. Nenhum outro ID é gerado em outros pontos do sistema.