### PR TITLE
Serviço RedisSessionService modificado para usar exclusivamente session_id como identificador único. Métodos de criação, recuperação, atualização e restauração da sessão foram adaptados para garantir que o session_id seja obrigatório e único. Atualizações de estado criam novos registros no Redis, evitando sobrescritas diretas. Passos da sessão e relatórios são gerenciados dentro do objeto de sessão identificado por session_id.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -28,8 +28,9 @@ class RedisSessionService:
     def _deserialize_session(self, session_json: str) -> dict:
         return json.loads(session_json)
 
-    def create_session(self, usuario_executor: str, projeto: str, analysis_type: str, comentario_usuario: Optional[str] = None, extracted_text: Optional[str] = None, project_id: Optional[str] = None) -> str:
-        session_id = str(uuid.uuid4())
+    def create_session(self, usuario_executor: str, projeto: str, analysis_type: str, comentario_usuario: Optional[str] = None, extracted_text: Optional[str] = None, project_id: Optional[str] = None, session_id: Optional[str] = None) -> str:
+        if not session_id:
+            raise ValueError("session_id é obrigatório para criar uma sessão.")
         created_at = datetime.utcnow().isoformat()
         if not project_id:
             project_id = str(uuid.uuid4())
@@ -121,11 +122,11 @@ class RedisSessionService:
         except Exception as e:
             self.logger.error(f"Erro ao salvar estado imediatamente após update_report: {e}")
 
-    def restore_session_from_state(self, usuario_executor: str, projeto: str, analysis_type: str, project_state: Dict[str, Any]) -> str:
+    def restore_session_from_state(self, usuario_executor: str, projeto: str, analysis_type: str, project_state: Dict[str, Any], session_id: str) -> str:
         comentario_usuario = project_state.get("comentario_usuario")
         extracted_text = project_state.get("extracted_text")
         project_id = project_state.get("project_id")
-        session_id = self.create_session(usuario_executor, projeto, analysis_type, comentario_usuario=comentario_usuario, extracted_text=extracted_text, project_id=project_id)
+        self.create_session(usuario_executor, projeto, analysis_type, comentario_usuario=comentario_usuario, extracted_text=extracted_text, project_id=project_id, session_id=session_id)
         key = f"session:{session_id}"
         session_json = self.redis_client.get(key)
         if not session_json:


### PR DESCRIPTION
O método create_session agora exige session_id obrigatório, que deve ser gerado externamente (ex: no backend ao listar projetos). O método restore_session_from_state usa session_id para criar nova sessão com estado restaurado. Métodos de atualização (update_report, update_session_status, add_docx_file, update_session_extracted_text, update_session_on_state_change) sempre atualizam o estado criando nova versão no Redis sob a mesma chave session_id. A busca de sessão por projeto retorna a sessão ativa mais recente pelo session_id. Removidas todas as referências a job_id. Logs e exceções foram mantidos para garantir rastreabilidade e robustez.