### PR TITLE
Atualização do MCPClientService para garantir que o session_id seja sempre enviado ao MCP e validado na resposta. O payload MCPStartAnalysisPayload exige session_id obrigatório. Removida toda lógica relacionada a job_id.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -60,7 +60,8 @@ class MCPClientService:
                     logging.error(f"❌ [MCP Client] Erro {response.status_code}: {response.text}")
                 response.raise_for_status()
                 data = response.json()
-                # Espera-se que o MCP retorne status e session_id
+                if data.get('session_id') != payload.session_id:
+                    raise Exception(f"O MCP retornou um session_id diferente do enviado. Esperado: {payload.session_id}, Recebido: {data.get('session_id')}")
                 return MCPStartAnalysisResponse(**data)
         except httpx.HTTPStatusError as exc:
             raise Exception(f"Erro ao comunicar com MCP Server: {exc.response.status_code} - {exc.response.text}")


### PR DESCRIPTION
O método start_analysis envia o session_id recebido no payload para o MCP e valida que o MCP retorne o mesmo session_id. O endpoint MCP é obtido conforme configuração, sem gerar ou modificar IDs. O payload do MCP inclui session_id obrigatório, alinhado com a unificação do identificador único da sessão.