### PR TITLE
Garantir atualização do relatório no webhook MCP independente da sessão atual ou estado prévio, mantendo recuperação e restauração da sessão do Blob Storage.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException, status, Request, Depends
 from backend.app.models.mcp_webhook_models import MCPWebhookPayload
 from backend.app.services.redis_session_service import RedisSessionService
 from backend.app.utils.webhook_validator import validate_report_data_structure
+from backend.app.services.project_state_service import ProjectStateService
 
 router = APIRouter()
 logger = logging.getLogger("webhooks_api")
@@ -11,12 +12,49 @@ logger = logging.getLogger("webhooks_api")
 async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
     redis_service = RedisSessionService()
     logger.info(f"Recebido webhook MCP para session_id: {payload.session_id}, status: {payload.status}")
+    session = None
     try:
         logger.info(f"Buscando sessão associada ao session_id: {payload.session_id}")
-        session = redis_service.get_session(payload.session_id)
-        if not session:
-            logger.error(f"Webhook recebido para session_id não encontrado: {payload.session_id}. Estado do Redis pode estar inconsistente.")
-            raise HTTPException(status_code=404, detail=f"Sessão não encontrada para session_id: {payload.session_id}")
+        try:
+            session = redis_service.get_session(payload.session_id)
+        except Exception as e:
+            logger.error(f"Sessão não encontrada no Redis para session_id={payload.session_id}: {e}")
+            usuario_executor = getattr(payload, "usuario_executor", None)
+            projeto = getattr(payload, "projeto", None)
+            state = None
+            if usuario_executor and projeto:
+                logger.info(f"Tentando buscar estado no Blob Storage via usuario_executor={usuario_executor}, projeto={projeto}")
+                try:
+                    state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, projeto, session_id=payload.session_id)
+                except Exception as ex_blob:
+                    logger.error(f"Erro ao buscar estado no Blob Storage via usuario_executor/projeto: {ex_blob}")
+            if not state:
+                logger.info(f"Tentando buscar estado no Blob Storage via session_id={payload.session_id}")
+                try:
+                    state = await ProjectStateService.load_latest_state_by_session_id(payload.session_id)
+                except Exception as ex_blob2:
+                    logger.error(f"Erro ao buscar estado no Blob Storage via session_id: {ex_blob2}")
+            if state:
+                usuario_executor_restore = state.get("usuario_executor")
+                projeto_restore = state.get("projeto")
+                analysis_type_restore = state.get("analysis_type")
+                logger.info(f"Restaurando sessão no Redis para session_id={payload.session_id}, usuario_executor={usuario_executor_restore}, projeto={projeto_restore}, analysis_type={analysis_type_restore}")
+                redis_service.restore_session_from_state(
+                    usuario_executor_restore,
+                    projeto_restore,
+                    analysis_type_restore,
+                    state,
+                    session_id=payload.session_id
+                )
+                try:
+                    session = redis_service.get_session(payload.session_id)
+                    logger.info(f"Sessão restaurada no Redis para session_id={payload.session_id}")
+                except Exception as e2:
+                    logger.error(f"Falha ao recuperar sessão restaurada do Redis: {e2}")
+                    session = None
+            else:
+                logger.error(f"Webhook recebido para session_id não encontrado: {payload.session_id}. Estado do Redis e Blob Storage podem estar inconsistentes.")
+                raise HTTPException(status_code=404, detail=f"Sessão não encontrada para session_id: {payload.session_id}")
         analysis_type = getattr(session, "analysis_type", None)
         if payload.status in {"in_progress", "done"}:
             if not payload.report_type:
@@ -34,7 +72,6 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
             )
             try:
                 session_atualizada = redis_service.get_session(session.session_id)
-                from backend.app.services.project_state_service import ProjectStateService
                 await ProjectStateService.save_state_to_blob(session_atualizada)
                 logger.info(f"Estado salvo imediatamente após atualização de relatório para sessão {session.session_id} (session_id={payload.session_id})")
             except Exception as e:


### PR DESCRIPTION
Modificado o endpoint /webhooks/mcp para que, ao receber um webhook com status 'in_progress' ou 'done', o relatório seja atualizado sempre, mesmo que o projeto tenha sido criado em outra sessão ou esteja sendo criado na sessão atual. A lógica de recuperação da sessão do Blob Storage permanece, mas a atualização do relatório não depende mais da sessão atual estar ativa ou previamente carregada. Isso corrige o problema de não atualização do estado após análise solicitada em projeto existente.