### PR TITLE
Adição dos campos opcionais usuario_executor e projeto no modelo MCPWebhookPayload para facilitar a recuperação da sessão.

### DIFF
--- a/backend/app/models/mcp_webhook_models.py
+++ b/backend/app/models/mcp_webhook_models.py
@@ -9,6 +9,8 @@ class MCPWebhookPayload(BaseModel):
     report_data: Optional[Any] = Field(None)
     error_type: Optional[str] = Field(None)
     error_message: Optional[str] = Field(None)
+    usuario_executor: Optional[str] = Field(None, description="Usuário executor da sessão. Opcional, mas recomendado para facilitar a recuperação de sessão caso não esteja no Redis.")
+    projeto: Optional[str] = Field(None, description="Nome do projeto relacionado à sessão. Opcional, mas recomendado para facilitar a recuperação de sessão caso não esteja no Redis.")
 
     @validator('status')
     def status_must_be_valid(cls, v):


### PR DESCRIPTION
O modelo MCPWebhookPayload foi modificado para incluir os campos opcionais usuario_executor e projeto, que são recomendados para facilitar a recuperação da sessão caso não esteja no Redis. Validações foram mantidas para garantir integridade dos dados.