### PR TITLE
Atualização da função _ensure_session_exists para usar load_latest_state_by_session_id como fallback secundário e ajuste no update_report para garantir atualização do relatório sempre que o MCP enviar resposta.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -88,11 +88,10 @@ class RedisSessionService:
         session_data["status"] = status
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
 
-    async def update_report(self, session_id: str, report_type: str, report_data: Any, analysis_type: Optional[str] = None):
+    async def update_report(self, session_id: str, report_type: str, report_data: Any, analysis_type: Optional[str] = None, usuario_executor: Optional[str] = None, projeto: Optional[str] = None):
         self.logger.info(f"[update_report] Iniciando atualização de relatório para session_id={session_id}, report_type={report_type}")
-        # Passo 1, 2, 3: garantir sessão no Redis (restaura do Blob se necessário)
         try:
-            session_obj = await self._ensure_session_exists(session_id=session_id)
+            session_obj = await self._ensure_session_exists(session_id=session_id, usuario_executor=usuario_executor, projeto=projeto)
             self.logger.info(f"[update_report] Sessão garantida no Redis para session_id={session_id}")
         except Exception as e:
             self.logger.error(f"[update_report] Falha ao garantir sessão no Redis para session_id={session_id}: {e}")


### PR DESCRIPTION
A função _ensure_session_exists foi aprimorada para tentar restaurar a sessão a partir do Blob Storage usando primeiro usuario_executor e projeto, e em seguida usando apenas session_id via load_latest_state_by_session_id, garantindo maior robustez na recuperação da sessão. A função update_report foi modificada para aceitar usuario_executor e projeto como parâmetros opcionais, permitindo que a sessão seja restaurada e o relatório atualizado independentemente da sessão atual, atendendo ao requisito de atualizar o estado sempre que o MCP enviar uma resposta, mesmo que o projeto tenha sido criado em outra sessão.