### PR TITLE
Ajuste na função restore_session_from_state para garantir e logar a consistência do session_id e reforço da reutilização do session_id do estado mais recente do projeto para evitar criação de sessões duplicadas.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -176,6 +176,10 @@ class RedisSessionService:
         comentario_usuario = project_state.get("comentario_usuario")
         extracted_text = project_state.get("extracted_text")
         project_id = project_state.get("project_id")
+        state_session_id = project_state.get("session_id")
+        if state_session_id and session_id != state_session_id:
+            self.logger.warning(f"[restore_session_from_state] Aviso: session_id fornecido ({session_id}) é diferente do session_id no estado ({state_session_id}). Usando o session_id do estado: {state_session_id}")
+            session_id = state_session_id
         self.create_session(usuario_executor, projeto, analysis_type, comentario_usuario=comentario_usuario, extracted_text=extracted_text, project_id=project_id, session_id=session_id)
         key = f"session:{session_id}"
         session_json = self.redis_client.get(key)


### PR DESCRIPTION
Foi implementada validação na função restore_session_from_state para garantir que o session_id passado seja igual ao do estado carregado. Se forem diferentes, um aviso é logado e o session_id do estado é utilizado. Isso assegura a consistência do identificador de sessão. Além disso, o fluxo de recuperação automática da sessão no Redis foi reforçado para priorizar a reutilização do session_id existente, evitando criação de novas sessões para projetos já existentes, corrigindo o problema de atualização de estado após resposta do MCP.