### PR TITLE
Refatoração do RedisSessionService para suportar múltiplos relatórios individuais no estado da sessão, garantindo que toda alteração seja salva imediatamente no Redis e no Blob Storage, e que consultas retornem o estado mais atual do Redis.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -47,7 +47,11 @@ class RedisSessionService:
             "comentario_usuario": comentario_usuario,
             "extracted_text": extracted_text,
             "project_id": project_id,
-            "reports": {}
+            "epicos_report": None,
+            "features_report": None,
+            "times_descricao_report": None,
+            "alocacao_times_report": None,
+            "premissas_riscos_report": None
         }
         self.redis_client.setex(f"session:{session_id}", self.session_ttl, self._serialize_session(session_data))
         return session_id
@@ -102,49 +106,33 @@ class RedisSessionService:
         if not session_json:
             raise ValueError(f"Sessão {session_id} não encontrada no Redis após tentativa de restauração.")
         session_data = self._deserialize_session(session_json)
-        analysis_type_in_session = session_data.get("analysis_type")
-        analysis_type = analysis_type or analysis_type_in_session
-        report_field = None
-        if hasattr(settings, "mcp_config_registry") and settings.mcp_config_registry and hasattr(settings.mcp_config_registry, "agents") and analysis_type in settings.mcp_config_registry.agents:
-            agent_cfg = settings.mcp_config_registry.agents[analysis_type]
-            if hasattr(agent_cfg, "report_mapping") and report_type in agent_cfg.report_mapping:
-                report_field = agent_cfg.report_mapping[report_type]
-        if not report_field:
-            report_field = f"{report_type}_report"
-        if "reports" not in session_data or not isinstance(session_data["reports"], dict):
-            session_data["reports"] = {}
-        reports_before = dict(session_data["reports"])
-        self.logger.info(f"[update_report] Antes da atualização: session_id={session_id}, reports={json.dumps(reports_before, ensure_ascii=False)}")
-        session_data["reports"][report_field] = report_data
-        self.logger.info(f"[update_report] Chave modificada: '{report_field}' para session_id={session_id}")
-        reports_after = dict(session_data["reports"])
-        self.logger.info(f"[update_report] Após atualização: session_id={session_id}, reports={json.dumps(reports_after, ensure_ascii=False)}")
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
-        # Validação explícita: garantir que todas as chaves anteriores foram preservadas
-        session_json_valid = self.redis_client.get(key)
-        if not session_json_valid:
-            self.logger.critical(f"[update_report] Sessão {session_id} não encontrada no Redis após atualização.")
-            raise HTTPException(status_code=500, detail=f"Sessão {session_id} não encontrada no Redis após atualização.")
-        session_data_valid = self._deserialize_session(session_json_valid)
-        reports_dict = session_data_valid.get("reports", {})
-        if not isinstance(reports_dict, dict):
-            self.logger.critical(f"[update_report] Após update_report, reports não é um dicionário para session_id={session_id}")
-            raise HTTPException(status_code=500, detail="Campo 'reports' corrompido após atualização.")
-        missing_keys = [k for k in reports_before.keys() if k not in reports_dict]
-        if missing_keys:
-            self.logger.critical(f"[update_report] Após update_report, as chaves {missing_keys} não foram preservadas em reports para session_id={session_id}. Chaves atuais: {list(reports_dict.keys())}")
-            raise HTTPException(status_code=500, detail=f"Chaves {missing_keys} não encontradas em reports após atualização.")
-        if report_field not in reports_dict:
-            self.logger.critical(f"[update_report] Após update_report, chave '{report_field}' não encontrada em reports para session_id={session_id}. Chaves atuais: {list(reports_dict.keys())}")
-            raise HTTPException(status_code=500, detail=f"Chave '{report_field}' não encontrada em reports após atualização.")
-        self.logger.info(f"[update_report] Validação pós-update_report: reports contém as chaves: {list(reports_dict.keys())}")
-        try:
-            session_obj = SessionData(**session_data)
-            self.logger.info(f"[update_report] Salvando estado no Blob Storage imediatamente após atualização do relatório. session_id={session_id}, reports={json.dumps(session_data['reports'], ensure_ascii=False)}")
-            await ProjectStateService.save_state_to_blob(session_obj)
-            self.logger.info(f"[update_report] Estado salvo no Blob Storage para session_id={session_id}")
-        except Exception as e:
-            self.logger.error(f"Erro ao salvar estado imediatamente após update_report: {e}")
+        updated = False
+        if report_type == "epicos":
+            session_data["epicos_report"] = report_data
+            updated = True
+        elif report_type == "features":
+            session_data["features_report"] = report_data
+            updated = True
+        elif report_type == "times_descricao":
+            session_data["times_descricao_report"] = report_data
+            updated = True
+        elif report_type == "alocacao_times":
+            session_data["alocacao_times_report"] = report_data
+            updated = True
+        elif report_type == "premissas_riscos":
+            session_data["premissas_riscos_report"] = report_data
+            updated = True
+        else:
+            self.logger.error(f"[update_report] report_type '{report_type}' não reconhecido para session_id={session_id}")
+            raise HTTPException(status_code=400, detail=f"Tipo de relatório '{report_type}' não reconhecido.")
+        if updated:
+            self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
+            try:
+                session_obj = SessionData(**session_data)
+                await ProjectStateService.save_state_to_blob(session_obj)
+                self.logger.info(f"[update_report] Estado salvo no Blob Storage para session_id={session_id}")
+            except Exception as e:
+                self.logger.error(f"Erro ao salvar estado imediatamente após update_report: {e}")
 
     async def _ensure_session_exists(self, session_id: str, usuario_executor: Optional[str] = None, projeto: Optional[str] = None) -> SessionData:
         self.logger.info(f"[_ensure_session_exists] Verificando existência da sessão no Redis para session_id={session_id}")
@@ -197,20 +185,25 @@ class RedisSessionService:
         if state_session_id and session_id != state_session_id:
             self.logger.warning(f"[restore_session_from_state] Aviso: session_id fornecido ({session_id}) é diferente do session_id no estado ({state_session_id}). Usando o session_id do estado: {state_session_id}")
             session_id = state_session_id
-        self.create_session(usuario_executor, projeto, analysis_type, comentario_usuario=comentario_usuario, extracted_text=extracted_text, project_id=project_id, session_id=session_id)
-        key = f"session:{session_id}"
-        session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Sessão {session_id} não encontrada no Redis.")
-        session_data = self._deserialize_session(session_json)
-        reports = project_state.get("reports", {})
-        session_data["reports"] = reports
-        session_data["last_saved_to_blob"] = project_state.get("last_saved_to_blob")
-        session_data["docx_files"] = project_state.get("docx_files", [])
-        session_data["comentario_usuario"] = comentario_usuario
-        session_data["extracted_text"] = extracted_text
-        session_data["project_id"] = project_id
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
+        session_data = {
+            "session_id": session_id,
+            "usuario_executor": usuario_executor,
+            "projeto": projeto,
+            "analysis_type": analysis_type,
+            "created_at": project_state.get("created_at"),
+            "steps": [],
+            "last_saved_to_blob": project_state.get("last_saved_to_blob"),
+            "docx_files": project_state.get("docx_files", []),
+            "comentario_usuario": comentario_usuario,
+            "extracted_text": extracted_text,
+            "project_id": project_id,
+            "epicos_report": project_state.get("epicos_report"),
+            "features_report": project_state.get("features_report"),
+            "times_descricao_report": project_state.get("times_descricao_report"),
+            "alocacao_times_report": project_state.get("alocacao_times_report"),
+            "premissas_riscos_report": project_state.get("premissas_riscos_report")
+        }
+        self.redis_client.setex(f"session:{session_id}", self.session_ttl, self._serialize_session(session_data))
         return session_id
 
     def add_docx_file(self, session_id: str, blob_url: str):


### PR DESCRIPTION
Este PR modifica o serviço RedisSessionService para substituir a variável única 'report' por múltiplas chaves específicas para cada relatório (epicos_report, features_report, times_descricao_report, alocacao_times_report, premissas_riscos_report). Além disso, toda atualização de relatório é salva imediatamente tanto no Redis quanto no Blob Storage. A restauração da sessão a partir do estado também foi adaptada para considerar os novos campos individuais. A busca pelo estado mais atual do projeto prioriza o Redis, garantindo maior consistência e performance.