### PR TITLE
Atualização da validação dos relatórios para uso de campos individuais específicos de cada tipo de relatório.

### DIFF
--- a/backend/app/utils/webhook_validator.py
+++ b/backend/app/utils/webhook_validator.py
@@ -6,23 +6,27 @@ def validate_report_data_structure(report_type: str, report_data: dict, analysis
     if not isinstance(report_data, dict):
         logger.error(f"report_data não é um dicionário: {type(report_data)}")
         return False
-    mcp_config_registry = getattr(settings, "mcp_config_registry", None)
-    if not mcp_config_registry or not hasattr(mcp_config_registry, "agents"):
-        logger.warning("mcp_config_registry não está configurado corretamente. Validação ignorada.")
-        return True
-    agents = mcp_config_registry.agents
-    if analysis_type not in agents:
-        logger.warning(f"analysis_type '{analysis_type}' não encontrado em mcp_config_registry. Validação ignorada.")
-        return True
-    agent_cfg = agents[analysis_type]
-    if not hasattr(agent_cfg, "report_mapping"):
-        logger.warning(f"Agent config para '{analysis_type}' não possui report_mapping. Validação ignorada.")
-        return True
-    expected_field = agent_cfg.report_mapping.get(report_type)
-    if not expected_field:
-        logger.warning(f"report_type '{report_type}' não mapeado para analysis_type '{analysis_type}'. Validação ignorada.")
-        return True
-    if expected_field not in report_data:
-        logger.error(f"Campo '{expected_field}' ausente em report_data para report_type '{report_type}' e analysis_type '{analysis_type}'.")
+    if report_type == "epicos":
+        if "epicos" not in report_data:
+            logger.error(f"Campo 'epicos' ausente em report_data para report_type 'epicos'.")
+            return False
+    elif report_type == "features":
+        if "features" not in report_data:
+            logger.error(f"Campo 'features' ausente em report_data para report_type 'features'.")
+            return False
+    elif report_type == "times_descricao":
+        if "times_descricao" not in report_data:
+            logger.error(f"Campo 'times_descricao' ausente em report_data para report_type 'times_descricao'.")
+            return False
+    elif report_type == "alocacao_times":
+        if "alocacao_times" not in report_data:
+            logger.error(f"Campo 'alocacao_times' ausente em report_data para report_type 'alocacao_times'.")
+            return False
+    elif report_type == "premissas_riscos":
+        if "premissas_riscos" not in report_data:
+            logger.error(f"Campo 'premissas_riscos' ausente em report_data para report_type 'premissas_riscos'.")
+            return False
+    else:
+        logger.error(f"report_type '{report_type}' não reconhecido.")
         return False
     return True


### PR DESCRIPTION
Substituída a lógica de validação dinâmica baseada em report_mapping por validação direta e explícita para cada tipo de relatório: epicos, features, times_descricao, alocacao_times e premissas_riscos.