### PR TITLE
Garantia de que todos os cinco campos de relatório são sempre incluídos e extraídos no modelo SessionData, evitando omissões que possam causar perda de dados no estado do projeto.

### DIFF
--- a/backend/app/models/session_models.py
+++ b/backend/app/models/session_models.py
@@ -28,7 +28,7 @@ class SessionData(BaseModel):
     premissas_riscos_report: Optional[Dict[str, Any]] = Field(default=None)
 
     def to_project_state(self) -> Dict[str, Any]:
-        return {
+        state = {
             "usuario_executor": self.usuario_executor,
             "projeto": self.projeto,
             "analysis_type": self.analysis_type,
@@ -38,13 +38,23 @@ class SessionData(BaseModel):
             "comentario_usuario": self.comentario_usuario,
             "extracted_text": self.extracted_text,
             "project_id": self.project_id,
-            "epicos_report": self.epicos_report,
-            "features_report": self.features_report,
-            "times_descricao_report": self.times_descricao_report,
-            "alocacao_times_report": self.alocacao_times_report,
-            "premissas_riscos_report": self.premissas_riscos_report,
+            "epicos_report": self.epicos_report if hasattr(self, 'epicos_report') else None,
+            "features_report": self.features_report if hasattr(self, 'features_report') else None,
+            "times_descricao_report": self.times_descricao_report if hasattr(self, 'times_descricao_report') else None,
+            "alocacao_times_report": self.alocacao_times_report if hasattr(self, 'alocacao_times_report') else None,
+            "premissas_riscos_report": self.premissas_riscos_report if hasattr(self, 'premissas_riscos_report') else None,
             "session_id": self.session_id
         }
+        for k in [
+            "epicos_report",
+            "features_report",
+            "times_descricao_report",
+            "alocacao_times_report",
+            "premissas_riscos_report"
+        ]:
+            if k not in state:
+                state[k] = None
+        return state
 
     @classmethod
     def from_project_state(cls, state: Dict[str, Any]) -> "SessionData":
@@ -60,9 +70,9 @@ class SessionData(BaseModel):
             comentario_usuario=state.get("comentario_usuario"),
             extracted_text=state.get("extracted_text"),
             project_id=state.get("project_id"),
-            epicos_report=state.get("epicos_report"),
-            features_report=state.get("features_report"),
-            times_descricao_report=state.get("times_descricao_report"),
-            alocacao_times_report=state.get("alocacao_times_report"),
-            premissas_riscos_report=state.get("premissas_riscos_report")
+            epicos_report=state.get("epicos_report") if "epicos_report" in state else None,
+            features_report=state.get("features_report") if "features_report" in state else None,
+            times_descricao_report=state.get("times_descricao_report") if "times_descricao_report" in state else None,
+            alocacao_times_report=state.get("alocacao_times_report") if "alocacao_times_report" in state else None,
+            premissas_riscos_report=state.get("premissas_riscos_report") if "premissas_riscos_report" in state else None
         )


### PR DESCRIPTION
No modelo SessionData, os métodos to_project_state e from_project_state foram ajustados para garantir que os cinco campos de relatório (epicos_report, features_report, times_descricao_report, alocacao_times_report, premissas_riscos_report) sejam sempre explicitamente incluídos no dicionário de estado e corretamente extraídos, mesmo quando None. Isso assegura que o estado do projeto mantenha a integridade e consistência dos relatórios.