### PR TITLE
Atualização da documentação de exemplos de payloads para refletir a nova estrutura de relatórios individuais e o uso do session_id como identificador único.

### DIFF
--- a/backend/docs/API_PAYLOAD_EXAMPLES.md
+++ b/backend/docs/API_PAYLOAD_EXAMPLES.md
@@ -16,7 +16,7 @@ Content-Type: application/json
 
 **Resposta:**
 
-```json
+
 { 
   "user_info": { 
     "usuario_executor": "user@example.com",
@@ -35,7 +35,7 @@ Content-Type: application/json
     }
   ]
 }
-```
+
 
 ### 1.2 Verificação de Projeto (GET /projects/check)
 
@@ -44,21 +44,22 @@ Content-Type: application/json
 GET /projects/check?projeto=ProjetoNovo HTTP/1.1
 Authorization: Bearer <token>
 
-
 **Resposta (projeto encontrado):**
 
-```json{ 
+
+{ 
   "exists": true,
-  "state": ```json{ 
+  "state": { 
     "usuario_executor": "user@example.com",
     "projeto": "ProjetoNovo",
     "analysis_type": "criacao_epicos_azure_devops",
     "created_at": "2024-06-01T12:00:00Z",
     "last_saved_to_blob": "2024-06-01T12:30:00Z",
-    "reports": ```json{ 
-      "epicos_report": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário..."}´´´]}´´´,
-      "features_report": ```json{ "features": [```json{ "id": 1, "nome": "Login"}´´´]}´´´
-    },
+    "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
+    "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+    "times_descricao_report": null,
+    "alocacao_times_report": null,
+    "premissas_riscos_report": null,
     "docx_files": ["https://.../arquivo1.docx"],
     "comentario_usuario": "Comentário salvo",
     "extracted_text": "Texto extraído do arquivo DOCX da reunião",
@@ -66,14 +67,15 @@ Authorization: Bearer <token>
     "last_mcp_job_id": "123456"
   }
 }
-```
+
 
 **Resposta (projeto não encontrado):**
 
-```json{ 
+
+{ 
   "exists": false
 }
-```
+
 
 ### 1.3 Upload de DOCX (POST /upload/docx)
 
@@ -88,17 +90,17 @@ projeto=ProjetoNovo
 analysis_type=criacao_epicos_azure_devops
 comentario_usuario=Comentário opcional
 
-
 **Resposta:**
 
-```json{ 
+
+{ 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
   "message": "Arquivo processado com sucesso. Pronto para análise. (Upload opcional para projetos existentes)",
   "session_id": "ghijkl-uuid",
   "job_id": "ghijkl-uuid"
 }
-```
+
 
 ### 1.4 Início de Análise (POST /analysis/start)
 
@@ -108,13 +110,14 @@ POST /analysis/start HTTP/1.1
 Authorization: Bearer <token>
 Content-Type: application/json
 
-```json{ 
+
+{ 
   "projeto": "ProjetoNovo",
   "analysis_type": "criacao_epicos_azure_devops",
   "arquivo_docx": "Texto extraído do arquivo DOCX da reunião",
   "comentario_usuario": "Este é um comentário adicional do usuário."
 }
-```
+
 
 **Requisição (projeto existente, sem novo upload):**
 
@@ -122,27 +125,29 @@ POST /analysis/start HTTP/1.1
 Authorization: Bearer <token>
 Content-Type: application/json
 
-```json{ 
+
+{ 
   "projeto": "ProjetoExistente",
   "analysis_type": "criacao_epicos_azure_devops",
   "comentario_usuario": "Comentário sem arquivo.",
   "project_id": "projeto-uuid-123"
 }
-```
+
 
 **Resposta:**
 
-```json{ 
+
+{ 
   "job_id": "123456",
   "message": "Análise solicitada com sucesso ao agente.",
   "session_id": "abcdef-uuid",
   "project_id": "projeto-uuid-123"
 }
-```
+
 
 > **Nota:** Após o início da análise, o backend persiste imediatamente a relação job_id -> session_id no Redis. Isso garante que, quando o webhook do MCP chegar, a sessão possa ser encontrada rapidamente usando o job_id.
 
-### 1.5 Atualização de Relatório (PUT /session/```json{ session_id}/report)
+### 1.5 Atualização de Relatório (PUT /session/{session_id}/report)
 
 **Requisição:**
 
@@ -150,34 +155,39 @@ PUT /session/abcdef-uuid/report HTTP/1.1
 Authorization: Bearer <token>
 Content-Type: application/json
 
-```json{ 
+
+{ 
   "report_type": "epicos",
-  "report_data": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário..."}]}
+  "report_data": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]}
 }
-```
+
 
 **Resposta:**
 
-```json{ 
+
+{ 
   "status": "ok"
 }
-```
 
-### 1.6 Consulta de Relatórios (GET /session/```json{ session_id}/reports)
+
+### 1.6 Consulta de Relatórios (GET /session/{session_id}/reports)
 
 **Requisição:**
 
 GET /session/abcdef-uuid/reports HTTP/1.1
 Authorization: Bearer <token>
 
-
 **Resposta:**
 
-```json{ 
-  "epicos_report": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário..."}]},
-  "features_report": ```json{ "features": [```json{ "id": 1, "nome": "Login"}]}
+
+{ 
+  "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
+  "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+  "times_descricao_report": null,
+  "alocacao_times_report": null,
+  "premissas_riscos_report": null
 }
-```
+
 
 ---
 
@@ -188,7 +198,7 @@ Authorization: Bearer <token>
 O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o seguinte formato JSON:
 
 
-```json{ 
+{ 
   "job_id": "<string>",
   "status": "in_progress" | "done" | "error",
   "progress": <opcional, int>,
@@ -197,7 +207,7 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   "error_type": <string, obrigatório quando status="error">,
   "error_message": <string, obrigatório quando status="error">
 }
-```
+
 
 **Campos obrigatórios:**
 - `job_id`: string. Identificador do job retornado pelo backend ao MCP.
@@ -215,105 +225,108 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 #### 2.2.1 Webhook de Progresso (`status: in_progress`)
 
 
-```json{ 
+{ 
   "job_id": "123456",
   "status": "in_progress",
   "progress": 40,
   "report_type": "epicos",
-  "report_data": ```json{ 
+  "report_data": { 
     "epicos": [
-      ```json{ "id": 1, "titulo": "Como usuário..."}
+      { "id": 1, "titulo": "Como usuário..." }
     ]
   }
 }
-```
+
 
 #### 2.2.2 Webhook de Conclusão (`status: done`)
 
 
-```json{ 
+{ 
   "job_id": "123456",
   "status": "done",
   "report_type": "epicos",
-  "report_data": ```json{ 
+  "report_data": { 
     "epicos": [
-      ```json{ "id": 1, "titulo": "Como usuário...", "descricao": "..."},
-      ```json{ "id": 2, "titulo": "Como admin...", "descricao": "..."}
+      { "id": 1, "titulo": "Como usuário...", "descricao": "..." },
+      { "id": 2, "titulo": "Como admin...", "descricao": "..." }
     ]
   }
 }
-```
+
 
 #### 2.2.3 Webhook de Erro (`status: error`)
 
 
-```json{ 
+{ 
   "job_id": "123456",
   "status": "error",
   "error_type": "timeout",
   "error_message": "Tempo limite excedido ao processar análise."
 }
-```
+
 
 #### 2.2.4 Webhook para Features (`status: done`)
 
 
-```json{ 
+{ 
   "job_id": "7891011",
   "status": "done",
   "report_type": "features",
-  "report_data": ```json{ 
+  "report_data": { 
     "features": [
-      ```json{ "id": 1, "nome": "Login", "descricao": "Permitir login com Azure AD"}
+      { "id": 1, "nome": "Login", "descricao": "Permitir login com Azure AD" }
     ]
   }
 }
-```
+
 
 #### 2.2.5 Webhook para Tech Debt (`status: done`)
 
 
-```json{ 
+{ 
   "job_id": "555777",
   "status": "done",
   "report_type": "tech_debt",
-  "report_data": ```json{ 
+  "report_data": { 
     "tech_debt": [
-      ```json{ "id": 1, "descricao": "Código duplicado"}
+      { "id": 1, "descricao": "Código duplicado" }
     ]
   }
 }
-```
+
 
 ### 2.3 Estrutura de report_data Esperada por Tipo
 
 - Para `report_type: "epicos"`:
   - `report_data` deve conter a chave `epicos` com uma lista de épicos:
     
-    ```json{ 
+    
+    {
       "epicos": [
-        ```json{ "id": 1, "titulo": "Como usuário...", "descricao": "..."}
+        { "id": 1, "titulo": "Como usuário...", "descricao": "..." }
       ]
     }
-    ```
+    
 - Para `report_type: "features"`:
   - `report_data` deve conter a chave `features` com uma lista de features:
     
-    ```json{ 
+    
+    {
       "features": [
-        ```json{ "id": 1, "nome": "Login", "descricao": "Permitir login com Azure AD"}
+        { "id": 1, "nome": "Login", "descricao": "Permitir login com Azure AD" }
       ]
     }
-    ```
+    
 - Para `report_type: "tech_debt"`:
   - `report_data` deve conter a chave `tech_debt` com uma lista de itens de débito técnico:
     
-    ```json{ 
+    
+    {
       "tech_debt": [
-        ```json{ "id": 1, "descricao": "Código duplicado"}
+        { "id": 1, "descricao": "Código duplicado" }
       ]
     }
-    ```
+    
 
 ### 2.4 Regras Importantes para o MCP
 
@@ -328,17 +341,17 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 ### 2.5 Exemplo de Webhook Inválido (Será Rejeitado)
 
 
-```json{ 
+{ 
   "job_id": "123456",
   "status": "done",
   "report_type": "epicos",
-  "report_data": ```json{ 
+  "report_data": { 
     "errado": [
-      ```json{ "id": 1, "titulo": "Como usuário..."}
+      { "id": 1, "titulo": "Como usuário..." }
     ]
   }
 }
-```
+
 
 **Motivo:** O campo esperado em `report_data` para `report_type: "epicos"` é `epicos`, não `errado`.
 
@@ -359,47 +372,59 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 ### 3.1 /analysis/start
 **Sucesso:**
 
-```json{ 
+
+{ 
   "job_id": "123456",
   "message": "Análise solicitada com sucesso ao agente.",
   "session_id": "abcdef-uuid",
   "project_id": "projeto-uuid-123"
 }
-```
+
 **Erro:**
 
-```json{ 
+
+{ 
   "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): Tempo limite excedido ao processar análise."
 }
-```
 
-### 3.2 /session/```json{ session_id}/reports
+
+### 3.2 /session/{session_id}/reports
 **Sucesso:**
 
-```json{ 
-  "epicos_report": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário..."}]},
-  "features_report": ```json{ "features": [```json{ "id": 1, "nome": "Login"}]}
+
+{ 
+  "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
+  "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+  "times_descricao_report": null,
+  "alocacao_times_report": null,
+  "premissas_riscos_report": null
 }
-```
+
 **Erro:**
 
-```json{ 
+
+{ 
   "detail": "Sessão não encontrada: ..."
 }
-```
+
 
 ### 3.3 /projects/check
 **Projeto encontrado:**
 
-```json{ 
+
+{ 
   "exists": true,
-  "state": ```json{ 
+  "state": { 
     "usuario_executor": "user@example.com",
     "projeto": "ProjetoNovo",
     "analysis_type": "criacao_epicos_azure_devops",
     "created_at": "2024-06-01T12:00:00Z",
     "last_saved_to_blob": "2024-06-01T12:30:00Z",
-    "reports": ```json{ "epicos_report": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário..."}]}},
+    "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
+    "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+    "times_descricao_report": null,
+    "alocacao_times_report": null,
+    "premissas_riscos_report": null,
     "docx_files": ["https://.../arquivo1.docx"],
     "comentario_usuario": "Comentário salvo",
     "extracted_text": "Texto extraído do arquivo DOCX da reunião",
@@ -407,19 +432,21 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
     "last_mcp_job_id": "123456"
   }
 }
-```
+
 **Projeto não encontrado:**
 
-```json{ 
+
+{ 
   "exists": false
 }
-```
+
 
 ### 3.4 /auth/login
 **Sucesso:**
 
-```json{ 
-  "user_info": ```json{ 
+
+{ 
+  "user_info": { 
     "usuario_executor": "user@example.com",
     "sub": "uuid",
     "name": "Nome do Usuário",
@@ -427,7 +454,7 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
     "roles": ["admin"]
   },
   "projects": [
-    ```json{ 
+    { 
       "projeto": "ProjetoNovo",
       "analysis_type": "criacao_epicos_azure_devops",
       "created_at": "2024-06-01T12:00:00Z",
@@ -436,84 +463,92 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
     }
   ]
 }
-```
+
 **Erro:**
 
-```json{ 
+
+{ 
   "detail": "Usuário não autenticado."
 }
-```
+
 
 ### 3.5 /upload/docx
 **Sucesso:**
 
-```json{ 
+
+{ 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
   "message": "Arquivo processado com sucesso. Pronto para análise. (Upload opcional para projetos existentes)",
   "session_id": "ghijkl-uuid",
   "job_id": "ghijkl-uuid"
 }
-```
 
-### 3.6 /session/```json{ session_id}/report (atualização de relatório)
+
+### 3.6 /session/{session_id}/report (atualização de relatório)
 **Sucesso:**
 
-```json{ 
+
+{ 
   "status": "ok"
 }
-```
+
 **Erro:**
 
-```json{ 
+
+{ 
   "detail": "Erro ao atualizar relatório: ..."
 }
-```
 
-### 3.7 /session/```json{ session_id}/save-state
+
+### 3.7 /session/{session_id}/save-state
 **Sucesso:**
 
-```json{ 
+
+{ 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/estados/estado_20240601T120000Z.json"
 }
-```
+
 **Erro:**
 
-```json{ 
+
+{ 
   "detail": "Erro ao salvar estado: ..."
 }
-```
 
-### 3.8 /session/```json{ session_id}/docx-files
+
+### 3.8 /session/{session_id}/docx-files
 **Sucesso:**
 
-```json{ 
+
+{ 
   "docx_files": [
     "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx"
   ]
 }
-```
+
 **Erro:**
 
-```json{ 
+
+{ 
   "detail": "Sessão não encontrada: ..."
 }
-```
+
 ---
 
 ## 4. Exemplos de Respostas de Erro (Backend → Frontend)
 
 | Código | Cenário | Exemplo |
 |--------|---------|---------|
-| 401 | Autenticação inválida | ````json{  "detail": "Cabeçalho Authorization ausente." }` |
-| 403 | IP não autorizado | ````json{  "detail": "Acesso negado. IP 200.100.50.25 não autorizado." }` |
-| 400 | Payload inválido | ````json{  "detail": "Os campos 'analysis_type' e pelo menos um de 'arquivo_docx' ou 'comentario_usuario' são obrigatórios." }` |
-| 502 | Falha comunicação MCP | ````json{  "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): ..." }` |
-| 504 | Timeout MCP | ````json{  "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): Tempo limite excedido ao processar análise." }` |
-| 503 | Key Vault indisponível | ````json{  "detail": "Erro ao carregar segredos do Key Vault na inicialização: ..." }` |
-| 503 | Redis indisponível | ````json{  "detail": "Erro ao conectar ao Redis (endpoint privado): ..." }` |
-| 503 | Blob Storage indisponível | ````json{  "detail": "Erro ao conectar ao Blob Storage: ..." }` |
-| 500 | Erro interno | ````json{  "detail": "Erro interno do servidor." }` |
+| 401 | Autenticação inválida | `{  "detail": "Cabeçalho Authorization ausente." }` |
+| 403 | IP não autorizado | `{  "detail": "Acesso negado. IP 200.100.50.25 não autorizado." }` |
+| 400 | Payload inválido | `{  "detail": "Os campos 'analysis_type' e pelo menos um de 'arquivo_docx' ou 'comentario_usuario' são obrigatórios." }` |
+| 502 | Falha comunicação MCP | `{  "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): ..." }` |
+| 504 | Timeout MCP | `{  "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): Tempo limite excedido ao processar análise." }` |
+| 503 | Key Vault indisponível | `{  "detail": "Erro ao carregar segredos do Key Vault na inicialização: ..." }` |
+| 503 | Redis indisponível | `{  "detail": "Erro ao conectar ao Redis (endpoint privado): ..." }` |
+| 503 | Blob Storage indisponível | `{  "detail": "Erro ao conectar ao Blob Storage: ..." }` |
+| 500 | Erro interno | `{  "detail": "Erro interno do servidor." }` |
 
 ---
 
@@ -523,15 +558,17 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 
 POST /auth/login
 Authorization: Bearer <token>
-```json{ }
+
+{}
 
 Resposta:
 
-```json{ 
-  "user_info": ```json{ "usuario_executor": "user@example.com", "sub": "uuid", "name": "Nome do Usuário", "email": "user@example.com", "roles": ["admin"]},
-  "projects": [```json{ "projeto": "ProjetoNovo", "analysis_type": "criacao_epicos_azure_devops", "created_at": "2024-06-01T12:00:00Z", "last_saved_to_blob": "2024-06-01T12:30:00Z", "project_id": "projeto-uuid-123"}]
+
+{ 
+  "user_info": { "usuario_executor": "user@example.com", "sub": "uuid", "name": "Nome do Usuário", "email": "user@example.com", "roles": ["admin"]},
+  "projects": [{ "projeto": "ProjetoNovo", "analysis_type": "criacao_epicos_azure_devops", "created_at": "2024-06-01T12:00:00Z", "last_saved_to_blob": "2024-06-01T12:30:00Z", "project_id": "projeto-uuid-123"}]
 }
-```
+
 
 ### 2. Verificação de Projeto
 
@@ -540,15 +577,20 @@ Authorization: Bearer <token>
 
 Resposta:
 
-```json{ 
+
+{ 
   "exists": true,
-  "state": ```json{ 
+  "state": { 
     "usuario_executor": "user@example.com",
     "projeto": "ProjetoNovo",
     "analysis_type": "criacao_epicos_azure_devops",
     "created_at": "2024-06-01T12:00:00Z",
     "last_saved_to_blob": "2024-06-01T12:30:00Z",
-    "reports": ```json{ "epicos_report": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário..."}]}},
+    "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
+    "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+    "times_descricao_report": null,
+    "alocacao_times_report": null,
+    "premissas_riscos_report": null,
     "docx_files": ["https://.../arquivo1.docx"],
     "comentario_usuario": "Comentário salvo",
     "extracted_text": "Texto extraído do arquivo DOCX da reunião",
@@ -556,7 +598,7 @@ Resposta:
     "last_mcp_job_id": "123456"
   }
 }
-```
+
 
 ### 3. Upload de DOCX
 
@@ -566,58 +608,63 @@ file=<arquivo.docx>&projeto=ProjetoNovo&analysis_type=criacao_epicos_azure_devop
 
 Resposta:
 
-```json{ 
+
+{ 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
   "message": "Arquivo processado com sucesso. Pronto para análise. (Upload opcional para projetos existentes)",
   "session_id": "ghijkl-uuid",
   "job_id": "ghijkl-uuid"
 }
-```
+
 
 ### 4. Início de Análise
 
 POST /analysis/start
 Authorization: Bearer <token>
-```json{ 
+
+{ 
   "projeto": "ProjetoNovo",
   "analysis_type": "criacao_epicos_azure_devops",
   "arquivo_docx": "Texto extraído do arquivo DOCX da reunião",
   "comentario_usuario": "Este é um comentário adicional do usuário."
 }
-```
+
 Resposta:
 
-```json{ 
+
+{ 
   "job_id": "123456",
   "message": "Análise solicitada com sucesso ao agente.",
   "session_id": "abcdef-uuid",
   "project_id": "projeto-uuid-123"
 }
-```
+
 > **Nota:** O backend persiste imediatamente a relação job_id -> session_id no Redis após o início da análise.
 
 
 ### 5. Webhook de Progresso (MCP → Backend)
 
-```json{ 
+
+{ 
   "job_id": "123456",
   "status": "in_progress",
   "progress": 50,
   "report_type": "epicos",
-  "report_data": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário..."}]}
+  "report_data": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]}
 }
-```
+
 
 ### 6. Webhook de Conclusão (MCP → Backend)
 
-```json{ 
+
+{ 
   "job_id": "123456",
   "status": "done",
   "report_type": "epicos",
-  "report_data": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário...", "descricao": "..."}]}
+  "report_data": { "epicos": [{ "id": 1, "titulo": "Como usuário...", "descricao": "..." }]}
 }
-```
+
 
 ### 7. Consulta de Relatórios
 
@@ -626,10 +673,15 @@ Authorization: Bearer <token>
 
 Resposta:
 
-```json{ 
-  "epicos_report": ```json{ "epicos": [```json{ "id": 1, "titulo": "Como usuário..."}]}
+
+{ 
+  "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
+  "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+  "times_descricao_report": null,
+  "alocacao_times_report": null,
+  "premissas_riscos_report": null
 }
-```
+
 
 ### 8. Salvamento Manual de Estado
 
@@ -638,10 +690,11 @@ Authorization: Bearer <token>
 
 Resposta:
 
-```json{ 
+
+{ 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/estados/estado_20240601T120000Z.json"
 }
-```
+
 
 ---
 
@@ -649,7 +702,7 @@ Resposta:
 - Todos os exemplos de requisição (exceto `/auth/config`) exigem o header `Authorization: Bearer <token>`.
 - O campo `project_id` está presente em todas as respostas de endpoints que envolvem projetos ou sessões.
 - O campo `arquivo_docx` enviado para o MCP sempre contém o texto extraído do DOCX, nunca a URL.
-- Todos os relatórios estão sob o campo unificado `reports`. Campos legados como `epicos_report` ainda podem aparecer para retrocompatibilidade, mas o padrão é usar o objeto `reports`.
+- Todos os relatórios estão sob campos individuais (`epicos_report`, `features_report`, etc). Não existe mais a chave `reports`.
 - O upload de DOCX retorna tanto a URL do arquivo quanto o texto extraído, em paralelo.
 - Para erros, o backend sempre retorna o campo `detail` no corpo JSON.
 - Após o início da análise, a relação job_id -> session_id é persistida no Redis para garantir que o webhook do MCP encontre a sessão correta.


### PR DESCRIPTION
A documentação de exemplos de payloads foi atualizada para remover a chave 'reports' e apresentar os relatórios em campos individuais como 'epicos_report', 'features_report', etc. Também foi reforçado que o session_id é o identificador único para todas as operações, mantendo a continuidade das sessões para projetos existentes e criando novas sessões para novos projetos.