### PR TITLE
Atualização do MCPStartAnalysisPayload para uso exclusivo do project_id como identificador do projeto.

### DIFF
--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -7,7 +7,7 @@ class MCPStartAnalysisPayload(BaseModel):
     arquivo_docx: Optional[str] = Field(None, description="Texto extraído do arquivo docx com a transcrição da reunião. NÃO é a URL do Blob Storage.")
     comentario_usuario: Optional[str] = Field(None, description="Comentário adicional enviado pelo usuário.")
     usuario_executor: str = Field(..., description="Usuário executor extraído do token JWT.")
-    session_id: str = Field(..., description="Identificador da sessão.")
+    project_id: str = Field(..., description="Identificador único do projeto.")
 
     @validator('analysis_type')
     def analysis_type_must_not_be_empty(cls, v):


### PR DESCRIPTION
Removido o campo session_id da classe MCPStartAnalysisPayload e adicionado o campo obrigatório project_id, que será o único identificador usado para guiar todas as operações do projeto e integrações com o MCP.