### PR TITLE
Inclusão do project_id obrigatório na classe MCPWebhookPayload para garantir o uso exclusivo deste identificador nas integrações com o MCP.

### DIFF
--- a/backend/app/models/mcp_webhook_models.py
+++ b/backend/app/models/mcp_webhook_models.py
@@ -9,6 +9,7 @@ class MCPWebhookPayload(BaseModel):
     report_data: Optional[Any] = Field(None)
     error_type: Optional[str] = Field(None)
     error_message: Optional[str] = Field(None)
+    project_id: str = Field(..., description="Identificador único do projeto.")
 
     @validator('status')
     def status_must_be_valid(cls, v):
@@ -32,4 +33,10 @@ class MCPWebhookPayload(BaseModel):
         status = values.get('status')
         if status == 'error' and not v:
             raise ValueError("error_message é obrigatório quando status é 'error'")
+        return v
+
+    @validator('project_id', always=True)
+    def project_id_must_be_present(cls, v, values):
+        if not v or not isinstance(v, str) or not v.strip():
+            raise ValueError('project_id é obrigatório e deve ser uma string não vazia')
         return v


### PR DESCRIPTION
Adicionado o campo obrigatório project_id na classe MCPWebhookPayload, com validação para garantir que sempre esteja presente e seja uma string não vazia, reforçando que project_id é o único id usado para identificar projetos em todas as interações com o MCP.