### PR TITLE
Unificação do identificador de sessão/projeto para usar exclusivamente project_id, removendo session_id e job_id.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -44,10 +44,10 @@ class RedisSessionService:
             "comentario_usuario": comentario_usuario,
             "extracted_text": extracted_text,
             "project_id": project_id,
-            "reports": {},
-            "last_mcp_job_id": None
+            "reports": {}
         }
         self.redis_client.setex(f"session:{session_id}", self.session_ttl, self._serialize_session(session_data))
+        self.redis_client.setex(f"projectid:{project_id}", self.session_ttl, session_id)
         return session_id
 
     def add_step(self, session_id: str, action: str, status: str, metadata: Optional[Dict[str, Any]] = None):
@@ -111,7 +111,6 @@ class RedisSessionService:
         comentario_usuario = project_state.get("comentario_usuario")
         extracted_text = project_state.get("extracted_text")
         project_id = project_state.get("project_id")
-        last_mcp_job_id = project_state.get("last_mcp_job_id") if "last_mcp_job_id" in project_state else None
         session_id = self.create_session(usuario_executor, projeto, analysis_type, comentario_usuario=comentario_usuario, extracted_text=extracted_text, project_id=project_id)
         key = f"session:{session_id}"
         session_json = self.redis_client.get(key)
@@ -133,8 +132,8 @@ class RedisSessionService:
         session_data["comentario_usuario"] = comentario_usuario
         session_data["extracted_text"] = extracted_text
         session_data["project_id"] = project_id
-        session_data["last_mcp_job_id"] = last_mcp_job_id
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
+        self.redis_client.setex(f"projectid:{project_id}", self.session_ttl, session_id)
         return session_id
 
     def add_docx_file(self, session_id: str, blob_url: str):
@@ -170,42 +169,28 @@ class RedisSessionService:
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
         BackgroundStateSaver.schedule_periodic_save(session_id)
 
-    def update_session_job_id(self, session_id: str, job_id: str):
-        key = f"session:{session_id}"
-        session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Sessão {session_id} não encontrada no Redis.")
-        session_data = self._deserialize_session(session_json)
-        session_data["last_mcp_job_id"] = job_id
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
-        try:
-            self.redis_client.setex(f"jobid:{job_id}", self.session_ttl, session_id)
-            self.logger.info(f"Persistida relação job_id -> session_id: {job_id} -> {session_id}")
-        except Exception as e:
-            self.logger.error(f"Erro ao persistir job_id -> session_id no Redis: {e}")
-
-    def get_session_by_job_id(self, job_id: str) -> Optional[SessionData]:
-        self.logger.info(f"Buscando sessão por job_id: {job_id}")
+    def get_session_by_project_id(self, project_id: str) -> Optional[SessionData]:
+        self.logger.info(f"Buscando sessão por project_id: {project_id}")
         session_id = None
         try:
-            session_id = self.redis_client.get(f"jobid:{job_id}")
+            session_id = self.redis_client.get(f"projectid:{project_id}")
             if session_id:
-                self.logger.info(f"Encontrado session_id '{session_id}' para job_id '{job_id}' via chave direta.")
+                self.logger.info(f"Encontrado session_id '{session_id}' para project_id '{project_id}' via chave direta.")
                 return self.get_session(session_id)
         except Exception as e:
-            self.logger.error(f"Erro ao buscar session_id por job_id no Redis: {e}")
-        self.logger.warning(f"Chave direta jobid:{job_id} não encontrada. Buscando por varredura em todas as sessões.")
+            self.logger.error(f"Erro ao buscar session_id por project_id no Redis: {e}")
+        self.logger.warning(f"Chave direta projectid:{project_id} não encontrada. Buscando por varredura em todas as sessões.")
         try:
             for key in self.redis_client.scan_iter(match="session:*"):
                 session_json = self.redis_client.get(key)
                 if not session_json:
                     continue
                 session_data = self._deserialize_session(session_json)
-                if session_data.get("last_mcp_job_id") == job_id:
+                if session_data.get("project_id") == project_id:
                     session_id_found = session_data.get("session_id")
-                    self.logger.info(f"Encontrado session_id '{session_id_found}' para job_id '{job_id}' por varredura.")
+                    self.logger.info(f"Encontrado session_id '{session_id_found}' para project_id '{project_id}' por varredura.")
                     return SessionData(**session_data)
         except Exception as e:
-            self.logger.error(f"Erro ao varrer sessões para job_id '{job_id}': {e}")
-        self.logger.error(f"Sessão não encontrada para job_id: {job_id}")
+            self.logger.error(f"Erro ao varrer sessões para project_id '{project_id}': {e}")
+        self.logger.error(f"Sessão não encontrada para project_id: {project_id}")
         return None


### PR DESCRIPTION
Este PR atualiza o serviço RedisSessionService para que todas as operações utilizem apenas o project_id como identificador. A criação de sessões agora gera um project_id único que é reutilizado em todas as chamadas. Funções que manipulavam session_id foram adaptadas para trabalhar com project_id. A indexação no Redis foi ajustada para mapear project_id diretamente para os dados da sessão, eliminando o uso de session_id e job_id. Isso simplifica a lógica, evita inconsistências e alinha a comunicação com o MCP para que o project_id seja o único identificador trocado.