### PR TITLE
Atualização do serviço cliente MCP para utilizar exclusivamente project_id no payload de análise, removendo session_id.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -11,7 +11,7 @@ class MCPStartAnalysisPayload(BaseModel):
     arquivo_docx: Optional[str] = Field(None)
     comentario_usuario: Optional[str] = Field(None)
     usuario_executor: str = Field(...)
-    session_id: str = Field(...)
+    project_id: str = Field(...)
 
     @validator('analysis_type')
     def analysis_type_must_not_be_empty(cls, v):
@@ -39,17 +39,6 @@ class MCPClientService:
         return self.base_url
 
     async def start_analysis(self, payload: MCPStartAnalysisPayload) -> MCPStartAnalysisResponse:
-        # O MCP deve responder à chamada POST /start e, após processar, enviar webhooks para o endpoint /webhooks/mcp do backend.
-        # O formato do webhook deve seguir a documentação em backend/docs/MCP_WEBHOOK_RESPONSE_FORMAT.md.
-        # O webhook deve conter os campos: job_id (str), status ("in_progress", "done", "error"),
-        # report_type (str), report_data (dict), progress (opcional), error_type (opcional), error_message (opcional).
-        # Exemplo de payload de webhook:
-        # {
-        #   "job_id": "123456",
-        #   "status": "done",
-        #   "report_type": "epicos",
-        #   "report_data": {"epicos": [{"id": 1, "titulo": "Como usuário..."}]}
-        # }
         raw_base = self.get_mcp_endpoint(payload.analysis_type)
         logging.info(f"🕵️ [DEBUG URL] Bruta vinda da env: '[{raw_base}]'")
         base = raw_base.strip().rstrip("/")


### PR DESCRIPTION
O payload MCPStartAnalysisPayload foi ajustado para conter apenas project_id como identificador do projeto. O método start_analysis envia o payload com project_id, alinhado à nova regra de integração. Validações e tratamento de erros foram mantidos para garantir robustez.