### PR TITLE
Remoção de todas as referências ao last_mcp_job_id na persistência de estado do projeto, mantendo apenas o project_id como identificador único.

### DIFF
--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -17,9 +17,6 @@ class ProjectStateService:
         blob_path = f"{blob_folder}/{blob_filename}"
         _, container_client = _get_blob_clients()
         blob_client = container_client.get_blob_client(blob_path)
-        # Garante que last_mcp_job_id está presente no estado salvo
-        if hasattr(session_data, "last_mcp_job_id"):
-            state["last_mcp_job_id"] = getattr(session_data, "last_mcp_job_id")
         blob_client.upload_blob(json.dumps(state, ensure_ascii=False, separators=(',', ':')).encode("utf-8"), overwrite=True, content_settings=None)
         return blob_client.url
 
@@ -45,9 +42,6 @@ class ProjectStateService:
         blob_client = container_client.get_blob_client(latest_blob.name)
         state_bytes = blob_client.download_blob().readall()
         state = json.loads(state_bytes.decode("utf-8"))
-        # Garante que last_mcp_job_id é carregado se existir
-        if "last_mcp_job_id" in state:
-            state["last_mcp_job_id"] = state["last_mcp_job_id"]
         logger.info(f"Estado carregado com sucesso para usuario_executor={usuario_executor}, projeto={projeto}")
         return state
 


### PR DESCRIPTION
Atualizado o serviço de persistência de estado para eliminar qualquer uso do last_mcp_job_id, garantindo que o único identificador persistido e utilizado para operações seja o project_id. Isso simplifica a lógica de salvamento e recuperação de estados, alinhando-se à diretriz de uso exclusivo do project_id para todas as operações.