### PR TITLE
Atualização dos exemplos de payloads e webhooks para uso exclusivo do project_id como identificador principal, removendo referências a last_mcp_job_id e session_id como identificadores de integração.

### DIFF
--- a/backend/docs/API_PAYLOAD_EXAMPLES.md
+++ b/backend/docs/API_PAYLOAD_EXAMPLES.md
@@ -16,7 +16,6 @@ Content-Type: application/json
 
 **Resposta:**
 
-
 { 
   "user_info": { 
     "usuario_executor": "user@example.com",
@@ -36,7 +35,6 @@ Content-Type: application/json
   ]
 }
 
-
 ### 1.2 Verificação de Projeto (GET /projects/check)
 
 **Requisição:**
@@ -45,7 +43,6 @@ GET /projects/check?projeto=ProjetoNovo HTTP/1.1
 Authorization: Bearer <token>
 
 **Resposta (projeto encontrado):**
-
 
 { 
   "exists": true,
@@ -63,19 +60,15 @@ Authorization: Bearer <token>
     "docx_files": ["https://.../arquivo1.docx"],
     "comentario_usuario": "Comentário salvo",
     "extracted_text": "Texto extraído do arquivo DOCX da reunião",
-    "project_id": "projeto-uuid-123",
-    "last_mcp_job_id": "123456"
+    "project_id": "projeto-uuid-123"
   }
 }
 
-
 **Resposta (projeto não encontrado):**
-
 
 { 
   "exists": false
 }
-
 
 ### 1.3 Upload de DOCX (POST /upload/docx)
 
@@ -92,7 +85,6 @@ comentario_usuario=Comentário opcional
 
 **Resposta:**
 
-
 { 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
@@ -100,7 +92,6 @@ comentario_usuario=Comentário opcional
   "session_id": "ghijkl-uuid",
   "job_id": "ghijkl-uuid"
 }
-
 
 ### 1.4 Início de Análise (POST /analysis/start)
 
@@ -110,21 +101,19 @@ POST /analysis/start HTTP/1.1
 Authorization: Bearer <token>
 Content-Type: application/json
 
-
 { 
   "projeto": "ProjetoNovo",
   "analysis_type": "criacao_epicos_azure_devops",
   "arquivo_docx": "Texto extraído do arquivo DOCX da reunião",
-  "comentario_usuario": "Este é um comentário adicional do usuário."
+  "comentario_usuario": "Este é um comentário adicional do usuário.",
+  "project_id": "projeto-uuid-123"
 }
-
 
 **Requisição (projeto existente, sem novo upload):**
 
 POST /analysis/start HTTP/1.1
 Authorization: Bearer <token>
 Content-Type: application/json
-
 
 { 
   "projeto": "ProjetoExistente",
@@ -133,9 +122,7 @@ Content-Type: application/json
   "project_id": "projeto-uuid-123"
 }
 
-
 **Resposta:**
-
 
 { 
   "job_id": "123456",
@@ -144,8 +131,7 @@ Content-Type: application/json
   "project_id": "projeto-uuid-123"
 }
 
-
-> **Nota:** Após o início da análise, o backend persiste imediatamente a relação job_id -> session_id no Redis. Isso garante que, quando o webhook do MCP chegar, a sessão possa ser encontrada rapidamente usando o job_id.
+> **Nota:** O campo project_id é criado no momento de criação do projeto e será reutilizado em toda interação no projeto. Toda comunicação com o MCP utiliza o project_id como identificador principal.
 
 ### 1.5 Atualização de Relatório (PUT /session/{session_id}/report)
 
@@ -155,20 +141,16 @@ PUT /session/abcdef-uuid/report HTTP/1.1
 Authorization: Bearer <token>
 Content-Type: application/json
 
-
 { 
   "report_type": "epicos",
   "report_data": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]}
 }
 
-
 **Resposta:**
-
 
 { 
   "status": "ok"
 }
-
 
 ### 1.6 Consulta de Relatórios (GET /session/{session_id}/reports)
 
@@ -179,7 +161,6 @@ Authorization: Bearer <token>
 
 **Resposta:**
 
-
 { 
   "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
   "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
@@ -187,7 +168,6 @@ Authorization: Bearer <token>
   "alocacao_times_report": null,
   "premissas_riscos_report": null
 }
-
 
 ---
 
@@ -197,9 +177,9 @@ Authorization: Bearer <token>
 
 O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o seguinte formato JSON:
 
-
 { 
   "job_id": "<string>",
+  "project_id": "<string>",
   "status": "in_progress" | "done" | "error",
   "progress": <opcional, int>,
   "report_type": <string, obrigatório quando status="in_progress" ou "done">,
@@ -208,9 +188,9 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   "error_message": <string, obrigatório quando status="error">
 }
 
-
 **Campos obrigatórios:**
 - `job_id`: string. Identificador do job retornado pelo backend ao MCP.
+- `project_id`: string. Identificador único do projeto, usado para buscar a sessão correspondente.
 - `status`: string. Um dos valores: `in_progress`, `done`, `error`.
 - `progress`: inteiro opcional (0-100), só para status `in_progress`.
 - `report_type`: string. Obrigatório para status `in_progress` ou `done`. Exemplo: `epicos`, `features`, `tech_debt`.
@@ -218,15 +198,15 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 - `error_type`: string. Obrigatório para status `error`.
 - `error_message`: string. Obrigatório para status `error`.
 
-> **Nota:** O backend busca a sessão correspondente usando o job_id persistido no Redis. Se não encontrar, retorna 404 e loga o erro detalhadamente.
+> **Nota:** O backend busca a sessão correspondente usando o project_id persistido no Redis. Se não encontrar, retorna 404 e loga o erro detalhadamente.
 
 ### 2.2 Exemplos de Webhook para Cada Tipo de Relatório
 
 #### 2.2.1 Webhook de Progresso (`status: in_progress`)
 
-
 { 
   "job_id": "123456",
+  "project_id": "projeto-uuid-123",
   "status": "in_progress",
   "progress": 40,
   "report_type": "epicos",
@@ -237,12 +217,11 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   }
 }
 
-
 #### 2.2.2 Webhook de Conclusão (`status: done`)
-
 
 { 
   "job_id": "123456",
+  "project_id": "projeto-uuid-123",
   "status": "done",
   "report_type": "epicos",
   "report_data": { 
@@ -253,23 +232,21 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   }
 }
 
-
 #### 2.2.3 Webhook de Erro (`status: error`)
-
 
 { 
   "job_id": "123456",
+  "project_id": "projeto-uuid-123",
   "status": "error",
   "error_type": "timeout",
   "error_message": "Tempo limite excedido ao processar análise."
 }
 
-
 #### 2.2.4 Webhook para Features (`status: done`)
-
 
 { 
   "job_id": "7891011",
+  "project_id": "projeto-uuid-456",
   "status": "done",
   "report_type": "features",
   "report_data": { 
@@ -279,12 +256,11 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   }
 }
 
-
 #### 2.2.5 Webhook para Tech Debt (`status: done`)
-
 
 { 
   "job_id": "555777",
+  "project_id": "projeto-uuid-789",
   "status": "done",
   "report_type": "tech_debt",
   "report_data": { 
@@ -294,12 +270,10 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   }
 }
 
-
 ### 2.3 Estrutura de report_data Esperada por Tipo
 
 - Para `report_type: "epicos"`:
   - `report_data` deve conter a chave `epicos` com uma lista de épicos:
-    
     
     {
       "epicos": [
@@ -310,7 +284,6 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 - Para `report_type: "features"`:
   - `report_data` deve conter a chave `features` com uma lista de features:
     
-    
     {
       "features": [
         { "id": 1, "nome": "Login", "descricao": "Permitir login com Azure AD" }
@@ -319,7 +292,6 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
     
 - Para `report_type: "tech_debt"`:
   - `report_data` deve conter a chave `tech_debt` com uma lista de itens de débito técnico:
-    
     
     {
       "tech_debt": [
@@ -330,19 +302,19 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 
 ### 2.4 Regras Importantes para o MCP
 
-- O campo `job_id` deve ser exatamente o mesmo recebido do backend na chamada de início de análise.
+- O campo `project_id` deve ser exatamente o mesmo recebido do backend na chamada de início de análise.
 - O campo `report_type` DEVE ser igual ao tipo de relatório definido no mapeamento do backend para o `analysis_type` correspondente.
 - O campo principal de `report_data` (ex: `epicos`, `features`, `tech_debt`) deve estar presente e conter a lista de resultados.
 - Para status `error`, não envie `report_type` nem `report_data`.
 - Para status `in_progress` e `done`, ambos `report_type` e `report_data` são obrigatórios.
 - O backend rejeitará webhooks com estrutura inválida ou campos ausentes.
-- O backend busca a sessão pelo job_id persistido no Redis. Se não encontrar, retorna 404 e loga o erro detalhadamente.
+- O backend busca a sessão pelo project_id persistido no Redis. Se não encontrar, retorna 404 e loga o erro detalhadamente.
 
 ### 2.5 Exemplo de Webhook Inválido (Será Rejeitado)
 
-
 { 
   "job_id": "123456",
+  "project_id": "projeto-uuid-123",
   "status": "done",
   "report_type": "epicos",
   "report_data": { 
@@ -351,7 +323,6 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
     ]
   }
 }
-
 
 **Motivo:** O campo esperado em `report_data` para `report_type: "epicos"` é `epicos`, não `errado`.
 
@@ -362,7 +333,6 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 | criacao_epicos_azure_devops    | epicos       | epicos_report                |
 | refinamento_epicos_azure_devops| epicos       | epicos_report                        |
 
-
 O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeamento acima.
 
 ---
@@ -371,7 +341,6 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 
 ### 3.1 /analysis/start
 **Sucesso:**
-
 
 { 
   "job_id": "123456",
@@ -382,15 +351,12 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 
 **Erro:**
 
-
 { 
   "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): Tempo limite excedido ao processar análise."
 }
 
-
 ### 3.2 /session/{session_id}/reports
 **Sucesso:**
-
 
 { 
   "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
@@ -402,15 +368,12 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 
 **Erro:**
 
-
 { 
   "detail": "Sessão não encontrada: ..."
 }
 
-
 ### 3.3 /projects/check
 **Projeto encontrado:**
-
 
 { 
   "exists": true,
@@ -428,22 +391,18 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
     "docx_files": ["https://.../arquivo1.docx"],
     "comentario_usuario": "Comentário salvo",
     "extracted_text": "Texto extraído do arquivo DOCX da reunião",
-    "project_id": "projeto-uuid-123",
-    "last_mcp_job_id": "123456"
+    "project_id": "projeto-uuid-123"
   }
 }
 
 **Projeto não encontrado:**
 
-
 { 
   "exists": false
 }
 
-
 ### 3.4 /auth/login
 **Sucesso:**
-
 
 { 
   "user_info": { 
@@ -466,15 +425,12 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 
 **Erro:**
 
-
 { 
   "detail": "Usuário não autenticado."
 }
 
-
 ### 3.5 /upload/docx
 **Sucesso:**
-
 
 { 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
@@ -484,10 +440,8 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
   "job_id": "ghijkl-uuid"
 }
 
-
 ### 3.6 /session/{session_id}/report (atualização de relatório)
 **Sucesso:**
-
 
 { 
   "status": "ok"
@@ -495,15 +449,12 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 
 **Erro:**
 
-
 { 
   "detail": "Erro ao atualizar relatório: ..."
 }
 
-
 ### 3.7 /session/{session_id}/save-state
 **Sucesso:**
-
 
 { 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/estados/estado_20240601T120000Z.json"
@@ -511,15 +462,12 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 
 **Erro:**
 
-
 { 
   "detail": "Erro ao salvar estado: ..."
 }
 
-
 ### 3.8 /session/{session_id}/docx-files
 **Sucesso:**
-
 
 { 
   "docx_files": [
@@ -528,7 +476,6 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 }
 
 **Erro:**
-
 
 { 
   "detail": "Sessão não encontrada: ..."
@@ -563,12 +510,10 @@ Authorization: Bearer <token>
 
 Resposta:
 
-
 { 
   "user_info": { "usuario_executor": "user@example.com", "sub": "uuid", "name": "Nome do Usuário", "email": "user@example.com", "roles": ["admin"]},
   "projects": [{ "projeto": "ProjetoNovo", "analysis_type": "criacao_epicos_azure_devops", "created_at": "2024-06-01T12:00:00Z", "last_saved_to_blob": "2024-06-01T12:30:00Z", "project_id": "projeto-uuid-123"}]
 }
-
 
 ### 2. Verificação de Projeto
 
@@ -576,7 +521,6 @@ GET /projects/check?projeto=ProjetoNovo
 Authorization: Bearer <token>
 
 Resposta:
-
 
 { 
   "exists": true,
@@ -594,11 +538,9 @@ Resposta:
     "docx_files": ["https://.../arquivo1.docx"],
     "comentario_usuario": "Comentário salvo",
     "extracted_text": "Texto extraído do arquivo DOCX da reunião",
-    "project_id": "projeto-uuid-123",
-    "last_mcp_job_id": "123456"
+    "project_id": "projeto-uuid-123"
   }
 }
-
 
 ### 3. Upload de DOCX
 
@@ -608,7 +550,6 @@ file=<arquivo.docx>&projeto=ProjetoNovo&analysis_type=criacao_epicos_azure_devop
 
 Resposta:
 
-
 { 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
@@ -616,7 +557,6 @@ Resposta:
   "session_id": "ghijkl-uuid",
   "job_id": "ghijkl-uuid"
 }
-
 
 ### 4. Início de Análise
 
@@ -627,11 +567,11 @@ Authorization: Bearer <token>
   "projeto": "ProjetoNovo",
   "analysis_type": "criacao_epicos_azure_devops",
   "arquivo_docx": "Texto extraído do arquivo DOCX da reunião",
-  "comentario_usuario": "Este é um comentário adicional do usuário."
+  "comentario_usuario": "Este é um comentário adicional do usuário.",
+  "project_id": "projeto-uuid-123"
 }
 
 Resposta:
-
 
 { 
   "job_id": "123456",
@@ -640,31 +580,28 @@ Resposta:
   "project_id": "projeto-uuid-123"
 }
 
-> **Nota:** O backend persiste imediatamente a relação job_id -> session_id no Redis após o início da análise.
-
+> **Nota:** Toda a comunicação com o MCP utiliza o project_id como identificador principal. O job_id é apenas um identificador da execução no MCP, mas não é usado para buscar sessões no backend.
 
 ### 5. Webhook de Progresso (MCP → Backend)
 
-
 { 
   "job_id": "123456",
+  "project_id": "projeto-uuid-123",
   "status": "in_progress",
   "progress": 50,
   "report_type": "epicos",
   "report_data": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]}
 }
 
-
 ### 6. Webhook de Conclusão (MCP → Backend)
-
 
 { 
   "job_id": "123456",
+  "project_id": "projeto-uuid-123",
   "status": "done",
   "report_type": "epicos",
   "report_data": { "epicos": [{ "id": 1, "titulo": "Como usuário...", "descricao": "..." }]}
 }
-
 
 ### 7. Consulta de Relatórios
 
@@ -672,7 +609,6 @@ GET /session/abcdef-uuid/reports
 Authorization: Bearer <token>
 
 Resposta:
-
 
 { 
   "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
@@ -682,7 +618,6 @@ Resposta:
   "premissas_riscos_report": null
 }
 
-
 ### 8. Salvamento Manual de Estado
 
 POST /session/abcdef-uuid/save-state
@@ -690,11 +625,9 @@ Authorization: Bearer <token>
 
 Resposta:
 
-
 { 
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/estados/estado_20240601T120000Z.json"
 }
-
 
 ---
 
@@ -705,4 +638,4 @@ Resposta:
 - Todos os relatórios estão sob campos individuais (`epicos_report`, `features_report`, etc). Não existe mais a chave `reports`.
 - O upload de DOCX retorna tanto a URL do arquivo quanto o texto extraído, em paralelo.
 - Para erros, o backend sempre retorna o campo `detail` no corpo JSON.
-- Após o início da análise, a relação job_id -> session_id é persistida no Redis para garantir que o webhook do MCP encontre a sessão correta.
+- Toda a comunicação com o MCP utiliza o project_id como identificador principal. O job_id é apenas um identificador da execução no MCP, mas não é usado para buscar sessões no backend.


### PR DESCRIPTION
Todos os exemplos de payloads enviados pelo frontend, respostas do backend, exemplos de webhooks do MCP e fluxos de comunicação foram atualizados para refletir que o único identificador usado em toda a integração é o project_id. Isso inclui a remoção de referências a last_mcp_job_id e session_id como identificadores para integração com o MCP, garantindo clareza e consistência na comunicação.