### PR TITLE
Atualização da documentação de arquitetura para refletir que o project_id é o único identificador usado em toda a comunicação com o MCP e na busca de sessões, removendo menções a last_mcp_job_id e session_id como identificadores de integração.

### DIFF
--- a/backend/docs/ARCHITECTURE_FLOW.md
+++ b/backend/docs/ARCHITECTURE_FLOW.md
@@ -48,78 +48,76 @@ flowchart TD
     AG -->|Salvamento Periódico| AE
     AC -->|Carrega Segredos| AA
 
-
 ---
 
 ## Etapas do Fluxo e Código Responsável
 
 ### 1. Login e Autenticação via Azure AD
-- **Descrição:** O frontend envia o token JWT via header `Authorization`. O backend valida o token, extrai o `usuario_executor` e retorna a lista de projetos do usuário.
-- **Código:**
+- O frontend envia o token JWT via header `Authorization`. O backend valida o token, extrai o `usuario_executor` e retorna a lista de projetos do usuário.
+- Código:
   - `backend/app/api/auth.py` (`POST /auth/login`)
   - `backend/app/middleware/auth_middleware.py` (`get_current_user`)
   - `backend/app/services/azure_ad_service.py` (`validate_token`)
   - `backend/app/services/project_state_service.py` (`list_user_projects`)
 
 ### 2. Verificação de Projeto Existente
-- **Descrição:** Antes de qualquer operação, o frontend chama `/projects/check` para saber se o projeto existe. Se existir, retorna o estado completo do projeto (incluindo `project_id` e os campos individuais de relatório: `epicos_report`, `features_report`, etc).
-- **Código:**
+- O frontend chama `/projects/check` para saber se o projeto existe. Se existir, retorna o estado completo do projeto (incluindo `project_id` e os campos individuais de relatório: `epicos_report`, `features_report`, etc).
+- Código:
   - `backend/app/api/projects.py` (`/projects/check`)
   - `backend/app/services/project_state_service.py` (`load_latest_state_from_blob`)
 
 ### 3. Upload de DOCX e Extração de Texto (Processamento Paralelo)
-- **Descrição:** O upload do arquivo DOCX e a extração do texto ocorrem em paralelo. O backend retorna tanto a URL do arquivo quanto o texto extraído.
-- **Código:**
+- O upload do arquivo DOCX e a extração do texto ocorrem em paralelo. O backend retorna tanto a URL do arquivo quanto o texto extraído.
+- Código:
   - `backend/app/api/upload.py` (`/upload/docx`)
   - `backend/app/services/blob_storage_service.py` (`upload_and_extract_docx`)
   - `backend/app/services/docx_parser_service.py` (`extract_text_from_docx`)
 
 ### 4. Criação e Gerenciamento de Sessão no Redis
-- **Descrição:** Sessões são criadas e persistidas no Redis, incluindo campos como `comentario_usuario`, `extracted_text`, `project_id`, `docx_files` e os campos de relatório individuais (`epicos_report`, `features_report`, etc).
-- **Código:**
+- Sessões são criadas e persistidas no Redis, incluindo campos como `comentario_usuario`, `extracted_text`, `project_id`, `docx_files` e os campos de relatório individuais (`epicos_report`, `features_report`, etc).
+- Código:
   - `backend/app/services/redis_session_service.py` (`create_session`, `add_docx_file`, `update_session_extracted_text`, `update_report`, `restore_session_from_state`)
   - `backend/app/models/session_models.py` (`SessionData`)
 
 ### 5. Salvamento Automático e Periódico de Estado no Blob Storage
-- **Descrição:** Estados de sessão/projeto são salvos periodicamente no Blob Storage via `BackgroundStateSaver`. Mudanças em relatórios ou estado acionam o salvamento automático.
-- **Código:**
+- Estados de sessão/projeto são salvos periodicamente no Blob Storage via `BackgroundStateSaver`. Mudanças em relatórios ou estado acionam o salvamento automático.
+- Código:
   - `backend/app/services/background_state_saver.py` (`schedule_periodic_save`)
   - `backend/app/services/project_state_service.py` (`save_state_to_blob`)
   - `backend/app/services/redis_session_service.py` (`update_session_on_state_change`)
 
 ### 6. Carregamento de Segredos do Key Vault (Múltiplos Cofres)
-- **Descrição:** Segredos sensíveis são carregados de múltiplos Key Vaults (Azure, DevOps, GitHub, LLM) via Managed Identity. Existe fallback para variáveis de ambiente.
-- **Código:**
+- Segredos sensíveis são carregados de múltiplos Key Vaults (Azure, DevOps, GitHub, LLM) via Managed Identity. Existe fallback para variáveis de ambiente.
+- Código:
   - `backend/app/services/config_loader_service.py` (`load_secrets_from_key_vault`)
   - `backend/app/services/azure_secret_manager.py` (`AzureSecretManager`)
   - `backend/app/core/config.py` (`Settings`)
 
 ### 7. Configuração Dinâmica de Agentes MCP
-- **Arquivo:** `backend/config/mcp_agents.json` define agentes MCP, URLs, campos de relatório e mapeamentos.
-- **Carregamento:** `MCPConfigService.load_config` carrega o JSON na inicialização.
-- **Roteamento:** `MCPClientService.get_mcp_endpoint` seleciona a URL do MCP conforme `analysis_type`.
-- **Mapeamento de Relatórios:** `RedisSessionService.update_report` usa `report_mapping` para salvar relatórios no campo correto.
-- **Extensibilidade:** Novos agentes podem ser adicionados apenas editando o JSON.
+- Arquivo: `backend/config/mcp_agents.json` define agentes MCP, URLs, campos de relatório e mapeamentos.
+- Carregamento: `MCPConfigService.load_config` carrega o JSON na inicialização.
+- Roteamento: `MCPClientService.get_mcp_endpoint` seleciona a URL do MCP conforme `analysis_type`.
+- Mapeamento de Relatórios: `RedisSessionService.update_report` usa `report_mapping` para salvar relatórios no campo correto.
+- Extensibilidade: Novos agentes podem ser adicionados apenas editando o JSON.
 
 ### 8. Comunicação Backend ↔ MCP (Incluindo Webhooks)
-- **Descrição:** O backend envia payloads para o MCP (sempre com texto extraído, nunca URL). MCP responde com `job_id` e envia webhooks de progresso/conclusão, que atualizam relatórios na sessão Redis.
-- **Persistência do job_id:** Após receber o `job_id` do MCP no endpoint `/analysis/start`, o backend persiste imediatamente a relação `job_id -> session_id` no Redis, garantindo que, quando o webhook do MCP chegar, a sessão possa ser encontrada rapidamente usando o `job_id`.
-- **Busca do job_id no webhook:** O endpoint `/webhooks/mcp` recebe o webhook do MCP, busca a sessão correspondente usando o `job_id` persistido no Redis, e atualiza o relatório individual correspondente na sessão. Se o `job_id` não for encontrado, retorna 404 e loga o erro detalhadamente.
-- **Código:**
+- O backend envia payloads para o MCP (sempre com texto extraído, nunca URL). MCP responde com `job_id` e envia webhooks de progresso/conclusão, que atualizam relatórios na sessão Redis.
+- O campo `project_id` é criado no momento de criação do projeto e será reutilizado em toda interação no projeto. Toda comunicação com o MCP utiliza o `project_id` como identificador principal. O backend busca a sessão correspondente usando o `project_id` persistido no Redis. O `job_id` é apenas um identificador da execução no MCP, mas não é usado para buscar sessões no backend.
+- Código:
   - `backend/app/services/mcp_client_service.py` (`start_analysis`)
-  - `backend/app/services/redis_session_service.py` (`update_session_job_id`, `get_session_by_job_id`)
-  - `backend/app/api/analysis.py` (chama `update_session_job_id` após início da análise)
-  - `backend/app/api/webhooks.py` (busca sessão por `job_id` no webhook)
+  - `backend/app/services/redis_session_service.py` (`get_session_by_project_id`)
+  - `backend/app/api/analysis.py` (envio do project_id ao MCP)
+  - `backend/app/api/webhooks.py` (busca sessão por `project_id` no webhook)
 
 ### 9. Atualização de Relatórios e Propagação de Estado
-- **Descrição:** Relatórios são atualizados via endpoint ou webhook. Toda atualização aciona o salvamento automático do estado no Blob Storage. Cada relatório é salvo em seu campo individual (`epicos_report`, `features_report`, etc).
-- **Código:**
+- Relatórios são atualizados via endpoint ou webhook. Toda atualização aciona o salvamento automático do estado no Blob Storage. Cada relatório é salvo em seu campo individual (`epicos_report`, `features_report`, etc).
+- Código:
   - `backend/app/api/session.py` (`PUT /session/{session_id}/report`)
   - `backend/app/services/redis_session_service.py` (`update_report`, `update_session_on_state_change`)
 
 ### 10. Fluxo de Erro e Recuperação
-- **Descrição:** O sistema lida com falhas do MCP, Key Vault, Redis e Blob Storage, propagando erros padronizados para o frontend.
-- **Código:**
+- O sistema lida com falhas do MCP, Key Vault, Redis e Blob Storage, propagando erros padronizados para o frontend.
+- Código:
   - Handlers de exceção em todos os endpoints
   - `backend/app/services/startup_validator.py`
 
@@ -143,45 +141,40 @@ sequenceDiagram
     FE->>BE: POST /upload/docx (arquivo)
     BE->>BS: Salva arquivo
     BE->>BE: Extrai texto
-    BE->>RS: Cria sessão (com campos de relatório individuais)
+    BE->>RS: Cria sessão (com campos de relatório individuais e project_id)
     BE-->>FE: blob_url, texto extraído, session_id
-    FE->>BE: POST /analysis/start (projeto, analysis_type, session_id)
-    BE->>MCP: Envia payload (texto extraído)
-    MCP-->>BE: job_id
-    BE->>RS: Atualiza sessão (job_id) e persiste relação job_id -> session_id no Redis
+    FE->>BE: POST /analysis/start (projeto, analysis_type, project_id)
+    BE->>MCP: Envia payload (texto extraído, project_id)
+    MCP-->>BE: job_id, project_id
     BE->>BS: Salva estado inicial
     BE-->>FE: job_id, session_id, project_id
-
 
 ### 2. Fluxo de Projeto Existente
 mermaid
 sequenceDiagram
     FE->>BE: GET /projects/check
     BE->>BS: Busca estado
-    BE-->>FE: exists: true, state (com campos de relatório individuais)
-    FE->>BE: POST /analysis/start (sem upload)
-    BE->>RS: Restaura sessão do estado
-    BE->>MCP: Envia payload (texto extraído do estado)
-    MCP-->>BE: job_id
-    BE->>RS: Atualiza sessão (job_id) e persiste relação job_id -> session_id no Redis
+    BE-->>FE: exists: true, state (com campos de relatório individuais e project_id)
+    FE->>BE: POST /analysis/start (sem upload, com project_id)
+    BE->>RS: Restaura sessão do estado (com project_id)
+    BE->>MCP: Envia payload (texto extraído do estado, project_id)
+    MCP-->>BE: job_id, project_id
     BE->>BS: Salva estado
     BE-->>FE: job_id, session_id, project_id
-
 
 ### 3. Fluxo de Atualização de Relatório
 mermaid
 sequenceDiagram
-    MCP->>BE: Webhook (job_id, status, report_type, report_data)
-    BE->>RS: Busca sessão por job_id (usando relação persistida job_id -> session_id)
+    MCP->>BE: Webhook (job_id, project_id, status, report_type, report_data)
+    BE->>RS: Busca sessão por project_id (usando relação persistida project_id -> session_id)
     BE->>RS: Atualiza relatório individual na sessão (ex: epicos_report)
     BE->>BS: Salva estado
-
 
 ### 4. Fluxo de Erro e Recuperação
 mermaid
 sequenceDiagram
     BE->>MCP: start_analysis
-    MCP-->>BE: status: error, error_message
+    MCP-->>BE: status: error, error_message, project_id
     BE-->>FE: 502 Bad Gateway, detail
     BE->>KV: get_secret
     KV-->>BE: erro
@@ -190,16 +183,15 @@ sequenceDiagram
     RS-->>BE: erro
     BE-->>FE: 503 Service Unavailable, detail
 
-
 ---
 
 ## Integração com Múltiplos Key Vaults
 
-- **Arquitetura:** O backend suporta múltiplos Key Vaults (Azure, DevOps, GitHub, LLM), roteando segredos conforme o tipo via `AzureSecretManager` e `VaultType`.
-- **Mapeamento:** O mapeamento de segredos está documentado em `backend/docs/KEY_VAULT_SECRETS_MAPPING.md`.
-- **Carregamento:** O carregamento ocorre na inicialização via `ConfigLoaderService.load_secrets_from_key_vault`, com cache thread-safe para evitar chamadas repetidas.
-- **Fallback:** Se um segredo não for encontrado no Key Vault, o backend tenta variável de ambiente.
-- **Validação:** Campos obrigatórios são validados por `settings.validate_required_fields`.
+- O backend suporta múltiplos Key Vaults (Azure, DevOps, GitHub, LLM), roteando segredos conforme o tipo via `AzureSecretManager` e `VaultType`.
+- O mapeamento de segredos está documentado em `backend/docs/KEY_VAULT_SECRETS_MAPPING.md`.
+- O carregamento ocorre na inicialização via `ConfigLoaderService.load_secrets_from_key_vault`, com cache thread-safe para evitar chamadas repetidas.
+- Fallback: Se um segredo não for encontrado no Key Vault, o backend tenta variável de ambiente.
+- Validação: Campos obrigatórios são validados por `settings.validate_required_fields`.
 
 mermaid
 flowchart LR
@@ -211,16 +203,15 @@ flowchart LR
     AzureSecretManager -->|Fallback| EnvVars[Variáveis de Ambiente]
     AzureSecretManager -->|Seta no settings| Settings
 
-
 ---
 
 ## Configuração Dinâmica de Agentes MCP
 
-- **Arquivo:** `backend/config/mcp_agents.json` define agentes MCP, URLs, campos de relatório e mapeamentos.
-- **Carregamento:** `MCPConfigService.load_config` carrega o JSON na inicialização.
-- **Roteamento:** `MCPClientService.get_mcp_endpoint` seleciona a URL do MCP conforme `analysis_type`.
-- **Mapeamento de Relatórios:** `RedisSessionService.update_report` usa `report_mapping` para salvar relatórios no campo correto (campo individual).
-- **Extensibilidade:** Novos agentes podem ser adicionados apenas editando o JSON.
+- Arquivo: `backend/config/mcp_agents.json` define agentes MCP, URLs, campos de relatório e mapeamentos.
+- Carregamento: `MCPConfigService.load_config` carrega o JSON na inicialização.
+- Roteamento: `MCPClientService.get_mcp_endpoint` seleciona a URL do MCP conforme `analysis_type`.
+- Mapeamento de Relatórios: `RedisSessionService.update_report` usa `report_mapping` para salvar relatórios no campo correto (campo individual).
+- Extensibilidade: Novos agentes podem ser adicionados apenas editando o JSON.
 
 **Exemplo de configuração de agente:**
 
@@ -241,7 +232,6 @@ flowchart LR
   }
 }
 
-
 ---
 
 ## Observações
@@ -255,5 +245,5 @@ flowchart LR
 - Para ambientes com Redis em subrede privada, o App Service deve estar integrado à mesma VNET.
 - O sistema pode operar em modo de teste com autenticação mockada (`SKIP_AUTH_FOR_TESTING`), útil para desenvolvimento local.
 - Todos os exemplos de payload e resposta estão detalhados em `backend/docs/API_PAYLOAD_EXAMPLES.md`.
-- Após o início da análise, a relação job_id -> session_id é persistida no Redis para garantir que o webhook do MCP encontre a sessão correta.
+- Toda a comunicação com o MCP utiliza o project_id como identificador principal. O job_id é apenas um identificador da execução no MCP, mas não é usado para buscar sessões no backend.
 - Todos os relatórios são salvos em campos individuais (`epicos_report`, `features_report`, etc). Não existe mais a chave `reports` no estado do projeto ou sessão.


### PR DESCRIPTION
A documentação do fluxo arquitetural do backend foi revisada para esclarecer que o único identificador persistente e utilizado para integração com o MCP e gerenciamento de sessões é o project_id. Foram removidas todas as referências a last_mcp_job_id e session_id como identificadores de integração, alinhando a documentação à nova estratégia de identificação única do projeto.