### PR TITLE
Adição do campo nome_projeto no modelo ProjectListItem para suportar nome legível do projeto.

### DIFF
--- a/backend/app/models/project_models.py
+++ b/backend/app/models/project_models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 class ProjectListItem(BaseModel):
     projeto: str = Field(...)
+    nome_projeto: str = Field(...)
     analysis_type: Optional[str] = Field(None)
     created_at: Optional[datetime] = Field(None)
     last_saved_to_blob: Optional[datetime] = Field(None)


### PR DESCRIPTION
O modelo ProjectListItem foi modificado para incluir o campo nome_projeto, mantendo a compatibilidade com o campo projeto, para que o backend possa enviar o nome do projeto ao front enquanto opera internamente com project_id.