### PR TITLE
Atualização dos endpoints de sessão para garantir uso de project_id nas operações internas e inclusão de nome_projeto nas respostas.

### DIFF
--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -20,7 +20,9 @@ def get_session_reports(session_id: str):
             "features_report": session.features_report,
             "times_descricao_report": session.times_descricao_report,
             "alocacao_times_report": session.alocacao_times_report,
-            "premissas_riscos_report": session.premissas_riscos_report
+            "premissas_riscos_report": session.premissas_riscos_report,
+            "project_id": session.project_id,
+            "nome_projeto": session.projeto
         }
     except Exception as e:
         raise HTTPException(status_code=404, detail=f"Sessão não encontrada: {e}")
@@ -29,9 +31,11 @@ def get_session_reports(session_id: str):
 def update_session_report(session_id: str, req: UpdateReportRequest):
     redis_service = RedisSessionService()
     try:
-        redis_service.update_report(session_id, req.report_type, req.report_data)
+        session = redis_service.get_session(session_id)
+        project_id = session.project_id
+        redis_service.update_report(session_id, req.report_type, req.report_data, analysis_type=session.analysis_type)
         redis_service.update_session_on_state_change(session_id, {})
-        return {"status": "ok"}
+        return {"status": "ok", "project_id": project_id, "nome_projeto": session.projeto}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Erro ao atualizar relatório: {e}")
 
@@ -41,7 +45,7 @@ async def save_session_state(session_id: str):
     try:
         session = redis_service.get_session(session_id)
         url = await ProjectStateService.save_state_to_blob(session)
-        return {"blob_url": url}
+        return {"blob_url": url, "project_id": session.project_id, "nome_projeto": session.projeto}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao salvar estado: {e}")
 
@@ -50,6 +54,6 @@ def get_session_docx_files(session_id: str):
     redis_service = RedisSessionService()
     try:
         session = redis_service.get_session(session_id)
-        return {"docx_files": session.docx_files}
+        return {"docx_files": session.docx_files, "project_id": session.project_id, "nome_projeto": session.projeto}
     except Exception as e:
         raise HTTPException(status_code=404, detail=f"Sessão não encontrada: {e}")


### PR DESCRIPTION
Todos os endpoints de sessão agora garantem que as operações internas usam project_id (obtido da sessão). As respostas incluem tanto project_id quanto nome_projeto para manter consistência e facilitar o frontend.