### PR TITLE
Atualiza MCPClientService para usar project_id como identificador principal na comunicação com MCP e adiciona campo opcional nome_projeto no payload para log/debug.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -12,6 +12,7 @@ class MCPStartAnalysisPayload(BaseModel):
     comentario_usuario: Optional[str] = Field(None)
     usuario_executor: str = Field(...)
     project_id: str = Field(...)
+    nome_projeto: Optional[str] = Field(None)
 
     @validator('analysis_type')
     def analysis_type_must_not_be_empty(cls, v):
@@ -49,6 +50,9 @@ class MCPClientService:
                 payload_dict = payload.model_dump()
             else:
                 payload_dict = payload.dict()
+            # Garante que project_id está presente e é o identificador principal
+            if not payload_dict.get("project_id"):
+                raise Exception("project_id é obrigatório para comunicação com MCP")
             async with httpx.AsyncClient(timeout=60.0) as client:
                 response = await client.post(
                     url,


### PR DESCRIPTION
O método start_analysis foi modificado para exigir project_id obrigatório no payload, garantindo que toda comunicação com o MCP utilize project_id como identificador principal. O modelo MCPStartAnalysisPayload foi estendido para incluir o campo opcional nome_projeto, que é enviado apenas para fins de log/debug e não interfere na lógica principal.