### PR TITLE
Adiciona campo opcional nome_projeto ao modelo MCPStartAnalysisPayload para suportar logs e debug, mantendo project_id como identificador principal.

### DIFF
--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -8,6 +8,7 @@ class MCPStartAnalysisPayload(BaseModel):
     comentario_usuario: Optional[str] = Field(None, description="Comentário adicional enviado pelo usuário.")
     usuario_executor: str = Field(..., description="Usuário executor extraído do token JWT.")
     project_id: str = Field(..., description="Identificador único do projeto.")
+    nome_projeto: Optional[str] = Field(None, description="Nome legível do projeto (apenas para log/debug).")
 
     @validator('analysis_type')
     def analysis_type_must_not_be_empty(cls, v):


### PR DESCRIPTION
O modelo MCPStartAnalysisPayload foi atualizado para incluir o campo opcional nome_projeto, que permite enviar o nome legível do projeto para fins de log/debug sem impactar a lógica principal que utiliza project_id como identificador único do projeto.