### PR TITLE
Refatoração do modelo SessionData para remover session_id e job_id, adotando project_id como único identificador obrigatório.

### DIFF
--- a/backend/app/models/session_models.py
+++ b/backend/app/models/session_models.py
@@ -10,7 +10,6 @@ class SessionStep(BaseModel):
     metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
 class SessionData(BaseModel):
-    session_id: str = Field(...)
     usuario_executor: str = Field(...)
     projeto: str = Field(...)
     analysis_type: str = Field(...)
@@ -20,7 +19,7 @@ class SessionData(BaseModel):
     docx_files: List[str] = Field(default_factory=list)
     comentario_usuario: Optional[str] = Field(default=None)
     extracted_text: Optional[str] = Field(default=None)
-    project_id: Optional[str] = Field(default=None)
+    project_id: str = Field(...)
     epicos_report: Optional[Any] = Field(default=None)
     features_report: Optional[Any] = Field(default=None)
     times_descricao_report: Optional[Any] = Field(default=None)
@@ -55,7 +54,6 @@ class SessionData(BaseModel):
                 return legacy_reports[field]
             return None
         return cls(
-            session_id=state.get("session_id", ""),
             usuario_executor=state.get("usuario_executor", ""),
             projeto=state.get("projeto", ""),
             analysis_type=state.get("analysis_type", ""),


### PR DESCRIPTION
O modelo SessionData foi ajustado para eliminar o campo session_id, tornando project_id o único identificador obrigatório. Métodos to_project_state e from_project_state foram atualizados para refletir essa mudança, garantindo que o estado do projeto seja manipulado exclusivamente via project_id.