### PR TITLE
Atualização dos endpoints para usar project_id como identificador principal e converter nome do projeto para project_id internamente.

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -16,12 +16,10 @@ async def check_project(
     usuario_executor = _extract_usuario_executor(current_user)
     logger.info(f"Verificando existência do projeto '{projeto}' para usuario_executor='{usuario_executor}'")
     try:
-        # Busca o project_id correspondente ao nome do projeto
         project_id = await ProjectStateService._get_project_id_by_name(usuario_executor, projeto)
         if not project_id:
             logger.info(f"Projeto '{projeto}' NÃO encontrado para usuario_executor='{usuario_executor}'.")
             return {"exists": False}
-        # Carrega o estado usando o project_id
         state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, project_id=project_id)
         if state:
             state.pop("analysis_name", None)
@@ -41,7 +39,6 @@ async def check_project(
 async def list_projects(current_user: dict = Depends(get_current_user)):
     usuario_executor = _extract_usuario_executor(current_user)
     projects = await ProjectStateService._fetch_and_sanitize_projects(usuario_executor)
-    # Garante que cada item tenha project_id e nome_projeto
     for p in projects:
         if "nome_projeto" not in p:
             p["nome_projeto"] = p.get("projeto", "")


### PR DESCRIPTION
Os endpoints de verificação e listagem de projetos foram ajustados para buscar o project_id correspondente ao nome do projeto recebido do frontend. Toda a lógica e resposta utilizam project_id como identificador único, retornando também o nome do projeto para o frontend.