### PR TITLE
Refatoração dos endpoints para usar project_id como identificador único, removendo session_id e job_id do fluxo.

### DIFF
--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -10,11 +10,11 @@ class UpdateReportRequest(BaseModel):
     report_type: str
     report_data: Any
 
-@router.get("/{session_id}/reports")
-def get_session_reports(session_id: str):
+@router.get("/project/{project_id}/reports")
+def get_project_reports(project_id: str):
     redis_service = RedisSessionService()
     try:
-        session = redis_service.get_session(session_id)
+        session = redis_service.get_session_by_project_id(project_id)
         return {
             "epicos_report": session.epicos_report,
             "features_report": session.features_report,
@@ -25,35 +25,34 @@ def get_session_reports(session_id: str):
             "nome_projeto": session.projeto
         }
     except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Sessão não encontrada: {e}")
+        raise HTTPException(status_code=404, detail=f"Projeto não encontrado: {e}")
 
-@router.put("/{session_id}/report")
-def update_session_report(session_id: str, req: UpdateReportRequest):
+@router.put("/project/{project_id}/report")
+def update_project_report(project_id: str, req: UpdateReportRequest):
     redis_service = RedisSessionService()
     try:
-        session = redis_service.get_session(session_id)
-        project_id = session.project_id
-        redis_service.update_report(session_id, req.report_type, req.report_data, analysis_type=session.analysis_type)
-        redis_service.update_session_on_state_change(session_id, {})
+        session = redis_service.get_session_by_project_id(project_id)
+        redis_service.update_report(project_id, req.report_type, req.report_data, analysis_type=session.analysis_type)
+        redis_service.update_session_on_state_change(project_id, {})
         return {"status": "ok", "project_id": project_id, "nome_projeto": session.projeto}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Erro ao atualizar relatório: {e}")
 
-@router.post("/{session_id}/save-state")
-async def save_session_state(session_id: str):
+@router.post("/project/{project_id}/save-state")
+async def save_project_state(project_id: str):
     redis_service = RedisSessionService()
     try:
-        session = redis_service.get_session(session_id)
+        session = redis_service.get_session_by_project_id(project_id)
         url = await ProjectStateService.save_state_to_blob(session)
         return {"blob_url": url, "project_id": session.project_id, "nome_projeto": session.projeto}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao salvar estado: {e}")
 
-@router.get("/{session_id}/docx-files")
-def get_session_docx_files(session_id: str):
+@router.get("/project/{project_id}/docx-files")
+def get_project_docx_files(project_id: str):
     redis_service = RedisSessionService()
     try:
-        session = redis_service.get_session(session_id)
+        session = redis_service.get_session_by_project_id(project_id)
         return {"docx_files": session.docx_files, "project_id": session.project_id, "nome_projeto": session.projeto}
     except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Sessão não encontrada: {e}")
+        raise HTTPException(status_code=404, detail=f"Projeto não encontrado: {e}")


### PR DESCRIPTION
Todos os endpoints relacionados a sessões e relatórios foram alterados para utilizar project_id no path e nas operações internas. session_id foi completamente removido do fluxo, garantindo que project_id seja a única identificação usada. As respostas incluem project_id e nome_projeto para o frontend.