### PR TITLE
Refatoração do serviço MCP Client para uso exclusivo de project_id na comunicação com o MCP Server.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -21,7 +21,7 @@ class MCPStartAnalysisPayload(BaseModel):
         return v
 
 class MCPStartAnalysisResponse(BaseModel):
-    job_id: str
+    project_id: str
 
 class MCPClientService:
     def __init__(self, base_url: str = None):
@@ -50,7 +50,6 @@ class MCPClientService:
                 payload_dict = payload.model_dump()
             else:
                 payload_dict = payload.dict()
-            # Garante que project_id está presente e é o identificador principal
             if not payload_dict.get("project_id"):
                 raise Exception("project_id é obrigatório para comunicação com MCP")
             async with httpx.AsyncClient(timeout=60.0) as client:
@@ -63,7 +62,7 @@ class MCPClientService:
                     logging.error(f"❌ [MCP Client] Erro {response.status_code}: {response.text}")
                 response.raise_for_status()
                 data = response.json()
-                return MCPStartAnalysisResponse(**data)
+                return MCPStartAnalysisResponse(project_id=data.get("project_id", payload.project_id))
         except httpx.HTTPStatusError as exc:
             raise Exception(f"Erro ao comunicar com MCP Server: {exc.response.status_code} - {exc.response.text}")
         except Exception as exc:


### PR DESCRIPTION
O serviço MCP Client foi modificado para garantir que project_id seja o único identificador enviado e recebido na comunicação com o MCP Server. O campo job_id foi removido da resposta e da lógica interna. A validação e envio do payload consideram apenas project_id como identificador principal, alinhando-se à estratégia de unificação dos identificadores.