### PR TITLE
Atualização dos modelos para remover session_id e job_id, garantindo que project_id seja o único identificador. Inclusão do campo nome_projeto para facilitar comunicação com o front-end.

### DIFF
--- a/backend/app/models/docx_models.py
+++ b/backend/app/models/docx_models.py
@@ -4,6 +4,6 @@ from pydantic import BaseModel, Field
 class UploadDocxResponse(BaseModel):
     message: str = Field(..., description="Mensagem de status do upload.")
     blob_url: str = Field(..., description="URL do arquivo salvo no blob storage.")
-    job_id: str = Field(..., description="Identificador do job relacionado ao upload.")
-    session_id: Optional[str] = Field(None, description="ID da sessão criada no Redis.")
     extracted_text: Optional[str] = Field(None, description="Texto extraído do documento DOCX.")
+    project_id: str = Field(..., description="Identificador único do projeto.")
+    nome_projeto: Optional[str] = Field(None, description="Nome legível do projeto.")

--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -17,4 +17,4 @@ class MCPStartAnalysisPayload(BaseModel):
         return v
 
 class MCPStartAnalysisResponse(BaseModel):
-    job_id: str = Field(..., description="Identificador do job criado no MCP.")
+    project_id: str = Field(..., description="Identificador único do projeto.")


### PR DESCRIPTION
Os modelos UploadDocxResponse e MCPStartAnalysisResponse foram modificados para remover session_id e job_id, mantendo apenas project_id como identificador principal. O payload MCPStartAnalysisPayload mantém o nome do projeto para entrada, mas inclui project_id para uso interno, com nome_projeto opcional para logs e respostas.