### PR TITLE
Refatoração do BackgroundStateSaver para operar exclusivamente com project_id, removendo qualquer uso de session_id ou job_id.

### DIFF
--- a/backend/app/services/background_state_saver.py
+++ b/backend/app/services/background_state_saver.py
@@ -9,25 +9,25 @@ class BackgroundStateSaver:
     _logger = logging.getLogger("BackgroundStateSaver")
 
     @classmethod
-    def schedule_periodic_save(cls, session_id: str, interval_minutes: int = None):
-        if session_id in cls._tasks:
+    def schedule_periodic_save(cls, project_id: str, interval_minutes: int = None):
+        if project_id in cls._tasks:
             return
         interval = interval_minutes or cls._interval_minutes
         loop = asyncio.get_event_loop()
-        task = loop.create_task(cls._periodic_save(session_id, interval))
-        cls._tasks[session_id] = task
+        task = loop.create_task(cls._periodic_save(project_id, interval))
+        cls._tasks[project_id] = task
 
     @classmethod
-    async def _periodic_save(cls, session_id: str, interval_minutes: int):
+    async def _periodic_save(cls, project_id: str, interval_minutes: int):
         from backend.app.services.redis_session_service import RedisSessionService
         redis_service = RedisSessionService()
         while True:
             try:
-                session_data = redis_service.get_session(session_id)
+                session_data = redis_service.get_session_by_project_id(project_id)
                 url = await ProjectStateService.save_state_to_blob(session_data)
                 session_data.last_saved_to_blob = None
-                redis_service.update_session_status(session_id, 'saved')
-                cls._logger.info(f"Estado da sessão {session_id} salvo no Blob: {url}")
+                redis_service.update_session_status(project_id, 'saved')
+                cls._logger.info(f"Estado do projeto {project_id} salvo no Blob: {url}")
             except Exception as e:
-                cls._logger.error(f"Erro ao salvar estado da sessão {session_id} no Blob: {e}")
+                cls._logger.error(f"Erro ao salvar estado do projeto {project_id} no Blob: {e}")
             await asyncio.sleep(interval_minutes * 60)


### PR DESCRIPTION
O serviço BackgroundStateSaver foi ajustado para usar apenas project_id como identificador para agendamento e salvamento periódico do estado do projeto. Isso inclui chamadas para obter e atualizar o estado no Redis e salvar no Blob Storage, garantindo coerência com a nova política de identificação única.