### PR TITLE
Atualização completa da documentação e exemplos para uso exclusivo de project_id como identificador principal, removendo session_id e job_id.

### DIFF
--- a/backend/docs/API_PAYLOAD_EXAMPLES.md
+++ b/backend/docs/API_PAYLOAD_EXAMPLES.md
@@ -91,8 +91,6 @@ comentario_usuario=Comentário opcional
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
   "message": "Arquivo processado com sucesso. Pronto para análise. (Upload opcional para projetos existentes)",
-  "session_id": "ghijkl-uuid",
-  "job_id": "ghijkl-uuid",
   "project_id": "projeto-uuid-123",
   "nome_projeto": "ProjetoNovo"
 }
@@ -147,18 +145,16 @@ Content-Type: application/json
 **Resposta:**
 
 { 
-  "job_id": "123456",
   "message": "Análise solicitada com sucesso ao agente.",
-  "session_id": "abcdef-uuid",
   "project_id": "projeto-uuid-123",
   "nome_projeto": "ProjetoNovo"
 }
 
-### 1.5 Atualização de Relatório (PUT /session/{session_id}/report)
+### 1.5 Atualização de Relatório (PUT /session/project/{project_id}/report)
 
 **Requisição:**
 
-PUT /session/abcdef-uuid/report HTTP/1.1
+PUT /session/project/projeto-uuid-123/report HTTP/1.1
 Authorization: Bearer <token>
 Content-Type: application/json
 
@@ -175,11 +171,11 @@ Content-Type: application/json
   "nome_projeto": "ProjetoNovo"
 }
 
-### 1.6 Consulta de Relatórios (GET /session/{session_id}/reports)
+### 1.6 Consulta de Relatórios (GET /session/project/{project_id}/reports)
 
 **Requisição:**
 
-GET /session/abcdef-uuid/reports HTTP/1.1
+GET /session/project/projeto-uuid-123/reports HTTP/1.1
 Authorization: Bearer <token>
 
 **Resposta:**
@@ -322,6 +318,7 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
       "tech_debt": [
         { "id": 1, "descricao": "Código duplicado" }
       ]
+    ]
     }
     
 
@@ -368,9 +365,7 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
 **Sucesso:**
 
 { 
-  "job_id": "123456",
   "message": "Análise solicitada com sucesso ao agente.",
-  "session_id": "abcdef-uuid",
   "project_id": "projeto-uuid-123",
   "nome_projeto": "ProjetoNovo"
 }
@@ -381,7 +376,7 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
   "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): Tempo limite excedido ao processar análise."
 }
 
-### 3.2 /session/{session_id}/reports
+### 3.2 /session/project/{project_id}/reports
 **Sucesso:**
 
 { 
@@ -466,13 +461,11 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
   "message": "Arquivo processado com sucesso. Pronto para análise. (Upload opcional para projetos existentes)",
-  "session_id": "ghijkl-uuid",
-  "job_id": "ghijkl-uuid",
   "project_id": "projeto-uuid-123",
   "nome_projeto": "ProjetoNovo"
 }
 
-### 3.6 /session/{session_id}/report (atualização de relatório)
+### 3.6 /session/project/{project_id}/report (atualização de relatório)
 **Sucesso:**
 
 { 
@@ -487,7 +480,7 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
   "detail": "Erro ao atualizar relatório: ..."
 }
 
-### 3.7 /session/{session_id}/save-state
+### 3.7 /session/project/{project_id}/save-state
 **Sucesso:**
 
 { 
@@ -502,7 +495,7 @@ O MCP deve garantir que o campo principal de `report_data` corresponda ao mapeam
   "detail": "Erro ao salvar estado: ..."
 }
 
-### 3.8 /session/{session_id}/docx-files
+### 3.8 /session/project/{project_id}/docx-files
 **Sucesso:**
 
 { 
@@ -593,8 +586,6 @@ Resposta:
   "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
   "extracted_text": "Texto extraído do DOCX da reunião",
   "message": "Arquivo processado com sucesso. Pronto para análise. (Upload opcional para projetos existentes)",
-  "session_id": "ghijkl-uuid",
-  "job_id": "ghijkl-uuid",
   "project_id": "projeto-uuid-123",
   "nome_projeto": "ProjetoNovo"
 }
@@ -614,9 +605,7 @@ Authorization: Bearer <token>
 Resposta:
 
 { 
-  "job_id": "123456",
   "message": "Análise solicitada com sucesso ao agente.",
-  "session_id": "abcdef-uuid",
   "project_id": "projeto-uuid-123",
   "nome_projeto": "ProjetoNovo"
 }
@@ -646,7 +635,7 @@ Resposta:
 
 ### 7. Consulta de Relatórios
 
-GET /session/abcdef-uuid/reports
+GET /session/project/projeto-uuid-123/reports
 Authorization: Bearer <token>
 
 Resposta:
@@ -663,7 +652,7 @@ Resposta:
 
 ### 8. Salvamento Manual de Estado
 
-POST /session/abcdef-uuid/save-state
+POST /session/project/projeto-uuid-123/save-state
 Authorization: Bearer <token>
 
 Resposta:


### PR DESCRIPTION
Atualizados todos os exemplos de payload e resposta para refletir a nova arquitetura onde project_id é o único identificador usado para operações de estado e comunicação com MCP. Removidas referências a session_id e job_id em payloads, respostas, webhooks e fluxos de comunicação. Documentação detalha o fluxo de conversão do nome do projeto para project_id e o retorno do nome do projeto para o frontend.