### PR TITLE
Padronização do formato report_data no webhook MCP e atualização direta dos campos de relatório no estado do projeto no Redis.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -22,19 +22,17 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
             raise HTTPException(status_code=404, detail=f"Sessão não encontrada para project_id: {payload.project_id}")
         analysis_type = getattr(session, "analysis_type", None)
         if payload.status in {"in_progress", "done"}:
-            if not payload.report_type:
-                logger.error(f"Webhook sem report_type para project_id {payload.project_id}")
-                raise HTTPException(status_code=400, detail="report_type é obrigatório quando status é 'in_progress' ou 'done'")
-            if not validate_report_data_structure(payload.report_type, payload.report_data, analysis_type):
-                logger.error(f"Estrutura de report_data inválida para report_type '{payload.report_type}', analysis_type '{analysis_type}' e project_id '{payload.project_id}'")
-                raise HTTPException(status_code=400, detail=f"Estrutura de report_data inválida para report_type '{payload.report_type}' e analysis_type '{analysis_type}'")
+            if not payload.report_data or not isinstance(payload.report_data, dict) or len(payload.report_data) != 1:
+                logger.error(f"Webhook com report_data inválido para project_id {payload.project_id}")
+                raise HTTPException(status_code=400, detail="report_data deve ser um dicionário com exatamente uma chave de relatório.")
+            if not validate_report_data_structure(payload.report_data, analysis_type):
+                logger.error(f"Estrutura de report_data inválida para analysis_type '{analysis_type}' e project_id '{payload.project_id}'")
+                raise HTTPException(status_code=400, detail=f"Estrutura de report_data inválida para analysis_type '{analysis_type}'")
             redis_service.update_report(
                 payload.project_id,
-                payload.report_type,
-                payload.report_data,
-                analysis_type=analysis_type
+                payload.report_data
             )
-            logger.info(f"Relatório '{payload.report_type}' atualizado para sessão (project_id={payload.project_id}, nome_projeto={session.projeto})")
+            logger.info(f"Relatório atualizado para sessão (project_id={payload.project_id}, nome_projeto={session.projeto})")
         elif payload.status == "error":
             logger.error(f"Webhook de erro recebido: job_id={payload.job_id}, error_type={payload.error_type}, error_message={payload.error_message}")
         return {"status": "ok", "project_id": payload.project_id, "nome_projeto": session.projeto}

--- a/backend/app/models/mcp_webhook_models.py
+++ b/backend/app/models/mcp_webhook_models.py
@@ -1,14 +1,14 @@
 from pydantic import BaseModel, Field, validator
-from typing import Optional, Any, Literal
+from typing import Optional, Any, Literal, Dict
 
 class MCPWebhookPayload(BaseModel):
     job_id: str = Field(...)
     status: Literal['in_progress', 'done', 'error'] = Field(...)
     progress: Optional[int] = Field(None)
-    report_type: Optional[str] = Field(None)
-    report_data: Optional[Any] = Field(None)
+    report_data: Optional[Dict[str, Any]] = Field(None)
     error_type: Optional[str] = Field(None)
     error_message: Optional[str] = Field(None)
+    project_id: Optional[str] = Field(None)
 
     @validator('status')
     def status_must_be_valid(cls, v):
@@ -21,10 +21,11 @@ class MCPWebhookPayload(BaseModel):
     def report_data_required_for_status(cls, v, values):
         status = values.get('status')
         if status in {'in_progress', 'done'}:
-            if v is None:
-                raise ValueError("report_data é obrigatório quando status é 'in_progress' ou 'done'")
-            if not isinstance(v, dict):
-                raise ValueError("report_data deve ser um dicionário")
+            if v is None or not isinstance(v, dict) or len(v) != 1:
+                raise ValueError("report_data deve ser um dicionário com exatamente uma chave quando status é 'in_progress' ou 'done'")
+            key = list(v.keys())[0]
+            if not isinstance(v[key], list):
+                raise ValueError("O valor da chave de report_data deve ser uma lista")
         return v
 
     @validator('error_message', always=True)

--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -83,24 +83,16 @@ class RedisSessionService:
         session_data["status"] = status
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
 
-    def update_report(self, project_id: str, report_type: str, report_data: Any, analysis_type: Optional[str] = None):
+    def update_report(self, project_id: str, report_data: Dict[str, Any]):
         key = f"project:{project_id}"
         session_json = self.redis_client.get(key)
         if not session_json:
             raise ValueError(f"Projeto {project_id} não encontrado no Redis.")
         session_data = self._deserialize_session(session_json)
-        analysis_type_in_session = session_data.get("analysis_type")
-        analysis_type = analysis_type or analysis_type_in_session
-        report_field = None
-        if hasattr(settings, "mcp_config_registry") and settings.mcp_config_registry and hasattr(settings.mcp_config_registry, "agents") and analysis_type in settings.mcp_config_registry.agents:
-            agent_cfg = settings.mcp_config_registry.agents[analysis_type]
-            if hasattr(agent_cfg, "report_mapping") and report_type in agent_cfg.report_mapping:
-                report_field = agent_cfg.report_mapping[report_type]
-        if not report_field:
-            report_field = f"{report_type}_report"
-        if "reports" not in session_data or not isinstance(session_data["reports"], dict):
-            session_data["reports"] = {}
-        session_data["reports"][report_field] = report_data
+        if not isinstance(report_data, dict) or len(report_data) != 1:
+            raise ValueError("report_data deve ser um dicionário com exatamente uma chave de relatório")
+        for report_field, value in report_data.items():
+            session_data[report_field] = value
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
 
     def restore_session_from_state(self, usuario_executor: str, projeto: str, analysis_type: str, project_state: Dict[str, Any]) -> str:


### PR DESCRIPTION
O modelo MCPWebhookPayload foi ajustado para aceitar report_data como um dicionário com exatamente uma chave, cujo valor é uma lista. O serviço RedisSessionService foi modificado para atualizar diretamente o campo correspondente no estado da sessão com base na chave única presente em report_data. A API do webhook MCP valida e processa report_data conforme esse padrão, garantindo que o backend e MCP estejam alinhados na estrutura e atualização dos relatórios.