### PR TITLE
Validação do formato report_data para garantir que é um dicionário com uma única chave válida de relatório e que o valor é uma lista.

### DIFF
--- a/backend/app/utils/webhook_validator.py
+++ b/backend/app/utils/webhook_validator.py
@@ -1,28 +1,27 @@
 import logging
 from backend.app.core.config import settings
 
-def validate_report_data_structure(report_type: str, report_data: dict, analysis_type: str) -> bool:
+def validate_report_data_structure(report_data: dict, analysis_type: str) -> bool:
     logger = logging.getLogger("webhook_validator")
+    valid_report_fields = [
+        "epicos_report",
+        "features_report",
+        "times_descricao_report",
+        "alocacao_times_report",
+        "premissas_riscos_report"
+    ]
     if not isinstance(report_data, dict):
         logger.error(f"report_data não é um dicionário: {type(report_data)}")
         return False
-    mcp_config_registry = getattr(settings, "mcp_config_registry", None)
-    if not mcp_config_registry or not hasattr(mcp_config_registry, "agents"):
-        logger.warning("mcp_config_registry não está configurado corretamente. Validação ignorada.")
-        return True
-    agents = mcp_config_registry.agents
-    if analysis_type not in agents:
-        logger.warning(f"analysis_type '{analysis_type}' não encontrado em mcp_config_registry. Validação ignorada.")
-        return True
-    agent_cfg = agents[analysis_type]
-    if not hasattr(agent_cfg, "report_mapping"):
-        logger.warning(f"Agent config para '{analysis_type}' não possui report_mapping. Validação ignorada.")
-        return True
-    expected_field = agent_cfg.report_mapping.get(report_type)
-    if not expected_field:
-        logger.warning(f"report_type '{report_type}' não mapeado para analysis_type '{analysis_type}'. Validação ignorada.")
-        return True
-    if expected_field not in report_data:
-        logger.error(f"Campo '{expected_field}' ausente em report_data para report_type '{report_type}' e analysis_type '{analysis_type}'.")
+    if len(report_data) != 1:
+        logger.error(f"report_data deve conter exatamente uma chave, recebido: {list(report_data.keys())}")
+        return False
+    report_field = list(report_data.keys())[0]
+    if report_field not in valid_report_fields:
+        logger.error(f"Chave de relatório '{report_field}' não é válida. Esperado uma das: {valid_report_fields}")
+        return False
+    value = report_data[report_field]
+    if not isinstance(value, list):
+        logger.error(f"O valor da chave '{report_field}' deve ser uma lista.")
         return False
     return True


### PR DESCRIPTION
A função validate_report_data_structure foi adaptada para validar que o report_data recebido do MCP é um dicionário contendo exatamente uma chave dentre as permitidas (epicos_report, features_report, times_descricao_report, alocacao_times_report, premissas_riscos_report) e que o valor associado é uma lista. Essa validação assegura a conformidade com o padrão único de resposta do MCP e evita erros na atualização do estado do projeto.