### PR TITLE
Refatoração do ProjectStateService para adequar o estado do projeto às novas regras de negócio e integração com MCP.

### DIFF
--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -12,11 +12,13 @@ class ProjectStateService:
         usuario_executor = state.get("usuario_executor")
         projeto = state.get("projeto")
         project_id = state.get("project_id")
-        nome_projeto = state.get("nome_projeto") or projeto
-        state["project_id"] = project_id
-        state["nome_projeto"] = nome_projeto
-        state["docx_blob_url"] = state.get("docx_blob_url")
         timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        # Atualiza last_saved_to_blob para o momento do salvamento
+        state["last_saved_to_blob"] = datetime.datetime.utcnow().isoformat()
+        # Remove campos obsoletos do estado antes de salvar
+        state.pop("nome_projeto", None)
+        state.pop("comentario_usuario", None)
+        state.pop("docx_blob_url", None)
         blob_folder = f"{usuario_executor}/{projeto}/estados"
         blob_filename = f"estado_{timestamp}.json"
         blob_path = f"{blob_folder}/{blob_filename}"
@@ -38,6 +40,10 @@ class ProjectStateService:
                     state_bytes = blob_client.download_blob().readall()
                     state = json.loads(state_bytes.decode("utf-8"))
                     if state.get("project_id") == project_id:
+                        # Remove campos obsoletos do estado carregado
+                        state.pop("nome_projeto", None)
+                        state.pop("comentario_usuario", None)
+                        state.pop("docx_blob_url", None)
                         logger.info(f"Estado carregado com sucesso para usuario_executor={usuario_executor}, project_id={project_id}")
                         return state
             logger.info(f"Nenhum estado encontrado para usuario_executor={usuario_executor}, project_id={project_id}")
@@ -92,16 +98,17 @@ class ProjectStateService:
                 blob_client = container_client.get_blob_client(latest_blob.name)
                 state_bytes = blob_client.download_blob().readall()
                 state = json.loads(state_bytes.decode("utf-8"))
+                # Remove campos obsoletos do estado carregado
+                state.pop("nome_projeto", None)
+                state.pop("comentario_usuario", None)
+                state.pop("docx_blob_url", None)
                 item = {
                     "projeto": state.get("projeto", projeto),
-                    "nome_projeto": state.get("nome_projeto", projeto),
                     "analysis_type": state.get("analysis_type"),
                     "created_at": state.get("created_at"),
                     "last_saved_to_blob": state.get("last_saved_to_blob"),
                     "project_id": state.get("project_id"),
-                    "docx_blob_url": state.get("docx_blob_url"),
                     "docx_files": state.get("docx_files", []),
-                    "comentario_usuario": state.get("comentario_usuario"),
                     "extracted_text": state.get("extracted_text"),
                     "epicos_report": state.get("epicos_report"),
                     "features_report": state.get("features_report"),
@@ -122,6 +129,9 @@ class ProjectStateService:
             if isinstance(p, dict):
                 p = dict(p)
                 p.pop("analysis_name", None)
+                p.pop("nome_projeto", None)
+                p.pop("comentario_usuario", None)
+                p.pop("docx_blob_url", None)
                 if "project_id" not in p or not p["project_id"]:
                     continue
                 sanitized.append(p)


### PR DESCRIPTION
Este PR ajusta os métodos save_state_to_blob e load_latest_state_from_blob para remover os campos nome_projeto, comentario_usuario e docx_blob_url do estado salvo e carregado. Garante que last_saved_to_blob seja atualizado com o timestamp exato do salvamento no blob storage. Ajusta docx_files para armazenar URLs dos arquivos docx enviados pelo usuário. Implementa a lógica para atualizar apenas o relatório específico recebido do MCP (epicos_report, features_report, times_descricao_report, alocacao_times_report ou premissas_riscos_report), preservando os demais relatórios no estado atual do projeto. Remove a variável report do estado de sessão, substituindo-a pelos relatórios específicos. Comentario_usuario permanece apenas no payload de comunicação entre front-end, back-end e MCP, não sendo salvo no estado.