### PR TITLE
Atualização do endpoint POST /webhooks/mcp para atualização cirúrgica dos relatórios individuais do estado do projeto.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -31,9 +31,7 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
                 raise HTTPException(status_code=400, detail=f"Estrutura de report_data inválida para analysis_type '{analysis_type}'")
             report_field = list(payload.report_data.keys())[0]
             report_value = payload.report_data[report_field]
-            session_dict = session.dict()
-            session_dict[report_field] = report_value
-            redis_service.update_report(payload.project_id, payload.report_data)
+            redis_service.update_report(payload.project_id, {report_field: report_value})
             logger.info(f"Relatório atualizado para sessão (project_id={payload.project_id}, nome_projeto={session.nome_projeto})")
             await ProjectStateService.save_state_to_blob(session)
         elif payload.status == "error":


### PR DESCRIPTION
O webhook agora atualiza apenas o campo de relatório específico recebido no report_data, sem sobrescrever outros campos do estado do projeto. Mantém salvamento automático no Blob Storage. Valida que report_data contenha exatamente um relatório e que sua estrutura seja válida para o analysis_type.