### PR TITLE
Atualização dos endpoints de sessão para retornar e atualizar relatórios individuais e remover chaves obsoletas do estado.

### DIFF
--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -15,7 +15,19 @@ def get_project_reports(project_id: str):
     try:
         session = redis_service.get_session_by_project_id(project_id)
         state = session.to_project_state()
-        return state
+        state.pop("projeto", None)
+        state.pop("comentario_usuario", None)
+        state.pop("docx_blob_url", None)
+        reports = {
+            "epicos_report": state.get("epicos_report"),
+            "features_report": state.get("features_report"),
+            "times_descricao_report": state.get("times_descricao_report"),
+            "alocacao_times_report": state.get("alocacao_times_report"),
+            "premissas_riscos_report": state.get("premissas_riscos_report"),
+            "project_id": state.get("project_id"),
+            "nome_projeto": state.get("nome_projeto")
+        }
+        return reports
     except Exception as e:
         raise HTTPException(status_code=404, detail=f"Projeto não encontrado: {e}")
 
@@ -23,10 +35,12 @@ def get_project_reports(project_id: str):
 def update_project_report(project_id: str, req: UpdateReportRequest):
     redis_service = RedisSessionService()
     try:
+        if not req.report_data or not isinstance(req.report_data, dict) or len(req.report_data) != 1:
+            raise HTTPException(status_code=400, detail="report_data deve ser um dicionário com exatamente uma chave de relatório.")
         redis_service.update_report(project_id, req.report_data)
         redis_service.update_session_on_state_change(project_id, {})
         session = redis_service.get_session_by_project_id(project_id)
-        return {"status": "ok", "project_id": project_id, "nome_projeto": session.projeto}
+        return {"status": "ok", "project_id": project_id, "nome_projeto": session.nome_projeto}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Erro ao atualizar relatório: {e}")
 
@@ -36,7 +50,7 @@ async def save_project_state(project_id: str):
     try:
         session = redis_service.get_session_by_project_id(project_id)
         url = await ProjectStateService.save_state_to_blob(session)
-        return {"blob_url": url, "project_id": session.project_id, "nome_projeto": session.projeto}
+        return {"blob_url": url, "project_id": session.project_id, "nome_projeto": session.nome_projeto}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erro ao salvar estado: {e}")
 
@@ -45,6 +59,6 @@ def get_project_docx_files(project_id: str):
     redis_service = RedisSessionService()
     try:
         session = redis_service.get_session_by_project_id(project_id)
-        return {"docx_files": session.docx_files, "project_id": session.project_id, "nome_projeto": session.projeto}
+        return {"docx_files": session.docx_files, "project_id": session.project_id, "nome_projeto": session.nome_projeto}
     except Exception as e:
         raise HTTPException(status_code=404, detail=f"Projeto não encontrado: {e}")


### PR DESCRIPTION
O endpoint GET /session/project/{project_id}/reports retorna apenas os campos individuais de relatório, project_id e nome_projeto, removendo chaves obsoletas. O endpoint PUT /session/project/{project_id}/report aceita apenas um campo de relatório por vez e atualiza de forma cirúrgica, evitando sobrescrever outros relatórios. Também há endpoints para salvar estado e obter arquivos DOCX associados.