### PR TITLE
Ajuste no endpoint de login para remover chaves obsoletas do estado dos projetos retornados e garantir a presença do campo nome_projeto.

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -40,6 +40,10 @@ async def auth_login(current_user: dict = Depends(get_current_user)):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não autenticado.")
     projects = await ProjectStateService._fetch_and_sanitize_projects(usuario_executor)
     for p in projects:
+        # Remove chaves obsoletas
+        p.pop("projeto", None)
+        p.pop("comentario_usuario", None)
+        p.pop("docx_blob_url", None)
         if "nome_projeto" not in p:
             p["nome_projeto"] = p.get("projeto", "")
         if "project_id" not in p:


### PR DESCRIPTION
O endpoint POST /auth/login foi modificado para garantir que cada projeto na lista de projetos do usuário remova as chaves 'projeto', 'comentario_usuario' e 'docx_blob_url'. Além disso, assegura que o campo 'nome_projeto' esteja presente para comunicação consistente com o frontend.