### PR TITLE
Atualização da documentação para refletir a nova estrutura do estado do projeto e exemplos de payloads e respostas atualizados.

### DIFF
--- a/backend/docs/API_PAYLOAD_EXAMPLES.md
+++ b/backend/docs/API_PAYLOAD_EXAMPLES.md
@@ -26,7 +26,6 @@ Content-Type: application/json
   },
   "projects": [
     { 
-      "projeto": "ProjetoNovo",
       "nome_projeto": "ProjetoNovo",
       "analysis_type": "criacao_epicos_azure_devops",
       "created_at": "2024-06-01T12:00:00Z",
@@ -40,7 +39,7 @@ Content-Type: application/json
 
 **Requisição:**
 
-GET /projects/check?projeto=ProjetoNovo HTTP/1.1
+GET /projects/check?nome_projeto=ProjetoNovo HTTP/1.1
 Authorization: Bearer <token>
 
 **Resposta (projeto encontrado):**
@@ -49,18 +48,16 @@ Authorization: Bearer <token>
   "exists": true,
   "state": { 
     "usuario_executor": "user@example.com",
-    "projeto": "ProjetoNovo",
     "nome_projeto": "ProjetoNovo",
     "analysis_type": "criacao_epicos_azure_devops",
     "created_at": "2024-06-01T12:00:00Z",
     "last_saved_to_blob": "2024-06-01T12:30:00Z",
-    "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
-    "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+    "epicos_report": [{ "id": 1, "titulo": "Como usuário..." }],
+    "features_report": [{ "id": 1, "nome": "Login" }],
     "times_descricao_report": null,
     "alocacao_times_report": null,
     "premissas_riscos_report": null,
     "docx_files": ["https://.../arquivo1.docx"],
-    "comentario_usuario": "Comentário salvo",
     "extracted_text": "Texto extraído do arquivo DOCX da reunião",
     "project_id": "projeto-uuid-123"
   }
@@ -81,9 +78,9 @@ Authorization: Bearer <token>
 Content-Type: multipart/form-data
 
 file=<arquivo.docx>
-projeto=ProjetoNovo
+nome_projeto=ProjetoNovo
 analysis_type=criacao_epicos_azure_devops
-comentario_usuario=Comentário opcional
+instrucoes_extras=Comentário opcional
 
 **Resposta:**
 
@@ -104,26 +101,14 @@ Authorization: Bearer <token>
 Content-Type: application/json
 
 { 
-  "projeto": "ProjetoNovo",
+  "nome_projeto": "ProjetoNovo",
   "analysis_type": "criacao_epicos_azure_devops",
-  "arquivo_docx": "Texto extraído do arquivo DOCX da reunião",
-  "comentario_usuario": "Este é um comentário adicional do usuário."
-}
-
-**Requisição (projeto existente, sem novo upload):**
-
-POST /analysis/start HTTP/1.1
-Authorization: Bearer <token>
-Content-Type: application/json
-
-{ 
-  "projeto": "ProjetoExistente",
-  "analysis_type": "criacao_epicos_azure_devops",
-  "comentario_usuario": "Comentário sem arquivo."
+  "instrucoes_extras": "Este é um comentário adicional do usuário.",
+  "arquivo_docx": "Texto extraído do arquivo DOCX da reunião"
 }
 
 **Fluxo interno:**
-- O backend recebe o campo "projeto" (nome legível do projeto) do frontend.
+- O backend recebe o campo "nome_projeto" do frontend.
 - O backend busca o project_id correspondente ao nome do projeto (se existir); caso contrário, gera um novo project_id.
 - Todas as operações internas e comunicação com o MCP passam a usar project_id como identificador principal.
 - O backend pode enviar nome_projeto na resposta para exibição no frontend.
@@ -131,13 +116,10 @@ Content-Type: application/json
 **Payload enviado do backend para o MCP:**
 
 {
-  "projeto": "ProjetoNovo",
-  "analysis_type": "criacao_epicos_azure_devops",
-  "arquivo_docx": "Texto extraído do arquivo DOCX da reunião",
-  "comentario_usuario": "Este é um comentário adicional do usuário.",
-  "usuario_executor": "user@example.com",
   "project_id": "projeto-uuid-123",
-  "nome_projeto": "ProjetoNovo"
+  "analysis_type": "criacao_epicos_azure_devops",
+  "instrucoes_extras": "Este é um comentário adicional do usuário.",
+  "arquivo_docx": "Texto extraído do arquivo DOCX da reunião"
 }
 
 > **Nota:** O campo project_id é sempre utilizado como identificador principal na comunicação com o MCP. O campo nome_projeto é enviado apenas para log/debug.
@@ -159,7 +141,7 @@ Authorization: Bearer <token>
 Content-Type: application/json
 
 { 
-  "report_data": { "epicos_report": [{ "id": 1, "titulo": "Como usuário..." }] }
+  "report_data": { "features_report": [{ "id": 101, "nome": "Configurar App Registration Azure", "descricao": "Criar app no entra ID" }] }
 }
 
 **Resposta:**
@@ -180,8 +162,8 @@ Authorization: Bearer <token>
 **Resposta:**
 
 { 
-  "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
-  "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+  "epicos_report": [{ "id": 1, "titulo": "Como usuário..." }],
+  "features_report": [{ "id": 1, "nome": "Login" }],
   "times_descricao_report": null,
   "alocacao_times_report": null,
   "premissas_riscos_report": null,
@@ -202,7 +184,7 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   "project_id": "<string>",
   "status": "in_progress" | "done" | "error",
   "progress": <opcional, int>,
-  "report_data": { "epicos_report": [{ ... }] },
+  "report_data": { "features_report": [{ ... }] },
   "error_type": <string, obrigatório quando status="error">,
   "error_message": <string, obrigatório quando status="error">
 }
@@ -212,7 +194,7 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 - `project_id`: string. Identificador único do projeto, usado para buscar a sessão correspondente.
 - `status`: string. Um dos valores: `in_progress`, `done`, `error`.
 - `progress`: inteiro opcional (0-100), só para status `in_progress`.
-- `report_data`: objeto/dict. Obrigatório para status `in_progress` ou `done`. Estrutura: `{<report_field>: [ ... ]}`. Exemplo: `{ "epicos_report": [{ ... }] }`
+- `report_data`: objeto/dict. Obrigatório para status `in_progress` ou `done`. Estrutura: `{<report_field>: [ ... ]}`. Exemplo: `{ "features_report": [{ ... }] }`
 - `error_type`: string. Obrigatório para status `error`.
 - `error_message`: string. Obrigatório para status `error`.
 
@@ -228,8 +210,8 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   "status": "in_progress",
   "progress": 40,
   "report_data": { 
-    "epicos_report": [
-      { "id": 1, "titulo": "Como usuário..." }
+    "features_report": [
+      { "id": 101, "nome": "Configurar App Registration Azure", "descricao": "Criar app no entra ID" }
     ]
   }
 }
@@ -241,9 +223,9 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   "project_id": "projeto-uuid-123",
   "status": "done",
   "report_data": { 
-    "epicos_report": [
-      { "id": 1, "titulo": "Como usuário...", "descricao": "..." },
-      { "id": 2, "titulo": "Como admin...", "descricao": "..." }
+    "features_report": [
+      { "id": 101, "nome": "Configurar App Registration Azure", "descricao": "Criar app no entra ID" },
+      { "id": 102, "nome": "Middleware de Validação JWT", "descricao": "Validar token no backend Python" }
     ]
   }
 }
@@ -258,38 +240,12 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   "error_message": "Tempo limite excedido ao processar análise."
 }
 
-#### 2.2.4 Webhook para Features (`status: done`)
-
-{ 
-  "job_id": "7891011",
-  "project_id": "projeto-uuid-456",
-  "status": "done",
-  "report_data": { 
-    "features_report": [
-      { "id": 1, "nome": "Login", "descricao": "Permitir login com Azure AD" }
-    ]
-  }
-}
-
-#### 2.2.5 Webhook para Tech Debt (`status: done`)
-
-{ 
-  "job_id": "555777",
-  "project_id": "projeto-uuid-789",
-  "status": "done",
-  "report_data": { 
-    "premissas_riscos_report": [
-      { "id": 1, "descricao": "Código duplicado" }
-    ]
-  }
-}
-
 ### 2.3 Estrutura de report_data Esperada por Tipo
 
-- Para `epicos_report`:
-    { "epicos_report": [ { ... } ] }
 - Para `features_report`:
     { "features_report": [ { ... } ] }
+- Para `epicos_report`:
+    { "epicos_report": [ { ... } ] }
 - Para `times_descricao_report`:
     { "times_descricao_report": [ { ... } ] }
 - Para `alocacao_times_report`:
@@ -302,7 +258,7 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 ### 2.4 Regras Importantes para o MCP
 
 - O campo `project_id` deve ser exatamente o mesmo recebido do backend na chamada de início de análise.
-- O campo principal de `report_data` (ex: `epicos_report`, `features_report`, etc) deve estar presente e conter a lista de resultados.
+- O campo principal de `report_data` (ex: `features_report`, `epicos_report`, etc) deve estar presente e conter a lista de resultados.
 - Para status `error`, não envie `report_data`.
 - Para status `in_progress` e `done`, `report_data` é obrigatório e deve conter exatamente uma chave de relatório.
 - O backend rejeitará webhooks com estrutura inválida ou campos ausentes.
@@ -356,8 +312,8 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 **Sucesso:**
 
 { 
-  "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
-  "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+  "epicos_report": [{ "id": 1, "titulo": "Como usuário..." }],
+  "features_report": [{ "id": 1, "nome": "Login" }],
   "times_descricao_report": null,
   "alocacao_times_report": null,
   "premissas_riscos_report": null,
@@ -378,18 +334,16 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   "exists": true,
   "state": { 
     "usuario_executor": "user@example.com",
-    "projeto": "ProjetoNovo",
     "nome_projeto": "ProjetoNovo",
     "analysis_type": "criacao_epicos_azure_devops",
     "created_at": "2024-06-01T12:00:00Z",
     "last_saved_to_blob": "2024-06-01T12:30:00Z",
-    "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
-    "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
+    "epicos_report": [{ "id": 1, "titulo": "Como usuário..." }],
+    "features_report": [{ "id": 1, "nome": "Login" }],
     "times_descricao_report": null,
     "alocacao_times_report": null,
     "premissas_riscos_report": null,
     "docx_files": ["https://.../arquivo1.docx"],
-    "comentario_usuario": "Comentário salvo",
     "extracted_text": "Texto extraído do arquivo DOCX da reunião",
     "project_id": "projeto-uuid-123"
   }
@@ -414,7 +368,6 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
   },
   "projects": [
     { 
-      "projeto": "ProjetoNovo",
       "nome_projeto": "ProjetoNovo",
       "analysis_type": "criacao_epicos_azure_devops",
       "created_at": "2024-06-01T12:00:00Z",
@@ -490,161 +443,12 @@ O MCP deve enviar um POST para o endpoint `/webhooks/mcp` do backend com o segui
 
 ---
 
-## 4. Exemplos de Respostas de Erro (Backend → Frontend)
-
-| Código | Cenário | Exemplo |
-|--------|---------|---------|
-| 401 | Autenticação inválida | `{  "detail": "Cabeçalho Authorization ausente." }` |
-| 403 | IP não autorizado | `{  "detail": "Acesso negado. IP 200.100.50.25 não autorizado." }` |
-| 400 | Payload inválido | `{  "detail": "Os campos 'analysis_type' e pelo menos um de 'arquivo_docx' ou 'comentario_usuario' são obrigatórios." }` |
-| 502 | Falha comunicação MCP | `{  "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): ..." }` |
-| 504 | Timeout MCP | `{  "detail": "Erro ao comunicar com o servidor de Inteligência (MCP): Tempo limite excedido ao processar análise." }` |
-| 503 | Key Vault indisponível | `{  "detail": "Erro ao carregar segredos do Key Vault na inicialização: ..." }` |
-| 503 | Redis indisponível | `{  "detail": "Erro ao conectar ao Redis (endpoint privado): ..." }` |
-| 503 | Blob Storage indisponível | `{  "detail": "Erro ao conectar ao Blob Storage: ..." }` |
-| 500 | Erro interno | `{  "detail": "Erro interno do servidor." }` |
-
----
-
-## 5. Fluxo Completo de Comunicação (Exemplo End-to-End)
-
-### 1. Login
-
-POST /auth/login
-Authorization: Bearer <token>
-
-{}
-
-Resposta:
-
-{ 
-  "user_info": { "usuario_executor": "user@example.com", "sub": "uuid", "name": "Nome do Usuário", "email": "user@example.com", "roles": ["admin"]},
-  "projects": [{ "projeto": "ProjetoNovo", "nome_projeto": "ProjetoNovo", "analysis_type": "criacao_epicos_azure_devops", "created_at": "2024-06-01T12:00:00Z", "last_saved_to_blob": "2024-06-01T12:30:00Z", "project_id": "projeto-uuid-123"}]
-}
-
-### 2. Verificação de Projeto
-
-GET /projects/check?projeto=ProjetoNovo
-Authorization: Bearer <token>
-
-Resposta:
-
-{ 
-  "exists": true,
-  "state": { 
-    "usuario_executor": "user@example.com",
-    "projeto": "ProjetoNovo",
-    "nome_projeto": "ProjetoNovo",
-    "analysis_type": "criacao_epicos_azure_devops",
-    "created_at": "2024-06-01T12:00:00Z",
-    "last_saved_to_blob": "2024-06-01T12:30:00Z",
-    "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
-    "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
-    "times_descricao_report": null,
-    "alocacao_times_report": null,
-    "premissas_riscos_report": null,
-    "docx_files": ["https://.../arquivo1.docx"],
-    "comentario_usuario": "Comentário salvo",
-    "extracted_text": "Texto extraído do arquivo DOCX da reunião",
-    "project_id": "projeto-uuid-123"
-  }
-}
-
-### 3. Upload de DOCX
-
-POST /upload/docx
-Authorization: Bearer <token>
-file=<arquivo.docx>&projeto=ProjetoNovo&analysis_type=criacao_epicos_azure_devops&comentario_usuario=Comentário opcional
-
-Resposta:
-
-{ 
-  "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/arquivos_recebidos/docx/Sprint2.docx",
-  "extracted_text": "Texto extraído do DOCX da reunião",
-  "message": "Arquivo processado com sucesso. Pronto para análise. (Upload opcional para projetos existentes)",
-  "project_id": "projeto-uuid-123",
-  "nome_projeto": "ProjetoNovo"
-}
-
-### 4. Início de Análise
-
-POST /analysis/start
-Authorization: Bearer <token>
-
-{ 
-  "projeto": "ProjetoNovo",
-  "analysis_type": "criacao_epicos_azure_devops",
-  "arquivo_docx": "Texto extraído do arquivo DOCX da reunião",
-  "comentario_usuario": "Este é um comentário adicional do usuário."
-}
-
-Resposta:
-
-{ 
-  "message": "Análise solicitada com sucesso ao agente.",
-  "project_id": "projeto-uuid-123",
-  "nome_projeto": "ProjetoNovo"
-}
-
-> **Nota:** Toda a comunicação com o MCP utiliza o project_id como identificador principal. O job_id é apenas um identificador da execução no MCP, mas não é usado para buscar sessões no backend.
-
-### 5. Webhook de Progresso (MCP → Backend)
-
-{ 
-  "job_id": "123456",
-  "project_id": "projeto-uuid-123",
-  "status": "in_progress",
-  "progress": 50,
-  "report_data": { "epicos_report": [{ "id": 1, "titulo": "Como usuário..." }]}
-}
-
-### 6. Webhook de Conclusão (MCP → Backend)
-
-{ 
-  "job_id": "123456",
-  "project_id": "projeto-uuid-123",
-  "status": "done",
-  "report_data": { "epicos_report": [{ "id": 1, "titulo": "Como usuário...", "descricao": "..." }]}
-}
-
-### 7. Consulta de Relatórios
-
-GET /session/project/projeto-uuid-123/reports
-Authorization: Bearer <token>
-
-Resposta:
-
-{ 
-  "epicos_report": { "epicos": [{ "id": 1, "titulo": "Como usuário..." }]},
-  "features_report": { "features": [{ "id": 1, "nome": "Login" }]},
-  "times_descricao_report": null,
-  "alocacao_times_report": null,
-  "premissas_riscos_report": null,
-  "project_id": "projeto-uuid-123",
-  "nome_projeto": "ProjetoNovo"
-}
-
-### 8. Salvamento Manual de Estado
-
-POST /session/project/projeto-uuid-123/save-state
-Authorization: Bearer <token>
-
-Resposta:
-
-{ 
-  "blob_url": "https://storage.blob.core.windows.net/usuario/projeto/estados/estado_20240601T120000Z.json",
-  "project_id": "projeto-uuid-123",
-  "nome_projeto": "ProjetoNovo"
-}
-
----
-
 ## Notas
 - Todos os exemplos de requisição (exceto `/auth/config`) exigem o header `Authorization: Bearer <token>`.
 - O campo `project_id` está presente em todas as respostas de endpoints que envolvem projetos ou sessões.
 - O campo `arquivo_docx` enviado para o MCP sempre contém o texto extraído do DOCX, nunca a URL.
-- Todos os relatórios estão sob campos individuais (`epicos_report`, `features_report`, etc). Não existe mais a chave `reports`.
+- Todos os relatórios estão sob campos individuais (`epicos_report`, `features_report`, etc). Não existe mais a chave `reports` ou campos obsoletos no estado do projeto.
 - O upload de DOCX retorna tanto a URL do arquivo quanto o texto extraído, em paralelo.
 - Para erros, o backend sempre retorna o campo `detail` no corpo JSON.
 - Toda a comunicação com o MCP utiliza o project_id como identificador principal. O job_id é apenas um identificador da execução no MCP, mas não é usado para buscar sessões no backend.
-- O backend aceita o campo "projeto" (nome do projeto) do frontend, converte internamente para project_id, e responde sempre com ambos.
+- O backend aceita o campo "nome_projeto" do frontend, converte internamente para project_id, e responde sempre com ambos.


### PR DESCRIPTION
A documentação foi revisada para remover referências às chaves obsoletas ('projeto', 'comentario_usuario', 'docx_blob_url') no estado do projeto. Os exemplos de payload e respostas agora mostram apenas os campos individuais de relatório e os campos essenciais do projeto, alinhados com as mudanças no backend. Também detalha o fluxo de comunicação entre frontend, backend e MCP, enfatizando o uso do project_id como identificador principal e a lógica de atualização cirúrgica dos relatórios.