### PR TITLE
Modificação do endpoint POST /analysis/start para não persistir extracted_text na sessão Redis e garantir que o estado do projeto mantenha integridade conforme regras definidas.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -83,8 +83,7 @@ async def start_analysis(
             usuario_executor,
             nome_projeto,
             analysis_type,
-            project_id=project_id_final,
-            extracted_text=texto_extraido
+            project_id=project_id_final
         )
     BackgroundStateSaver.schedule_periodic_save(project_id_final)
     mcp_payload = MCPStartAnalysisPayload(


### PR DESCRIPTION
O endpoint de início de análise foi ajustado para extrair texto do arquivo docx e enviá-lo ao MCP, porém sem salvar o campo extracted_text na sessão Redis. Isso evita a persistência indevida desse campo no estado do projeto, alinhando-se com a política de exclusão de extracted_text do estado. A criação e restauração da sessão preservam os campos imutáveis e atualizam analysis_type conforme necessário.