### PR TITLE
Ajuste no endpoint GET /session/project/{project_id}/reports para remover explicitamente o campo extracted_text da resposta e garantir que apenas os campos de relatório presentes no estado sejam retornados, mantendo a integridade do estado conforme regras definidas.

### DIFF
--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -18,6 +18,7 @@ def get_project_reports(project_id: str):
         state.pop("projeto", None)
         state.pop("comentario_usuario", None)
         state.pop("docx_blob_url", None)
+        state.pop("extracted_text", None)
         reports = {
             "epicos_report": state.get("epicos_report"),
             "features_report": state.get("features_report"),


### PR DESCRIPTION
O endpoint de consulta de relatórios foi modificado para excluir o campo extracted_text da resposta JSON, além de preservar os campos imutáveis e retornar somente os campos de relatório existentes no estado do projeto. Isso assegura que o campo extracted_text não seja exposto na API, alinhando-se às políticas de privacidade e consistência do estado do projeto.