### PR TITLE
Refatoração do método update_report para atualização seletiva dos campos de relatório na sessão Redis.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -113,13 +113,9 @@ class RedisSessionService:
         if report_field not in valid_report_fields:
             raise ValueError(f"Chave de relatório '{report_field}' não é válida. Esperado uma das: {valid_report_fields}")
         report_value = report_data[report_field]
-        # Atualização seletiva: apenas o campo presente em report_data é atualizado, os demais são preservados
         if report_value is not None:
             session_data[report_field] = report_value
             session_data["last_saved_to_blob"] = datetime.utcnow().isoformat()
-        # Não altera outros campos de relatório
-        if "analysis_type" in report_data:
-            session_data["analysis_type"] = report_data["analysis_type"]
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
         asyncio.create_task(self._save_to_blob_after_update(project_id))
 


### PR DESCRIPTION
O método update_report foi modificado para atualizar apenas o campo de relatório presente no report_data, preservando os demais campos do estado anterior. Isso evita sobrescrita de campos não presentes no payload e mantém a integridade do estado do projeto. A atualização assíncrona do estado no Blob foi mantida para garantir persistência.