### PR TITLE
Ajuste no endpoint de webhook MCP para garantir que o salvamento no Blob Storage ocorra somente quando o status do webhook for 'done', respeitando a ordem correta de atualização do estado.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -29,7 +29,8 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
                 raise HTTPException(status_code=400, detail=f"Estrutura de report_data inválida para analysis_type '{analysis_type}'")
             redis_service.update_report(payload.project_id, report_data)
             logger.info(f"Campo de relatório atualizado via webhook para project_id {payload.project_id}")
-            await ProjectStateService.save_state_to_blob(redis_service.get_session_by_project_id(payload.project_id))
+            if payload.status == "done":
+                await ProjectStateService.save_state_to_blob(redis_service.get_session_by_project_id(payload.project_id))
         elif payload.status == "error":
             logger.error(f"Webhook de erro recebido: job_id={payload.job_id}, error_type={payload.error_type}, error_message={payload.error_message}")
         return {"status": "ok", "project_id": payload.project_id, "nome_projeto": session.nome_projeto}


### PR DESCRIPTION
No endpoint /mcp, após validar e atualizar o estado no Redis via update_report, o salvamento no Blob Storage é executado somente se o status do payload for 'done'. Isso assegura que o estado no Blob Storage reflita a versão final do projeto após processamento completo do MCP.