### PR TITLE
Refatoração para garantir atualização ponto a ponto dos parâmetros do estado do projeto no Redis, mantendo o método update_report focado em atualizar apenas um campo de relatório por vez, sem disparar salvamento automático no Blob. Introdução do método _update_single_field para atualização individual de campos. Salvamento no Blob deve ser feito a partir do estado no Redis, garantindo sincronização.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -94,6 +94,16 @@ class RedisSessionService:
         except Exception as e:
             self.logger.error(f"Erro ao salvar estado no Blob após update_report para project_id={project_id}: {e}")
 
+    def _update_single_field(self, project_id: str, field_name: str, field_value: Any):
+        key = f"project:{project_id}"
+        session_json = self.redis_client.get(key)
+        if not session_json:
+            raise ValueError(f"Projeto {project_id} não encontrado no Redis.")
+        session_data = self._deserialize_session(session_json)
+        session_data[field_name] = field_value
+        session_data["last_modified"] = datetime.utcnow().isoformat()
+        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
+
     def update_report(self, project_id: str, report_data: Dict[str, Any]):
         key = f"project:{project_id}"
         session_json = self.redis_client.get(key)
@@ -109,18 +119,13 @@ class RedisSessionService:
             "alocacao_times_report",
             "premissas_riscos_report"
         ]
-        if len(list(report_data.keys()))>1:
+        if len(list(report_data.keys())) > 1:
             raise ValueError(f"erro, deve haver apenas uma chave o report")
         report_field = list(report_data.keys())[0]
         if report_field not in valid_report_fields:
             raise ValueError(f"Chave de relatório '{report_field}' não é válida. Esperado uma das: {valid_report_fields}")
         report_value = report_data[report_field]
-        session_data[report_field] = report_value
-        session_data["last_saved_to_blob"] = datetime.utcnow().isoformat()
-        if "analysis_type" in report_data:
-            session_data["analysis_type"] = report_data["analysis_type"]
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
-        # Removido salvamento automático no Blob Storage aqui (conforme instrução do usuário)
+        self._update_single_field(project_id, report_field, report_value)
 
     def restore_session_from_state(self, usuario_executor: str, nome_projeto: str, analysis_type: str, project_state: Dict[str, Any]) -> str:
         project_id = project_state.get("project_id")


### PR DESCRIPTION
O método update_report foi ajustado para atualizar somente o campo especificado do relatório, utilizando o método auxiliar _update_single_field. Este método realiza a atualização individual do campo no Redis e atualiza o timestamp de modificação. A lógica de salvamento automático no Blob foi removida do update_report, alinhando-se à diretriz de que o Blob deve refletir o último estado salvo no Redis. A atualização dos parâmetros do estado do projeto é feita ponto a ponto para garantir consistência e rastreabilidade. O método update_session_on_state_change mantém a atualização de múltiplos campos e agenda salvamento em background, reforçando a sincronização entre Redis e Blob.