### PR TITLE
Alteração do método save_state_to_blob para salvar exatamente o estado recebido do Redis, atualizando parâmetros individualmente.

### DIFF
--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -14,22 +14,6 @@ class ProjectStateService:
         project_id = state.get("project_id")
         timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
         state["last_saved_to_blob"] = datetime.datetime.utcnow().isoformat()
-        state.pop("projeto", None)
-        state.pop("comentario_usuario", None)
-        state.pop("docx_blob_url", None)
-        state.pop("extracted_text", None)
-        report_fields = [
-            "epicos_report",
-            "features_report",
-            "times_descricao_report",
-            "alocacao_times_report",
-            "premissas_riscos_report"
-        ]
-        for field in report_fields:
-            if field not in state:
-                state[field] = []
-            elif state[field] is None:
-                state[field] = []
         blob_folder = f"{usuario_executor}/{nome_projeto}/estados"
         blob_filename = f"estado_{timestamp}.json"
         blob_path = f"{blob_folder}/{blob_filename}"


### PR DESCRIPTION
O método save_state_to_blob foi ajustado para salvar no Blob Storage exatamente o estado recebido da sessão Redis, atualizando ponto a ponto os parâmetros do estado do projeto sem inicializar campos ausentes ou sobrescrever valores None. Isso assegura que o Blob Storage contenha uma cópia fiel e atualizada do último estado do Redis, respeitando a ordem e integridade dos dados conforme solicitado.