### PR TITLE
Atualização do endpoint PUT /project/{project_id}/report para não disparar salvamento automático no Blob após atualização do relatório. Mantém a validação para garantir que report_data contenha exatamente uma chave.

### DIFF
--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -39,7 +39,6 @@ def update_project_report(project_id: str, req: UpdateReportRequest):
         if not req.report_data or not isinstance(req.report_data, dict) or len(req.report_data) != 1:
             raise HTTPException(status_code=400, detail="report_data deve ser um dicionário com exatamente uma chave de relatório.")
         redis_service.update_report(project_id, req.report_data)
-        redis_service.update_session_on_state_change(project_id, {})
         session = redis_service.get_session_by_project_id(project_id)
         return {"status": "ok", "project_id": project_id, "nome_projeto": session.nome_projeto}
     except Exception as e:


### PR DESCRIPTION
Removida a chamada para salvar o estado no Blob após atualização do relatório no Redis, conforme passo 6. O endpoint agora atualiza apenas o campo de relatório no Redis e retorna o status sem acionar salvamento automático no Blob.