### PR TITLE
Modificação do webhook MCP para não acionar salvamento automático no Blob após atualização do relatório no Redis.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -29,8 +29,6 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
                 raise HTTPException(status_code=400, detail=f"Estrutura de report_data inválida para analysis_type '{analysis_type}'")
             redis_service.update_report(payload.project_id, report_data)
             logger.info(f"Campo de relatório atualizado via webhook para project_id {payload.project_id}")
-            if payload.status == "done":
-                await ProjectStateService.save_state_to_blob(redis_service.get_session_by_project_id(payload.project_id))
         elif payload.status == "error":
             logger.error(f"Webhook de erro recebido: job_id={payload.job_id}, error_type={payload.error_type}, error_message={payload.error_message}")
         return {"status": "ok", "project_id": payload.project_id, "nome_projeto": session.nome_projeto}


### PR DESCRIPTION
Removida a chamada para salvar o estado no Blob após update_report no webhook MCP, conforme passo 7. O webhook agora apenas atualiza o relatório no Redis sem disparar salvamento no Blob.