### PR TITLE
Correção da lógica de restauração e atualização dos campos de relatório na sessão Redis para manter o valor do estado do projeto mais atual ou atualizar apenas o campo presente no report_data do MCP, sem sobrescrever com listas vazias. Ajustes para garantir integridade dos dados e evitar perda de informações.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -125,7 +125,10 @@ class RedisSessionService:
         if report_field not in valid_report_fields:
             raise ValueError(f"Chave de relatório '{report_field}' não é válida. Esperado uma das: {valid_report_fields}")
         report_value = report_data[report_field]
-        self._update_single_field(project_id, report_field, report_value)
+        # Atualiza apenas o campo presente no report_data, mantendo os demais inalterados
+        session_data[report_field] = report_value
+        session_data["last_modified"] = datetime.utcnow().isoformat()
+        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
 
     def restore_session_from_state(self, usuario_executor: str, nome_projeto: str, analysis_type: str, project_state: Dict[str, Any]) -> str:
         project_id = project_state.get("project_id")
@@ -139,11 +142,16 @@ class RedisSessionService:
         session_data["docx_files"] = project_state.get("docx_files", [])
         session_data["project_id"] = project_id
         session_data["nome_projeto"] = nome_projeto
-        session_data["epicos_report"] = project_state.get("epicos_report") if "epicos_report" in project_state else []
-        session_data["features_report"] = project_state.get("features_report") if "features_report" in project_state else []
-        session_data["times_descricao_report"] = project_state.get("times_descricao_report") if "times_descricao_report" in project_state else []
-        session_data["alocacao_times_report"] = project_state.get("alocacao_times_report") if "alocacao_times_report" in project_state else []
-        session_data["premissas_riscos_report"] = project_state.get("premissas_riscos_report") if "premissas_riscos_report" in project_state else []
+        # Corrigido: mantém o valor do estado do projeto mais atual para cada campo de relatório
+        for report_field in [
+            "epicos_report",
+            "features_report",
+            "times_descricao_report",
+            "alocacao_times_report",
+            "premissas_riscos_report"
+        ]:
+            if report_field in project_state:
+                session_data[report_field] = project_state[report_field]
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
         return project_id
 


### PR DESCRIPTION
Ajustada a função restore_session_from_state para que os campos de relatório mantenham o valor do estado do projeto mais atual e não sejam sobrescritos por listas vazias quando a chave não existir. Em update_report, a atualização foi limitada ao campo presente no report_data, preservando os demais campos. Adicionada lógica para que os campos de relatório possam vir do estado do projeto ou da resposta do MCP, mantendo o valor anterior caso a chave não esteja presente na resposta do MCP.