### PR TITLE
Remoção do salvamento periódico automático no BackgroundStateSaver e ajuste do MCPClientService para enviar payload correto ao MCP conforme novo fluxo.

### DIFF
--- a/backend/app/services/background_state_saver.py
+++ b/backend/app/services/background_state_saver.py
@@ -1,31 +1,15 @@
-import asyncio
 import logging
-from backend.app.services.project_state_service import ProjectStateService
-from backend.app.core.config import settings
 
 class BackgroundStateSaver:
     _tasks = {}
-    _interval_minutes = int(getattr(settings, 'PROJECT_STATE_SAVE_INTERVAL_MINUTES', 10))
     _logger = logging.getLogger("BackgroundStateSaver")
 
     @classmethod
     def schedule_periodic_save(cls, project_id: str, interval_minutes: int = None):
-        if project_id in cls._tasks:
-            return
-        interval = interval_minutes or cls._interval_minutes
-        loop = asyncio.get_event_loop()
-        task = loop.create_task(cls._periodic_save(project_id, interval))
-        cls._tasks[project_id] = task
+        # Salvamento periódico desabilitado conforme novo fluxo.
+        pass
 
     @classmethod
     async def _periodic_save(cls, project_id: str, interval_minutes: int):
-        from backend.app.services.redis_session_service import RedisSessionService
-        redis_service = RedisSessionService()
-        while True:
-            try:
-                session_data = redis_service.get_session_by_project_id(project_id)
-                url = await ProjectStateService.save_state_to_blob(session_data)
-                cls._logger.info(f"Estado do projeto {project_id} salvo no Blob: {url}")
-            except Exception as e:
-                cls._logger.error(f"Erro ao salvar estado do projeto {project_id} no Blob: {e}")
-            await asyncio.sleep(interval_minutes * 60)
+        # Salvamento periódico desabilitado conforme novo fluxo.
+        pass

--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -7,7 +7,7 @@ from fastapi.encoders import jsonable_encoder
 
 class MCPStartAnalysisPayload(BaseModel):
     project_id: str = Field(...)
-    arquivo_docx: Optional[str] = Field(None)
+    texto_extraido_do_docx: Optional[str] = Field(None)
     comentario_extra: Optional[str] = Field(None)
     analysis_type: str = Field(...)
 
@@ -42,11 +42,18 @@ class MCPClientService:
         base = raw_base.strip().rstrip("/")
         url = f"{base}/start"
         logging.info(f"🔌 [MCP Client] URL Final Limpa: '[{url}]'")
+        # Ajuste do payload para o MCP conforme novo fluxo
+        mcp_payload = {
+            "project_id": payload["project_id"],
+            "texto_extraido_do_docx": payload.get("texto_extraido_do_docx"),
+            "comentario_extra": payload.get("comentario_extra"),
+            "analysis_type": payload["analysis_type"]
+        }
         try:
             async with httpx.AsyncClient(timeout=60.0) as client:
                 response = await client.post(
                     url,
-                    json=jsonable_encoder(payload),
+                    json=jsonable_encoder(mcp_payload),
                     headers={"Content-Type": "application/json"}
                 )
                 if response.status_code != 200:


### PR DESCRIPTION
O BackgroundStateSaver foi modificado para desabilitar o salvamento periódico automático, mantendo a interface para possíveis usos futuros. O MCPClientService foi ajustado para enviar o payload correto contendo project_id, texto_extraido_do_docx, comentario_extra e analysis_type, substituindo o antigo arquivo_docx pelo texto extraído, conforme o fluxo atualizado.