### PR TITLE
Implementação da normalização dos campos de relatório para garantir que sejam sempre listas nos métodos de carregamento e listagem do estado do projeto, com logs para rastreamento.

### DIFF
--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -39,6 +39,21 @@ class ProjectStateService:
                         state.pop("comentario_usuario", None)
                         state.pop("docx_blob_url", None)
                         state.pop("extracted_text", None)
+                        # Passo 4: Normalização dos campos de relatório
+                        report_fields = [
+                            "epicos_report",
+                            "features_report",
+                            "times_descricao_report",
+                            "alocacao_times_report",
+                            "premissas_riscos_report"
+                        ]
+                        normalized_count = 0
+                        for field in report_fields:
+                            if field not in state or state[field] is None or not isinstance(state[field], list):
+                                state[field] = []
+                                normalized_count += 1
+                        if normalized_count > 0:
+                            logger.info(f"Normalização: {normalized_count} campos de relatório convertidos para lista em load_latest_state_from_blob().")
                         logger.info(f"Estado carregado com sucesso para usuario_executor={usuario_executor}, project_id={project_id}")
                         return state
             logger.info(f"Nenhum estado encontrado para usuario_executor={usuario_executor}, project_id={project_id}")
@@ -97,6 +112,7 @@ class ProjectStateService:
                 state.pop("comentario_usuario", None)
                 state.pop("docx_blob_url", None)
                 state.pop("extracted_text", None)
+                # Passo 5: Normalização dos campos de relatório
                 report_fields = [
                     "epicos_report",
                     "features_report",
@@ -104,11 +120,13 @@ class ProjectStateService:
                     "alocacao_times_report",
                     "premissas_riscos_report"
                 ]
+                normalized_count = 0
                 for field in report_fields:
-                    if field not in state:
+                    if field not in state or state[field] is None or not isinstance(state[field], list):
                         state[field] = []
-                    elif state[field] is None:
-                        state[field] = []
+                        normalized_count += 1
+                if normalized_count > 0:
+                    logger.debug(f"Normalização: {normalized_count} campos de relatório convertidos para lista em list_user_projects().")
                 item = {
                     "nome_projeto": state.get("nome_projeto", nome_projeto),
                     "analysis_type": state.get("analysis_type"),


### PR DESCRIPTION
No serviço ProjectStateService, os métodos load_latest_state_from_blob e list_user_projects foram modificados para normalizar os campos de relatório (epicos_report, features_report, times_descricao_report, alocacao_times_report, premissas_riscos_report), assegurando que estes sejam sempre listas, mesmo que originalmente estejam ausentes, None ou em formato incorreto. Logs informativos e de debug foram adicionados para monitorar essas normalizações.