### PR TITLE
Método from_project_state da SessionData ajustado para copiar os campos de relatório conforme estão, sem normalizar para listas vazias.

### DIFF
--- a/backend/app/models/session_models.py
+++ b/backend/app/models/session_models.py
@@ -27,25 +27,12 @@ class SessionData(BaseModel):
             "last_saved_to_blob": self.last_saved_to_blob.isoformat() if self.last_saved_to_blob else None,
             "docx_files": self.docx_files,
             "project_id": self.project_id,
-            "epicos_report": self.epicos_report if isinstance(self.epicos_report, list) else ([] if self.epicos_report is None else list(self.epicos_report) if hasattr(self.epicos_report, '__iter__') and not isinstance(self.epicos_report, str) else [self.epicos_report]),
-            "features_report": self.features_report if isinstance(self.features_report, list) else ([] if self.features_report is None else list(self.features_report) if hasattr(self.features_report, '__iter__') and not isinstance(self.features_report, str) else [self.features_report]),
-            "times_descricao_report": self.times_descricao_report if isinstance(self.times_descricao_report, list) else ([] if self.times_descricao_report is None else list(self.times_descricao_report) if hasattr(self.times_descricao_report, '__iter__') and not isinstance(self.times_descricao_report, str) else [self.times_descricao_report]),
-            "alocacao_times_report": self.alocacao_times_report if isinstance(self.alocacao_times_report, list) else ([] if self.alocacao_times_report is None else list(self.alocacao_times_report) if hasattr(self.alocacao_times_report, '__iter__') and not isinstance(self.alocacao_times_report, str) else [self.alocacao_times_report]),
-            "premissas_riscos_report": self.premissas_riscos_report if isinstance(self.premissas_riscos_report, list) else ([] if self.premissas_riscos_report is None else list(self.premissas_riscos_report) if hasattr(self.premissas_riscos_report, '__iter__') and not isinstance(self.premissas_riscos_report, str) else [self.premissas_riscos_report])
+            "epicos_report": self.epicos_report,
+            "features_report": self.features_report,
+            "times_descricao_report": self.times_descricao_report,
+            "alocacao_times_report": self.alocacao_times_report,
+            "premissas_riscos_report": self.premissas_riscos_report
         }
-        normalized_count = 0
-        for field in [
-            "epicos_report",
-            "features_report",
-            "times_descricao_report",
-            "alocacao_times_report",
-            "premissas_riscos_report"
-        ]:
-            if state[field] is None or not isinstance(state[field], list):
-                state[field] = []
-                normalized_count += 1
-        if normalized_count > 0:
-            logger.debug(f"Normalização: {normalized_count} campos de relatório convertidos para lista em to_project_state().")
         state.pop("projeto", None)
         state.pop("comentario_usuario", None)
         state.pop("docx_blob_url", None)
@@ -55,14 +42,6 @@ class SessionData(BaseModel):
     @classmethod
     def from_project_state(cls, state: Dict[str, Any]) -> "SessionData":
         logger = logging.getLogger("SessionData")
-        normalized_fields = 0
-        def _normalize(field):
-            nonlocal normalized_fields
-            v = state.get(field)
-            if v is None or not isinstance(v, list):
-                normalized_fields += 1
-                return []
-            return v
         return cls(
             usuario_executor=state.get("usuario_executor", ""),
             nome_projeto=state.get("nome_projeto", ""),
@@ -71,9 +50,9 @@ class SessionData(BaseModel):
             last_saved_to_blob=datetime.fromisoformat(state["last_saved_to_blob"]) if state.get("last_saved_to_blob") else datetime.utcnow(),
             docx_files=state.get("docx_files", []),
             project_id=state.get("project_id"),
-            epicos_report=_normalize("epicos_report"),
-            features_report=_normalize("features_report"),
-            times_descricao_report=_normalize("times_descricao_report"),
-            alocacao_times_report=_normalize("alocacao_times_report"),
-            premissas_riscos_report=_normalize("premissas_riscos_report")
+            epicos_report=state.get("epicos_report"),
+            features_report=state.get("features_report"),
+            times_descricao_report=state.get("times_descricao_report"),
+            alocacao_times_report=state.get("alocacao_times_report"),
+            premissas_riscos_report=state.get("premissas_riscos_report")
         )


### PR DESCRIPTION
O método from_project_state foi alterado para que os campos de relatório (epicos_report, features_report, times_descricao_report, alocacao_times_report, premissas_riscos_report) sejam copiados diretamente do estado recebido, sem forçar a conversão para listas vazias quando estiverem ausentes ou None. Isso mantém a integridade dos dados do estado do projeto.