### PR TITLE
Alteração no endpoint /start para não retornar o estado do projeto ao iniciar análise em projeto existente e garantir que o estado só seja criado na primeira criação do projeto.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -60,6 +60,7 @@ async def start_analysis(
         raise HTTPException(status_code=400, detail="É obrigatório fornecer arquivo_docx ou comentario_extra.")
     session_exists = bool(project_state)
     if session_exists:
+        # Apenas restaura a sessão do estado existente, sem sobrescrever campos de relatório
         redis_service.restore_session_from_state(
             usuario_executor,
             nome_projeto,
@@ -67,6 +68,7 @@ async def start_analysis(
             project_state
         )
     else:
+        # Criação inicial: campos de relatório vazios
         redis_service.create_session(
             usuario_executor,
             nome_projeto,

--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -19,7 +19,6 @@ class StartAnalysisResponse(BaseModel):
     message: str
     project_id: str
     nome_projeto: Optional[str] = None
-    state: Optional[dict] = None
 
 @router.post("/start", response_model=StartAnalysisResponse, tags=["Analysis"])
 async def start_analysis(
@@ -60,7 +59,6 @@ async def start_analysis(
         raise HTTPException(status_code=400, detail="É obrigatório fornecer arquivo_docx ou comentario_extra.")
     session_exists = bool(project_state)
     if session_exists:
-        # Apenas restaura a sessão do estado existente, sem sobrescrever campos de relatório
         redis_service.restore_session_from_state(
             usuario_executor,
             nome_projeto,
@@ -68,7 +66,6 @@ async def start_analysis(
             project_state
         )
     else:
-        # Criação inicial: campos de relatório vazios
         redis_service.create_session(
             usuario_executor,
             nome_projeto,
@@ -90,11 +87,8 @@ async def start_analysis(
     except Exception as e:
         logger.error(f"Erro na comunicação com MCP: {e}")
         raise HTTPException(status_code=502, detail=f"Erro ao comunicar com o servidor de Inteligência (MCP): {str(e)}")
-    session = redis_service.get_session_by_project_id(project_id_final)
-    state = session.to_project_state()
     return StartAnalysisResponse(
         message="Análise solicitada com sucesso ao agente.",
         project_id=project_id_final,
-        nome_projeto=nome_projeto,
-        state=state
+        nome_projeto=nome_projeto
     )


### PR DESCRIPTION
O endpoint /start foi modificado para que, ao iniciar uma análise em um projeto já existente, o estado atual do projeto não seja sobrescrito nem retornado na resposta. O estado deve ser carregado do blob storage no login e mantido em redis durante as análises, sendo atualizado somente após o MCP enviar status final 'done'. Na criação inicial do projeto, o estado é criado com campos vazios. Isso evita a reinicialização indevida dos campos de relatório e mantém a integridade do estado durante o ciclo de análise.