### PR TITLE
Remoção da chave 'state' na resposta do endpoint POST /analysis/start e garantia de que o estado não seja criado ou retornado indevidamente.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -77,7 +77,7 @@ async def start_analysis(
         redis_service.add_docx_file(project_id_final, blob_url)
     mcp_payload = {
         "project_id": project_id_final,
-        "arquivo_docx": texto_extraido,
+        "texto_extraido_do_docx": texto_extraido,
         "comentario_extra": comentario_extra,
         "analysis_type": analysis_type
     }


### PR DESCRIPTION
O endpoint POST /analysis/start foi modificado para não retornar mais a chave 'state' na resposta. A criação do estado do projeto ocorre somente na criação inicial, e o estado não é exposto na resposta. A comunicação com o MCP é feita enviando apenas os dados necessários, sem declaração de estado. O estado será atualizado posteriormente após resposta do MCP.