### PR TITLE
Refatoração do serviço RedisSessionService para garantir que o estado do projeto seja criado apenas na criação inicial e que não haja inicialização ou redefinição de campos de relatório fora desse momento. O método update_report não salva mais automaticamente no Blob Storage, apenas atualiza o Redis.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -63,13 +63,6 @@ class RedisSessionService:
         session_data["status"] = status
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
 
-    async def _save_to_blob_after_update(self, project_id: str):
-        try:
-            session = self.get_session_by_project_id(project_id)
-            await ProjectStateService.save_state_to_blob(session)
-        except Exception as e:
-            self.logger.error(f"Erro ao salvar estado no Blob após update_report para project_id={project_id}: {e}")
-
     def _update_single_field(self, project_id: str, field_name: str, field_value: Any):
         key = f"project:{project_id}"
         session_json = self.redis_client.get(key)


### PR DESCRIPTION
Removida a inicialização de listas vazias para campos de relatório no método create_session. O método restore_session_from_state restaura o estado exatamente como está no Blob Storage, sem modificar campos de relatório. O método update_report atualiza o relatório no Redis sem salvar no Blob Storage. Adicionadas verificações para garantir que o estado do projeto não seja criado ou modificado fora da criação inicial.