### PR TITLE
Ajustes na API de webhooks para que o estado do projeto seja atualizado no Redis e salvo no Blob Storage somente quando o webhook do MCP retornar status 'done'. Para status 'in_progress' ou 'error', não há atualização do estado, apenas logs informativos ou de erro.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -19,7 +19,10 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
         if not session:
             logger.error(f"Webhook recebido para project_id não encontrado: {payload.project_id}. Estado do Redis pode estar inconsistente.")
             raise HTTPException(status_code=404, detail=f"Sessão não encontrada para project_id: {payload.project_id}")
-        if payload.status in {"in_progress", "done"}:
+        if payload.status == "in_progress":
+            logger.info(f"Webhook MCP status 'in_progress' recebido para project_id {payload.project_id}. Nenhuma atualização de estado será feita.")
+            return {"status": "ok", "project_id": payload.project_id, "nome_projeto": session.nome_projeto}
+        elif payload.status == "done":
             report_data = payload.report_data
             if not report_data or not isinstance(report_data, dict) or len(report_data) != 1:
                 logger.error(f"Estrutura de report_data inválida para project_id '{payload.project_id}'")
@@ -32,8 +35,7 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
             redis_service.update_report(payload.project_id, report_data)
             logger.info(f"Campo de relatório '{report_field}' atualizado via webhook para project_id {payload.project_id}. Valor anterior: {valor_anterior}")
             session = redis_service.get_session_by_project_id(payload.project_id)
-            if payload.status == "done":
-                await ProjectStateService.save_state_to_blob(session)
+            await ProjectStateService.save_state_to_blob(session)
             state = session.to_project_state()
             return {"status": "ok", "project_id": payload.project_id, "nome_projeto": session.nome_projeto, "state": state}
         elif payload.status == "error":


### PR DESCRIPTION
No endpoint do webhook MCP, verifica-se o status do payload. Se for 'done', atualiza o relatório no Redis, salva o estado atualizado no Blob Storage e retorna o estado atualizado ao usuário. Para 'in_progress', apenas registra log e retorna sucesso sem alterar o estado. Para 'error', registra log de erro e retorna sucesso sem alterar o estado. Essa abordagem garante que o estado do projeto seja consistente e atualizado somente após a conclusão da análise.