### PR TITLE
Ajuste no serviço MCPClientService para garantir que o payload enviado ao MCP contenha apenas identificadores e parâmetros de análise, sem qualquer dado de estado ou relatório do projeto.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -42,7 +42,6 @@ class MCPClientService:
         base = raw_base.strip().rstrip("/")
         url = f"{base}/start"
         logging.info(f"🔌 [MCP Client] URL Final Limpa: '[{url}]'")
-        # Ajuste do payload para o MCP conforme novo fluxo
         mcp_payload = {
             "project_id": payload["project_id"],
             "texto_extraido_do_docx": payload.get("texto_extraido_do_docx"),


### PR DESCRIPTION
No método start_analysis, o payload enviado ao MCP inclui somente os campos project_id, texto_extraido_do_docx, comentario_extra e analysis_type. Nenhum campo de estado ou relatório é enviado, garantindo que a comunicação com o MCP não envolva definição ou modificação do estado do projeto.