### PR TITLE
Atualização do documento de arquitetura para reforçar que o estado do projeto é criado apenas na criação, lido do Blob Storage após login e atualizado somente via webhooks MCP com status 'done'. Removida qualquer indicação de retorno ou definição de estado na comunicação de início de análise.

### DIFF
--- a/backend/docs/ARCHITECTURE_FLOW.md
+++ b/backend/docs/ARCHITECTURE_FLOW.md
@@ -55,6 +55,7 @@ flowchart TD
 
 ### 1. Login e Autenticação via Azure AD
 - O frontend envia o token JWT via header `Authorization`. O backend valida o token, extrai o `usuario_executor` e retorna a lista de projetos do usuário.
+- O backend **lê o estado mais atual de cada projeto diretamente do Blob Storage** e salva no Redis apenas para leitura e resposta ao usuário. Não há criação ou redefinição do estado neste momento.
 - Código:
   - `backend/app/api/auth.py` (`POST /auth/login`)
   - `backend/app/middleware/auth_middleware.py` (`get_current_user`)
@@ -63,6 +64,7 @@ flowchart TD
 
 ### 2. Verificação de Projeto Existente
 - O frontend chama `/projects/check` enviando o campo `nome_projeto`. O backend converte internamente para `project_id` usando o método auxiliar, e todas as operações subsequentes usam `project_id` como identificador principal.
+- Se o projeto existir, o backend **lê o estado mais atual do Blob Storage** e retorna ao usuário. Não há redefinição do estado.
 - Código:
   - `backend/app/api/projects.py` (`/projects/check`)
   - `backend/app/services/project_state_service.py` (`_get_project_id_by_name`, `load_latest_state_from_blob`)
@@ -71,19 +73,21 @@ flowchart TD
 - O frontend chama `/analysis/start` enviando os campos `nome_projeto`, `analysis_type`, `instrucoes_extras` e opcionalmente `arquivo_docx` como arquivo via multipart/form-data.
 - O backend extrai o texto do arquivo DOCX e salva o arquivo no Blob Storage em paralelo.
 - O texto extraído é enviado ao MCP no campo `arquivo_docx` do payload.
+- **A resposta deste endpoint contém apenas `message`, `project_id` e `nome_projeto`. Não há definição ou retorno do estado do projeto.**
 - Código:
   - `backend/app/api/analysis.py` (`POST /analysis/start`)
   - `backend/app/services/blob_storage_service.py` (`upload_docx_to_blob`)
   - `backend/app/services/docx_parser_service.py` (`extract_text_from_docx`)
 
 ### 4. Criação e Gerenciamento de Sessão no Redis
-- Sessões são criadas e persistidas no Redis, incluindo campos como `extracted_text`, `project_id`, `docx_files` e os campos de relatório individuais (`epicos_report`, `features_report`, etc).
+- Sessões são criadas e persistidas no Redis, incluindo campos como `extracted_text`, `project_id`, `docx_files`.
+- **Os campos de relatório são criados apenas quando o MCP envia dados via webhook com status `done`.**
 - Código:
-  - `backend/app/services/redis_session_service.py` (`create_session`, `add_docx_file`, `update_session_extracted_text`, `update_report`, `restore_session_from_state`)
+  - `backend/app/services/redis_session_service.py` (`create_session`, `add_docx_file`, `update_report`, `restore_session_from_state`)
   - `backend/app/models/session_models.py` (`SessionData`)
 
 ### 5. Salvamento Automático e Periódico de Estado no Blob Storage
-- Estados de sessão/projeto são salvos periodicamente no Blob Storage via `BackgroundStateSaver`. Mudanças em relatórios ou estado acionam o salvamento automático.
+- Estados de sessão/projeto são salvos no Blob Storage **apenas quando o MCP retorna status `done` via webhook** ou quando forçado pelo usuário.
 - Código:
   - `backend/app/services/background_state_saver.py` (`schedule_periodic_save`)
   - `backend/app/services/project_state_service.py` (`save_state_to_blob`)
@@ -106,6 +110,7 @@ flowchart TD
 - O backend envia payloads para o MCP sempre usando `project_id` como identificador principal. O campo `nome_projeto` é enviado apenas para log/debug. O MCP responde com `job_id` e envia webhooks de progresso/conclusão, que atualizam relatórios na sessão Redis usando `project_id`.
 - O backend busca a sessão correspondente usando o `project_id` persistido no Redis. O `job_id` é apenas um identificador da execução no MCP, mas não é usado para buscar sessões no backend.
 - O campo `report_data` do webhook do MCP deve ser um dicionário com exatamente uma chave, que pode ser: `epicos_report`, `features_report`, `times_descricao_report`, `alocacao_times_report` ou `premissas_riscos_report`. O valor é sempre uma lista de itens do relatório. O backend atualiza diretamente o campo correspondente no estado do projeto/sessão, sem sobrescrever outros relatórios.
+- **O backend só atualiza o estado do projeto no Redis e Blob Storage quando o status do webhook for `done`. Para `in_progress`, apenas loga o progresso, sem atualizar o estado.**
 - Código:
   - `backend/app/services/mcp_client_service.py` (`start_analysis`)
   - `backend/app/services/redis_session_service.py` (`get_session_by_project_id`, `update_report`)
@@ -113,7 +118,7 @@ flowchart TD
   - `backend/app/api/webhooks.py` (busca sessão por `project_id` no webhook)
 
 ### 9. Atualização de Relatórios e Propagação de Estado
-- Relatórios são atualizados via endpoint ou webhook. Toda atualização aciona o salvamento automático do estado no Blob Storage. Cada relatório é salvo em seu campo individual (`epicos_report`, `features_report`, etc).
+- Relatórios são atualizados via endpoint ou webhook. Toda atualização aciona o salvamento automático do estado no Blob Storage **apenas quando status do MCP for `done`**. Cada relatório é salvo em seu campo individual (`epicos_report`, `features_report`, etc).
 - Código:
   - `backend/app/api/session.py` (`PUT /session/project/{project_id}/report`)
   - `backend/app/services/redis_session_service.py` (`update_report`, `update_session_on_state_change`)
@@ -134,7 +139,7 @@ sequenceDiagram
     FE->>BE: POST /auth/login (token)
     BE->>KV: Carrega segredos
     BE->>BS: Lista projetos
-    BE-->>FE: Lista de projetos
+    BE-->>FE: Lista de projetos (lidos do Blob Storage)
     FE->>BE: POST /analysis/start (nome_projeto, analysis_type, instrucoes_extras, arquivo_docx)
     BE->>BE: Busca ou cria project_id correspondente ao nome do projeto
     BE->>BE: Extrai texto do arquivo docx
@@ -142,11 +147,13 @@ sequenceDiagram
         BE->>BS: Salva arquivo docx no Blob Storage
         BE->>BE: Extrai texto do arquivo docx
     end
-    BE->>RS: Cria sessão (com campos de relatório individuais, project_id e nome_projeto)
+    BE->>RS: Cria sessão (com campos obrigatórios, sem relatórios)
     BE->>MCP: Envia payload (project_id, analysis_type, instrucoes_extras, texto extraído do arquivo docx)
     MCP-->>BE: job_id, project_id
     BE->>BS: Salva estado inicial
-    BE-->>FE: job_id, project_id, nome_projeto
+    BE-->>FE: message, project_id, nome_projeto
+
+**Nota:** O estado do projeto é criado **apenas** no momento da criação. Após isso, ele é lido do Blob Storage e salvo no Redis apenas para leitura e resposta ao usuário. Não há definição ou retorno de estado no endpoint de início de análise.
 
 ### 2. Fluxo de Projeto Existente
 mermaid
@@ -166,18 +173,21 @@ sequenceDiagram
     BE->>MCP: Envia payload (project_id, analysis_type, instrucoes_extras, texto extraído do arquivo docx)
     MCP-->>BE: job_id, project_id
     BE->>BS: Salva estado
-    BE-->>FE: job_id, project_id, nome_projeto
+    BE-->>FE: message, project_id, nome_projeto
+
+**Nota:** O estado do projeto é apenas lido do Blob Storage e salvo no Redis. Não há redefinição ou retorno do estado no endpoint de início de análise.
 
 ### 3. Fluxo de Atualização de Relatório (Webhook MCP)
 mermaid
 sequenceDiagram
     MCP->>BE: Webhook (job_id, project_id, status, report_data)
-    BE->>RS: Busca sessão por project_id (usando relação persistida project_id)
-    BE->>RS: Atualiza relatório individual na sessão (ex: features_report)
+    BE->>BE: Se status == 'done', atualiza relatório individual na sessão e salva estado no Redis e Blob Storage
     par Atualização paralela
         BE->>RS: Salva sessão atualizada no Redis
         BE->>BS: Salva estado atualizado no Blob Storage
     end
+
+**Nota:** O backend só atualiza o estado do projeto no Redis e Blob Storage quando o status do webhook for `done`. Para `in_progress`, apenas loga o progresso, sem atualizar o estado.
 
 ### 4. Fluxo de Erro e Recuperação
 mermaid
@@ -199,10 +209,11 @@ sequenceDiagram
 - O endpoint /upload/docx foi removido. O upload de arquivo DOCX e a extração de texto ocorrem exclusivamente via POST /analysis/start.
 - Para iniciar análise, é obrigatório informar `analysis_type` e pelo menos um de `arquivo_docx` (arquivo) ou `instrucoes_extras`.
 - O upload de DOCX processa upload e extração de texto em paralelo, retornando ambos imediatamente.
-- O salvamento de estado no Blob Storage é automático e periódico, disparado por alterações de relatório ou estado.
+- O salvamento de estado no Blob Storage é automático e periódico, disparado por alterações de relatório ou estado **apenas quando status do MCP for `done`**.
 - O cache de segredos do Key Vault é thread-safe e evita múltiplas chamadas desnecessárias.
 - O Redis deve ser configurado via Key Vault (não via variáveis de ambiente do App Service).
 - Para ambientes com Redis em subrede privada, o App Service deve estar integrado à mesma VNET.
 - Toda a comunicação com o MCP utiliza o project_id como identificador principal.
 - Todos os relatórios são salvos em campos individuais (`epicos_report`, `features_report`, etc). Não existe mais a chave `reports` ou campos obsoletos no estado do projeto ou sessão.
 - O backend aceita o campo "nome_projeto" do frontend, converte internamente para project_id, e responde sempre com ambos.
+- **O estado do projeto é criado apenas na criação do projeto. Após isso, ele é lido do Blob Storage e atualizado somente quando o MCP retorna status `done` via webhook.**


### PR DESCRIPTION
Modificação do arquivo ARCHITECTURE_FLOW.md para esclarecer o fluxo correto do estado do projeto, incluindo diagramas e descrições. Destaca-se que o estado não é retornado no endpoint de início de análise e que a atualização ocorre somente após notificações do MCP com status 'done'.