### PR TITLE
Endpoint POST /analysis/start ajustado para criar novo project_id apenas para projetos novos e reutilizar project_id e sessão Redis para projetos existentes.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -35,8 +35,15 @@ async def start_analysis(
     redis_service = RedisSessionService()
     project_id_final = await ProjectStateService._get_project_id_by_name(usuario_executor, nome_projeto)
     project_state = None
+    session_exists = False
     if project_id_final:
         project_state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, project_id=project_id_final)
+        # Verifica se já existe sessão no Redis para este project_id
+        try:
+            redis_service.get_session_by_project_id(project_id_final)
+            session_exists = True
+        except Exception:
+            session_exists = False
     else:
         project_id_final = str(uuid.uuid4())
     texto_extraido = None
@@ -57,7 +64,6 @@ async def start_analysis(
         )
     if not texto_extraido and not comentario_extra:
         raise HTTPException(status_code=400, detail="É obrigatório fornecer arquivo_docx ou comentario_extra.")
-    session_exists = bool(project_state)
     if session_exists:
         redis_service.restore_session_from_state(
             usuario_executor,


### PR DESCRIPTION
O endpoint POST /analysis/start agora verifica se o project_id já existe para o nome_projeto. Se existir e houver sessão no Redis, utiliza restore_session_from_state. Se não existir, gera novo project_id. Isso garante que projetos existentes mantenham o mesmo project_id e novos projetos criem um novo, conforme instrução do usuário e plano de ação.