### PR TITLE
Ajuste no endpoint /analysis/start para seguir o fluxo correto de criação e restauração de sessões de análise, diferenciando projetos novos e existentes pela busca do project_id via nome_projeto e carregando estado do Blob Storage quando aplicável.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -33,18 +33,20 @@ async def start_analysis(
     usuario_executor = _extract_usuario_executor(current_user)
     logger.info(f"Iniciando análise para projeto '{nome_projeto}' (analysis_type: '{analysis_type}') para usuário {usuario_executor}")
     redis_service = RedisSessionService()
+    # Busca o project_id pelo nome do projeto
     project_id_final = await ProjectStateService._get_project_id_by_name(usuario_executor, nome_projeto)
     project_state = None
     session_exists = False
     if project_id_final:
+        # Projeto já existe, carrega o estado mais recente do projeto
         project_state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, project_id=project_id_final)
-        # Verifica se já existe sessão no Redis para este project_id
         try:
             redis_service.get_session_by_project_id(project_id_final)
             session_exists = True
         except Exception:
             session_exists = False
     else:
+        # Projeto novo, gera novo project_id
         project_id_final = str(uuid.uuid4())
     texto_extraido = None
     blob_url = None
@@ -64,7 +66,8 @@ async def start_analysis(
         )
     if not texto_extraido and not comentario_extra:
         raise HTTPException(status_code=400, detail="É obrigatório fornecer arquivo_docx ou comentario_extra.")
-    if session_exists:
+    if project_state:
+        # Projeto existente: restaura sessão a partir do estado
         redis_service.restore_session_from_state(
             usuario_executor,
             nome_projeto,
@@ -72,6 +75,7 @@ async def start_analysis(
             project_state
         )
     else:
+        # Projeto novo: cria nova sessão
         redis_service.create_session(
             usuario_executor,
             nome_projeto,


### PR DESCRIPTION
O endpoint POST /analysis/start foi modificado para buscar o project_id pelo nome do projeto. Se encontrado, carrega o estado mais recente do Blob Storage e restaura a sessão no Redis; caso contrário, gera um novo project_id e cria nova sessão. Também foi mantida a lógica para upload e extração de texto do arquivo docx, e para envio da solicitação de análise ao MCP. Essa alteração garante que o fluxo de análise respeite o estado atual dos projetos e evita duplicidade ou perda de dados.