### PR TITLE
Atualização do modelo MCPStartAnalysisPayload para manter os campos arquivo_docx e comentario_usuario opcionais, removendo validações que os tornavam obrigatórios.

### DIFF
--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, validator, root_validator
+from pydantic import BaseModel, Field, validator
 from typing import Optional
 
 class MCPStartAnalysisPayload(BaseModel):
@@ -15,14 +15,6 @@ class MCPStartAnalysisPayload(BaseModel):
         if not v or not isinstance(v, str) or not v.strip():
             raise ValueError('analysis_type deve ser uma string não vazia')
         return v
-
-    @root_validator
-    def at_least_one_text_field(cls, values):
-        arquivo_docx = values.get('arquivo_docx')
-        comentario_usuario = values.get('comentario_usuario')
-        if (not arquivo_docx or not str(arquivo_docx).strip()) and (not comentario_usuario or not str(comentario_usuario).strip()):
-            raise ValueError('É obrigatório fornecer pelo menos arquivo_docx (texto extraído) ou comentario_usuario.')
-        return values
 
 class MCPStartAnalysisResponse(BaseModel):
     project_id: str = Field(..., description="Identificador único do projeto.")


### PR DESCRIPTION
Removido o root_validator que obrigava pelo menos um dos campos arquivo_docx ou comentario_usuario, garantindo que ambos sejam opcionais conforme solicitado pelo usuário.