### PR TITLE
Atualização do endpoint /start para aceitar arquivo_docx e comentario_extra como campos opcionais, removendo validação que os tornava obrigatórios.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -61,8 +61,7 @@ async def start_analysis(
             blob_filename,
             background_tasks
         )
-    if not texto_extraido and not comentario_extra:
-        raise HTTPException(status_code=400, detail="É obrigatório fornecer arquivo_docx ou comentario_extra.")
+    # Removido: validação obrigatória de arquivo_docx ou comentario_extra
     if project_state:
         redis_service.restore_session_from_state(
             usuario_executor,


### PR DESCRIPTION
Removida a validação manual que exigia pelo menos arquivo_docx ou comentario_extra. O endpoint agora aceita ambos os campos como opcionais, alinhado à modelagem do payload.