### PR TITLE
Criação dos modelos Pydantic para os payloads de auditoria.

### DIFF
--- a/backend/app/models/audit_models.py
+++ b/backend/app/models/audit_models.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Any
+from datetime import datetime
+
+class FrontendToBackendPayload(BaseModel):
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    endpoint: str
+    method: str
+    payload_data: Any
+    usuario_executor: Optional[str] = None
+    project_id: Optional[str] = None
+
+class BackendToFrontendPayload(BaseModel):
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    endpoint: str
+    status_code: int
+    response_data: Any
+    usuario_executor: Optional[str] = None
+    project_id: Optional[str] = None
+
+class MCPToBackendPayload(BaseModel):
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    webhook_type: str
+    payload_data: Any
+    project_id: Optional[str] = None
+
+class BackendToMCPPayload(BaseModel):
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    analysis_type: str
+    payload_data: Any
+    project_id: Optional[str] = None


### PR DESCRIPTION
Foram criados modelos Pydantic para representar os payloads de auditoria das comunicações entre frontend e backend, e entre MCP e backend, incluindo campos para timestamp, endpoint, método, status, dados do payload, usuário executor e project_id.