### PR TITLE
Integração do AuditService no endpoint POST /analysis/start.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -9,6 +9,7 @@ from ..services.redis_session_service import RedisSessionService
 from ..services.project_state_service import ProjectStateService
 from ..services.blob_storage_service import upload_docx_to_blob
 from ..services.docx_parser_service import extract_text_from_docx
+from ..services.audit_service import AuditService
 
 import uuid
 
@@ -31,6 +32,21 @@ async def start_analysis(
     current_user: dict = Depends(get_current_user)
 ):
     usuario_executor = _extract_usuario_executor(current_user)
+    # Auditoria: salva payload recebido do frontend
+    try:
+        form_data = await request.form()
+        form_dict = dict(form_data)
+        if arquivo_docx is not None:
+            form_dict["arquivo_docx_filename"] = arquivo_docx.filename
+        AuditService.save_frontend_to_backend_payload(
+            payload=form_dict,
+            endpoint="/analysis/start",
+            method="POST",
+            usuario_executor=usuario_executor,
+            project_id=None
+        )
+    except Exception as e:
+        logger.error(f"Erro ao auditar payload frontend->backend: {e}")
     logger.info(f"Iniciando análise para projeto '{nome_projeto}' (analysis_type: '{analysis_type}') para usuário {usuario_executor}")
     redis_service = RedisSessionService()
     project_id_final = await ProjectStateService._get_project_id_by_name(usuario_executor, nome_projeto)
@@ -92,8 +108,20 @@ async def start_analysis(
     except Exception as e:
         logger.error(f"Erro na comunicação com MCP: {e}")
         raise HTTPException(status_code=502, detail=f"Erro ao comunicar com o servidor de Inteligência (MCP): {str(e)}")
-    return StartAnalysisResponse(
+    response_payload = StartAnalysisResponse(
         message="Análise solicitada com sucesso ao agente.",
         project_id=project_id_final,
         nome_projeto=nome_projeto
     )
+    # Auditoria: salva payload de resposta do backend para o frontend
+    try:
+        AuditService.save_backend_to_frontend_payload(
+            response=response_payload.dict(),
+            endpoint="/analysis/start",
+            status_code=200,
+            usuario_executor=usuario_executor,
+            project_id=project_id_final
+        )
+    except Exception as e:
+        logger.error(f"Erro ao auditar payload backend->frontend: {e}")
+    return response_payload


### PR DESCRIPTION
Integradas chamadas ao AuditService para salvar os payloads recebidos do frontend e as respostas enviadas do backend no endpoint POST /analysis/start, garantindo o registro das comunicações para auditoria futura.