### PR TITLE
Ajuste na serialização do payload enviado ao MCP para usar safe_json_dumps e evitar erros de serialização datetime.

### DIFF
--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -3,8 +3,9 @@ import httpx
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field, validator
 from backend.app.core.config import settings
-from fastapi.encoders import jsonable_encoder
 from backend.app.services.audit_service import AuditService
+from backend.app.utils.json_encoder import safe_json_dumps
+import json
 
 class MCPStartAnalysisPayload(BaseModel):
     project_id: str = Field(...)
@@ -51,10 +52,11 @@ class MCPClientService:
         }
         try:
             AuditService.save_backend_to_mcp_payload(mcp_payload, payload["analysis_type"], payload["project_id"])
+            json_payload = safe_json_dumps(mcp_payload)
             async with httpx.AsyncClient(timeout=60.0) as client:
                 response = await client.post(
                     url,
-                    json=jsonable_encoder(mcp_payload),
+                    content=json_payload,
                     headers={"Content-Type": "application/json"}
                 )
                 if response.status_code != 200:


### PR DESCRIPTION
Modificado o método start_analysis para serializar o payload com safe_json_dumps antes do envio HTTP, garantindo que campos datetime sejam convertidos para string ISO 8601.