### PR TITLE
Atualiza upload_json_to_blob para usar safe_json_dumps, garantindo serialização correta de datetime.

### DIFF
--- a/backend/app/services/blob_storage_service.py
+++ b/backend/app/services/blob_storage_service.py
@@ -6,6 +6,7 @@ from backend.app.core.config import settings
 import asyncio
 from backend.app.services.docx_parser_service import extract_text_from_docx
 import json
+from backend.app.utils.json_encoder import safe_json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ def upload_json_to_blob(json_data: dict, blob_folder: str, blob_filename: str) -
     blob_path = f"{blob_folder}/{blob_filename}"
     blob_client = container_client.get_blob_client(blob_path)
     blob_client.upload_blob(
-        json.dumps(json_data, ensure_ascii=False, separators=(",", ":")).encode("utf-8"),
+        safe_json_dumps(json_data).encode("utf-8"),
         overwrite=True,
         content_settings=None
     )


### PR DESCRIPTION
No método upload_json_to_blob do blob_storage_service.py, a serialização do JSON foi alterada para utilizar safe_json_dumps, que converte objetos datetime para string no formato ISO 8601, evitando erros de serialização JSON.