### PR TITLE
Configura json_encoders para serializar datetime como string ISO 8601 nos modelos de auditoria.

### DIFF
--- a/backend/app/models/audit_models.py
+++ b/backend/app/models/audit_models.py
@@ -9,6 +9,10 @@ class FrontendToBackendPayload(BaseModel):
     payload_data: Any
     usuario_executor: Optional[str] = None
     project_id: Optional[str] = None
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.isoformat() if v else None
+        }
 
 class BackendToFrontendPayload(BaseModel):
     timestamp: datetime = Field(default_factory=datetime.utcnow)
@@ -17,15 +21,27 @@ class BackendToFrontendPayload(BaseModel):
     response_data: Any
     usuario_executor: Optional[str] = None
     project_id: Optional[str] = None
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.isoformat() if v else None
+        }
 
 class MCPToBackendPayload(BaseModel):
     timestamp: datetime = Field(default_factory=datetime.utcnow)
     webhook_type: str
     payload_data: Any
     project_id: Optional[str] = None
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.isoformat() if v else None
+        }
 
 class BackendToMCPPayload(BaseModel):
     timestamp: datetime = Field(default_factory=datetime.utcnow)
     analysis_type: str
     payload_data: Any
     project_id: Optional[str] = None
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.isoformat() if v else None
+        }


### PR DESCRIPTION
Nos modelos de auditoria em audit_models.py, foi adicionado o atributo json_encoders na Config de cada modelo para converter campos datetime em strings ISO 8601 durante a serialização JSON, prevenindo erros de serialização.