### PR TITLE
Correção do erro de importação no audit_service.py para suporte à auditoria JSON.

### DIFF
--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from datetime import datetime
 from backend.app.services.blob_storage_service import _get_blob_clients, upload_json_to_blob
 from backend.app.models.audit_models import (


### PR DESCRIPTION
Adicionada a linha 'import json' no início do arquivo backend/app/services/audit_service.py para corrigir o erro 'name 'json' is not defined' que ocorria durante a execução da função start_analysis, especificamente ao tentar auditar o payload frontend->backend e comunicar com o servidor MCP.