### PR TITLE
Ajuste na inicialização dos campos de relatório para garantir que listas vazias sejam atribuídas somente na criação de um projeto novo, preservando os relatórios existentes ao restaurar sessões.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -54,7 +54,10 @@ class RedisSessionService:
         ]
         if initial_state:
             for field in report_fields:
-                session_data[field] = initial_state.get(field, [])
+                if field in initial_state:
+                    session_data[field] = initial_state[field]
+                else:
+                    session_data[field] = None
         else:
             for field in report_fields:
                 session_data[field] = []
@@ -134,16 +137,7 @@ class RedisSessionService:
         session_data["usuario_executor"] = usuario_executor
         session_data["nome_projeto"] = nome_projeto
         session_data["analysis_type"] = analysis_type
-        report_fields = [
-            "epicos_report",
-            "features_report",
-            "times_descricao_report",
-            "alocacao_times_report",
-            "premissas_riscos_report"
-        ]
-        for field in report_fields:
-            if field not in session_data:
-                session_data[field] = []
+        # Removida a lógica que sobrescrevia os campos de relatório por listas vazias
         if not project_id:
             self.logger.error(f"[restore_session_from_state] Estado não contém project_id para nome_projeto='{nome_projeto}'.")
             raise ValueError(f"Estado do projeto não contém project_id para nome_projeto='{nome_projeto}'.")


### PR DESCRIPTION
No método create_session, os campos de relatório são inicializados como listas vazias apenas se initial_state não for fornecido, indicando um projeto novo. Caso initial_state exista, os valores dos relatórios são preservados conforme o estado fornecido. No método restore_session_from_state, foi removida toda a lógica que sobrescrevia os campos de relatório por listas vazias, garantindo que o estado restaurado mantenha os relatórios existentes intactos, evitando reinicializações indevidas durante análises em projetos já existentes.