### PR TITLE
Ajusta o endpoint /analysis/start para que apenas projetos novos inicializem os campos de relatório como listas vazias, enquanto projetos existentes restauram o estado preservando os relatórios.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -79,7 +79,6 @@ async def start_analysis(
         )
     # Removido: validação obrigatória de arquivo_docx ou comentario_extra
     if project_state:
-        # Passa o project_state integralmente para restaurar a sessão, preservando os relatórios existentes
         redis_service.restore_session_from_state(
             usuario_executor,
             nome_projeto,


### PR DESCRIPTION
No endpoint /analysis/start, a criação de sessão com relatórios vazios ocorre somente para projetos novos. Para projetos existentes, o estado mais recente é carregado e restaurado sem sobrescrever os campos de relatório, evitando perda de dados durante atualizações.