### PR TITLE
Correção na atualização de relatórios via webhook MCP para preservar todos os campos existentes e atualizar somente o relatório especificado.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -28,13 +28,10 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
                 logger.error(f"Estrutura de report_data inválida para project_id '{payload.project_id}'")
                 raise HTTPException(status_code=400, detail=f"Estrutura de report_data inválida")
             report_field = list(report_data.keys())[0]
-            if not hasattr(session, report_field) or getattr(session, report_field) is None:
-                logger.warning(f"Campo de relatório '{report_field}' não existia ou estava None para project_id '{payload.project_id}'. Inicializando como lista vazia.")
-                setattr(session, report_field, [])
-            valor_anterior = getattr(session, report_field)
+            logger.debug(f"[WEBHOOK] Antes da atualização: {[getattr(session, rf, None) for rf in ['epicos_report','features_report','times_descricao_report','alocacao_times_report','premissas_riscos_report']]}")
             redis_service.update_report(payload.project_id, report_data)
-            logger.info(f"Campo de relatório '{report_field}' atualizado via webhook para project_id {payload.project_id}. Valor anterior: {valor_anterior}")
             session = redis_service.get_session_by_project_id(payload.project_id)
+            logger.debug(f"[WEBHOOK] Depois da atualização: {[getattr(session, rf, None) for rf in ['epicos_report','features_report','times_descricao_report','alocacao_times_report','premissas_riscos_report']]}")
             await ProjectStateService.save_state_to_blob(session)
             state = session.to_project_state()
             return {"status": "ok", "project_id": payload.project_id, "nome_projeto": session.nome_projeto, "state": state}


### PR DESCRIPTION
No endpoint POST /webhooks/mcp, ao receber status 'done', a função update_report do RedisSessionService é utilizada para atualizar apenas o relatório especificado, preservando os demais. Logs de debug mostram o conteúdo de todos os campos de relatório antes e depois da atualização. O estado salvo no Blob Storage reflete fielmente todos os campos presentes, sem inicializações indevidas.