### PR TITLE
Criação dos modelos Pydantic para estados de resumo e reports, com campos específicos para cada tipo de estado conforme especificado.

### DIFF
--- a/backend/app/models/project_state_models.py
+++ b/backend/app/models/project_state_models.py
@@ -1,0 +1,44 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List, Any
+from datetime import datetime
+
+class EstadoResumoProjeto(BaseModel):
+    nome_projeto: str = Field(...)
+    ultima_analysis_type: Optional[str] = Field(None)
+    created_at: datetime = Field(...)
+    ultima_atualizacao: datetime = Field(...)
+
+class EstadoEpicos(BaseModel):
+    nome_projeto: str = Field(...)
+    ultima_analysis_type: Optional[str] = Field(None)
+    created_at: datetime = Field(...)
+    ultima_atualizacao: datetime = Field(...)
+    epicos_report: List[Any] = Field(default_factory=list)
+
+class EstadoFeatures(BaseModel):
+    nome_projeto: str = Field(...)
+    ultima_analysis_type: Optional[str] = Field(None)
+    created_at: datetime = Field(...)
+    ultima_atualizacao: datetime = Field(...)
+    features_report: List[Any] = Field(default_factory=list)
+
+class EstadoTimesDescricao(BaseModel):
+    nome_projeto: str = Field(...)
+    ultima_analysis_type: Optional[str] = Field(None)
+    created_at: datetime = Field(...)
+    ultima_atualizacao: datetime = Field(...)
+    times_descricao_report: List[Any] = Field(default_factory=list)
+
+class EstadoAlocacaoTimes(BaseModel):
+    nome_projeto: str = Field(...)
+    ultima_analysis_type: Optional[str] = Field(None)
+    created_at: datetime = Field(...)
+    ultima_atualizacao: datetime = Field(...)
+    alocacao_times_report: List[Any] = Field(default_factory=list)
+
+class EstadoPremissasRiscos(BaseModel):
+    nome_projeto: str = Field(...)
+    ultima_analysis_type: Optional[str] = Field(None)
+    created_at: datetime = Field(...)
+    ultima_atualizacao: datetime = Field(...)
+    premissas_riscos_report: List[Any] = Field(default_factory=list)


### PR DESCRIPTION
Modelos Pydantic criados para representar o estado resumo do projeto e os estados específicos para cada tipo de report, com os campos nome_projeto, ultima_analysis_type, created_at, ultima_atualizacao e os dados específicos de cada report.