### PR TITLE
Refatoração do ProjectStateService para suportar múltiplos estados por projeto, com métodos para salvar e carregar estados de resumo e estados específicos de reports, usando o mapeamento de analysis_type para report.

### DIFF
--- a/backend/app/services/project_state_service.py
+++ b/backend/app/services/project_state_service.py
@@ -4,20 +4,33 @@ from typing import Optional, Dict, Any, List
 from backend.app.core.config import settings
 from backend.app.services.blob_storage_service import _get_blob_clients
 import logging
+from backend.app.models.project_state_models import (
+    EstadoResumoProjeto,
+    EstadoEpicos,
+    EstadoFeatures,
+    EstadoTimesDescricao,
+    EstadoAlocacaoTimes,
+    EstadoPremissasRiscos
+)
+from backend.app.config.analysis_type_to_report_mapping import analysis_type_to_report_mapping
 
 class ProjectStateService:
     _project_id_cache = {}
 
     @staticmethod
-    async def save_state_to_blob(session_data) -> str:
-        state = session_data.to_project_state()
-        usuario_executor = state.get("usuario_executor")
-        nome_projeto = state.get("nome_projeto")
-        project_id = state.get("project_id")
+    async def save_state_to_blob(session_data, report_type: Optional[str] = None) -> str:
+        usuario_executor = getattr(session_data, "usuario_executor", None)
+        nome_projeto = getattr(session_data, "nome_projeto", None)
+        project_id = getattr(session_data, "project_id", None)
         timestamp = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
-        state["last_saved_to_blob"] = datetime.datetime.utcnow().isoformat()
+        last_update = datetime.datetime.utcnow()
         blob_folder = f"{usuario_executor}/{nome_projeto}/estados"
-        blob_filename = f"estado_{timestamp}.json"
+        if report_type:
+            blob_filename = f"estado_{report_type}_{timestamp}.json"
+            state = ProjectStateService._build_report_state(session_data, report_type, last_update)
+        else:
+            blob_filename = f"estado_resumo_{timestamp}.json"
+            state = ProjectStateService._build_resumo_state(session_data, last_update)
         blob_path = f"{blob_folder}/{blob_filename}"
         _, container_client = _get_blob_clients()
         blob_client = container_client.get_blob_client(blob_path)
@@ -26,7 +39,72 @@ class ProjectStateService:
         return blob_client.url
 
     @staticmethod
-    async def load_latest_state_from_blob(usuario_executor: str, project_id: Optional[str] = None, nome_projeto: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    def _build_resumo_state(session_data, last_update):
+        nome_projeto = getattr(session_data, "nome_projeto", None)
+        ultima_analysis_type = getattr(session_data, "analysis_type", None)
+        created_at = getattr(session_data, "created_at", None)
+        if isinstance(created_at, str):
+            created_at = datetime.datetime.fromisoformat(created_at)
+        return EstadoResumoProjeto(
+            nome_projeto=nome_projeto,
+            ultima_analysis_type=ultima_analysis_type,
+            created_at=created_at or datetime.datetime.utcnow(),
+            ultima_atualizacao=last_update
+        ).dict()
+
+    @staticmethod
+    def _build_report_state(session_data, report_type, last_update):
+        nome_projeto = getattr(session_data, "nome_projeto", None)
+        ultima_analysis_type = getattr(session_data, "analysis_type", None)
+        created_at = getattr(session_data, "created_at", None)
+        if isinstance(created_at, str):
+            created_at = datetime.datetime.fromisoformat(created_at)
+        report_data = getattr(session_data, report_type, [])
+        if report_type == "epicos_report":
+            return EstadoEpicos(
+                nome_projeto=nome_projeto,
+                ultima_analysis_type=ultima_analysis_type,
+                created_at=created_at or datetime.datetime.utcnow(),
+                ultima_atualizacao=last_update,
+                epicos_report=report_data
+            ).dict()
+        elif report_type == "features_report":
+            return EstadoFeatures(
+                nome_projeto=nome_projeto,
+                ultima_analysis_type=ultima_analysis_type,
+                created_at=created_at or datetime.datetime.utcnow(),
+                ultima_atualizacao=last_update,
+                features_report=report_data
+            ).dict()
+        elif report_type == "times_descricao_report":
+            return EstadoTimesDescricao(
+                nome_projeto=nome_projeto,
+                ultima_analysis_type=ultima_analysis_type,
+                created_at=created_at or datetime.datetime.utcnow(),
+                ultima_atualizacao=last_update,
+                times_descricao_report=report_data
+            ).dict()
+        elif report_type == "alocacao_times_report":
+            return EstadoAlocacaoTimes(
+                nome_projeto=nome_projeto,
+                ultima_analysis_type=ultima_analysis_type,
+                created_at=created_at or datetime.datetime.utcnow(),
+                ultima_atualizacao=last_update,
+                alocacao_times_report=report_data
+            ).dict()
+        elif report_type == "premissas_riscos_report":
+            return EstadoPremissasRiscos(
+                nome_projeto=nome_projeto,
+                ultima_analysis_type=ultima_analysis_type,
+                created_at=created_at or datetime.datetime.utcnow(),
+                ultima_atualizacao=last_update,
+                premissas_riscos_report=report_data
+            ).dict()
+        else:
+            raise ValueError(f"Report type desconhecido: {report_type}")
+
+    @staticmethod
+    async def load_latest_state_from_blob(usuario_executor: str, project_id: Optional[str] = None, nome_projeto: Optional[str] = None, report_type: Optional[str] = None) -> Optional[Dict[str, Any]]:
         logger = logging.getLogger("ProjectStateService")
         _, container_client = _get_blob_clients()
         prefix = f"{usuario_executor}/"
@@ -34,13 +112,15 @@ class ProjectStateService:
         states = []
         for blob in blobs:
             if blob.name.endswith('.json'):
+                if report_type:
+                    if f"estado_{report_type}_" not in blob.name:
+                        continue
+                else:
+                    if "estado_resumo_" not in blob.name:
+                        continue
                 blob_client = container_client.get_blob_client(blob.name)
                 state_bytes = blob_client.download_blob().readall()
                 state = json.loads(state_bytes.decode("utf-8"))
-                state.pop("projeto", None)
-                state.pop("comentario_usuario", None)
-                state.pop("docx_blob_url", None)
-                state.pop("extracted_text", None)
                 if project_id and state.get("project_id") == project_id:
                     return state
                 if nome_projeto and state.get("nome_projeto") == nome_projeto:
@@ -48,7 +128,7 @@ class ProjectStateService:
         if nome_projeto and states:
             def get_sort_key(item):
                 state = item[1]
-                ts = state.get("last_saved_to_blob")
+                ts = state.get("ultima_atualizacao") or state.get("last_saved_to_blob")
                 if ts:
                     try:
                         return datetime.datetime.fromisoformat(ts)
@@ -57,7 +137,7 @@ class ProjectStateService:
                 return datetime.datetime.min
             states_sorted = sorted(states, key=get_sort_key, reverse=True)
             return states_sorted[0][1]
-        logger.info(f"Nenhum estado encontrado para usuario_executor={usuario_executor}, project_id={project_id}, nome_projeto={nome_projeto}")
+        logger.info(f"Nenhum estado encontrado para usuario_executor={usuario_executor}, project_id={project_id}, nome_projeto={nome_projeto}, report_type={report_type}")
         return None
 
     @staticmethod
@@ -77,84 +157,3 @@ class ProjectStateService:
         keys_to_remove = [k for k in ProjectStateService._project_id_cache if k.endswith(f":{nome_projeto}")]
         for k in keys_to_remove:
             del ProjectStateService._project_id_cache[k]
-
-    @staticmethod
-    async def get_latest_analysis_metadata(usuario_executor: str, project_id: Optional[str] = None) -> Dict[str, str]:
-        state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, project_id=project_id)
-        if not state:
-            return {}
-        analysis_type = state.get("analysis_type")
-        return {
-            "analysis_type": analysis_type
-        }
-
-    @staticmethod
-    async def list_user_projects(usuario_executor: str) -> List[Dict[str, Any]]:
-        logger = logging.getLogger("ProjectStateService")
-        projects = {}
-        try:
-            _, container_client = _get_blob_clients()
-            prefix = f"{usuario_executor}/"
-            blobs = list(container_client.list_blobs(name_starts_with=prefix))
-            for blob in blobs:
-                parts = blob.name.split('/')
-                if len(parts) >= 4 and parts[2] == 'estados' and blob.name.endswith('.json'):
-                    nome_projeto = parts[1]
-                    if nome_projeto not in projects:
-                        projects[nome_projeto] = []
-                    projects[nome_projeto].append(blob)
-            result = []
-            for nome_projeto, blob_list in projects.items():
-                blob_list_sorted = sorted(blob_list, key=lambda b: b.name, reverse=True)
-                latest_blob = blob_list_sorted[0]
-                blob_client = container_client.get_blob_client(latest_blob.name)
-                state_bytes = blob_client.download_blob().readall()
-                state = json.loads(state_bytes.decode("utf-8"))
-                state.pop("projeto", None)
-                state.pop("comentario_usuario", None)
-                state.pop("docx_blob_url", None)
-                state.pop("extracted_text", None)
-                item = {
-                    "nome_projeto": state.get("nome_projeto", nome_projeto),
-                    "analysis_type": state.get("analysis_type"),
-                    "created_at": state.get("created_at"),
-                    "last_saved_to_blob": state.get("last_saved_to_blob"),
-                    "project_id": state.get("project_id"),
-                    "docx_files": state.get("docx_files", []),
-                    "epicos_report": state.get("epicos_report"),
-                    "features_report": state.get("features_report"),
-                    "times_descricao_report": state.get("times_descricao_report"),
-                    "alocacao_times_report": state.get("alocacao_times_report"),
-                    "premissas_riscos_report": state.get("premissas_riscos_report")
-                }
-                result.append(item)
-            return result
-        except Exception as e:
-            logger.error(f"Erro ao listar projetos do usuário {usuario_executor}: {e}")
-            return []
-
-    @staticmethod
-    def _sanitize_project_list(projects: list) -> list:
-        sanitized = []
-        for p in projects:
-            if isinstance(p, dict):
-                p = dict(p)
-                p.pop("projeto", None)
-                p.pop("comentario_usuario", None)
-                p.pop("docx_blob_url", None)
-                p.pop("extracted_text", None)
-                if "project_id" not in p or not p["project_id"]:
-                    continue
-                sanitized.append(p)
-        return sanitized
-
-    @staticmethod
-    async def _fetch_and_sanitize_projects(usuario_executor: str) -> list:
-        logger = logging.getLogger("ProjectStateService")
-        try:
-            projects = await ProjectStateService.list_user_projects(usuario_executor)
-            sanitized = ProjectStateService._sanitize_project_list(projects)
-            return sanitized
-        except Exception as e:
-            logger.error(f"Erro ao buscar projetos do usuário {usuario_executor}: {e}")
-            return []


### PR DESCRIPTION
O serviço foi modificado para salvar estados distintos para o resumo geral do projeto e para cada tipo de report, utilizando os modelos correspondentes. A leitura dos estados também foi adaptada para buscar o estado correto conforme o tipo de report solicitado. Implementa cache para project_id e invalida cache após atualizações.