### PR TITLE
Refatoração do RedisSessionService para suportar múltiplos estados de reports por projeto, com métodos para criar, atualizar e obter estados individuais de reports e o estado resumo geral do projeto.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -30,10 +30,7 @@ class RedisSessionService:
         return json.loads(session_json)
 
     def create_session(self, usuario_executor: str, nome_projeto: str, analysis_type: str, project_id: str, extracted_text: Optional[str] = None, initial_state: Optional[Dict[str, Any]] = None) -> str:
-        key = f"project:{project_id}"
-        if self.redis_client.exists(key):
-            self.logger.warning(f"Sessão já existe para project_id={project_id}. Não será criada nova sessão.")
-            return project_id
+        key = f"project:{project_id}:resumo"
         created_at = datetime.utcnow().isoformat()
         last_saved_to_blob = datetime.utcnow().isoformat()
         session_data = {
@@ -42,135 +39,43 @@ class RedisSessionService:
             "analysis_type": analysis_type,
             "created_at": created_at,
             "last_saved_to_blob": last_saved_to_blob,
-            "docx_files": [],
-            "project_id": project_id
+            "project_id": project_id,
+            "ultima_analysis_type": analysis_type,
+            "ultima_atualizacao": last_saved_to_blob
         }
-        report_fields = [
-            "epicos_report",
-            "features_report",
-            "times_descricao_report",
-            "alocacao_times_report",
-            "premissas_riscos_report"
-        ]
-        if initial_state:
-            for field in report_fields:
-                session_data[field] = initial_state.get(field, [])
-        else:
-            for field in report_fields:
-                session_data[field] = []
-        if extracted_text is not None:
-            session_data["extracted_text"] = extracted_text
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
         return project_id
 
-    def get_session_by_project_id(self, project_id: str) -> SessionData:
-        key = f"project:{project_id}"
-        session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Projeto {project_id} não encontrado no Redis.")
-        session_dict = self._deserialize_session(session_json)
-        return SessionData(**session_dict)
+    def create_report_state(self, project_id: str, report_type: str, state_data: Dict[str, Any]):
+        key = f"project:{project_id}:report:{report_type}"
+        self.redis_client.setex(key, self.session_ttl, self._serialize_session(state_data))
 
-    def update_session_status(self, project_id: str, status: str):
-        key = f"project:{project_id}"
-        session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Projeto {project_id} não encontrado no Redis.")
-        session_data = self._deserialize_session(session_json)
-        session_data["status"] = status
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
+    def update_report_state(self, project_id: str, report_type: str, state_data: Dict[str, Any]):
+        key = f"project:{project_id}:report:{report_type}"
+        self.redis_client.setex(key, self.session_ttl, self._serialize_session(state_data))
 
-    async def _save_to_blob_after_update(self, project_id: str):
-        try:
-            session = self.get_session_by_project_id(project_id)
-            await ProjectStateService.save_state_to_blob(session)
-        except Exception as e:
-            self.logger.error(f"Erro ao salvar estado no Blob após update_report para project_id={project_id}: {e}")
-
-    def _update_single_field(self, project_id: str, field_name: str, field_value: Any):
-        key = f"project:{project_id}"
+    def get_report_state(self, project_id: str, report_type: str) -> Optional[Dict[str, Any]]:
+        key = f"project:{project_id}:report:{report_type}"
         session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Projeto {project_id} não encontrado no Redis.")
-        session_data = self._deserialize_session(session_json)
-        session_data[field_name] = field_value
-        session_data["last_modified"] = datetime.utcnow().isoformat()
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
+        if session_json:
+            return self._deserialize_session(session_json)
+        return None
 
-    def update_report(self, project_id: str, report_data: Dict[str, Any]):
-        key = f"project:{project_id}"
+    def get_resumo_state(self, project_id: str) -> Optional[Dict[str, Any]]:
+        key = f"project:{project_id}:resumo"
         session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Projeto {project_id} não encontrado no Redis.")
-        session_data = self._deserialize_session(session_json)
-        if not isinstance(report_data, dict) or len(report_data) != 1:
-            raise ValueError("report_data deve ser um dicionário com exatamente uma chave de relatório")
-        valid_report_fields = [
-            "epicos_report",
-            "features_report",
-            "times_descricao_report",
-            "alocacao_times_report",
-            "premissas_riscos_report"
-        ]
-        if len(list(report_data.keys())) > 1:
-            raise ValueError(f"erro, deve haver apenas uma chave o report")
-        report_field = list(report_data.keys())[0]
-        if report_field not in valid_report_fields:
-            raise ValueError(f"Chave de relatório '{report_field}' não é válida. Esperado uma das: {valid_report_fields}")
-        if report_field not in session_data or session_data[report_field] is None or not isinstance(session_data[report_field], list):
-            self.logger.debug(f"Campo '{report_field}' não existia ou era None. Inicializando como lista vazia antes de atualizar.")
-            session_data[report_field] = []
-        valor_anterior = session_data[report_field]
-        report_value = report_data[report_field]
-        session_data[report_field] = report_value
-        session_data["last_modified"] = datetime.utcnow().isoformat()
-        self.logger.debug(f"Atualizando campo de relatório '{report_field}' para project_id={project_id}. Valor anterior: {valor_anterior} | Novo valor: {report_value}")
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
+        if session_json:
+            return self._deserialize_session(session_json)
+        return None
 
     def restore_session_from_state(self, usuario_executor: str, nome_projeto: str, analysis_type: str, project_state: Dict[str, Any]) -> str:
         project_id = project_state.get("project_id")
-        key = f"project:{project_id}"
+        key = f"project:{project_id}:resumo"
         session_data = dict(project_state)
         session_data["usuario_executor"] = usuario_executor
         session_data["nome_projeto"] = nome_projeto
         session_data["analysis_type"] = analysis_type
-        report_fields = [
-            "epicos_report",
-            "features_report",
-            "times_descricao_report",
-            "alocacao_times_report",
-            "premissas_riscos_report"
-        ]
-        for field in report_fields:
-            if field not in session_data:
-                session_data[field] = []
-        if not project_id:
-            self.logger.error(f"[restore_session_from_state] Estado não contém project_id para nome_projeto='{nome_projeto}'.")
-            raise ValueError(f"Estado do projeto não contém project_id para nome_projeto='{nome_projeto}'.")
-        if "project_id" in session_data and session_data["project_id"] != project_id:
-            self.logger.critical(f"[restore_session_from_state] Divergência de project_id detectada: project_id do estado='{session_data['project_id']}', esperado='{project_id}'.")
-            raise ValueError(f"Divergência de project_id detectada ao restaurar sessão: estado='{session_data['project_id']}', esperado='{project_id}'")
+        session_data["ultima_analysis_type"] = analysis_type
+        session_data["ultima_atualizacao"] = datetime.utcnow().isoformat()
         self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
         return project_id
-
-    def add_docx_file(self, project_id: str, blob_url: str):
-        key = f"project:{project_id}"
-        session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Projeto {project_id} não encontrado no Redis.")
-        session_data = self._deserialize_session(session_json)
-        if "docx_files" not in session_data or not isinstance(session_data["docx_files"], list):
-            session_data["docx_files"] = []
-        if blob_url not in session_data["docx_files"]:
-            session_data["docx_files"].append(blob_url)
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))
-
-    def update_session_on_state_change(self, project_id: str, updated_fields: Dict[str, Any]):
-        key = f"project:{project_id}"
-        session_json = self.redis_client.get(key)
-        if not session_json:
-            raise ValueError(f"Projeto {project_id} não encontrado no Redis.")
-        session_data = self._deserialize_session(session_json)
-        session_data.update(updated_fields)
-        session_data["last_modified"] = datetime.utcnow().isoformat()
-        self.redis_client.setex(key, self.session_ttl, self._serialize_session(session_data))


### PR DESCRIPTION
Adicionados métodos para manipular estados específicos de reports no Redis, usando chaves no formato project:{project_id}:report:{report_type}, além do estado resumo do projeto em project:{project_id}:resumo. O estado resumo contém campos gerais do projeto, enquanto cada report possui seu próprio estado com campos específicos.