### PR TITLE
Ajuste do endpoint POST /auth/login para validar token, extrair usuario_executor e retornar projetos associados.

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -5,6 +5,7 @@ from backend.app.core.config import settings
 from backend.app.middleware.auth_middleware import get_current_user, _extract_usuario_executor
 from backend.app.services.project_state_service import ProjectStateService
 from backend.app.services.redis_session_service import RedisSessionService
+import logging
 
 router = APIRouter()
 
@@ -36,26 +37,27 @@ def get_auth_config():
 
 @router.post("/login", response_model=AuthLoginResponse, tags=["Auth"])
 async def auth_login(current_user: dict = Depends(get_current_user)):
+    logger = logging.getLogger("auth_api")
     usuario_executor = _extract_usuario_executor(current_user)
     if not usuario_executor:
+        logger.error("Usuário não autenticado: usuario_executor ausente no token.")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não autenticado.")
-    projects = await ProjectStateService._fetch_and_sanitize_projects(usuario_executor)
+    projetos = await ProjectStateService._fetch_and_sanitize_projects(usuario_executor)
     redis_service = RedisSessionService()
-    import logging
-    logger = logging.getLogger("auth_api")
     resumo_list = []
-    for p in projects:
+    for p in projetos:
         project_id = p.get("project_id")
         resumo_state = redis_service.get_resumo_state(project_id)
         if resumo_state:
-            resumo_list.append(resumo_state)
-        else:
             resumo = {
-                "nome_projeto": p.get("nome_projeto", ""),
-                "ultima_analysis_type": p.get("analysis_type", ""),
-                "created_at": p.get("created_at", None),
-                "ultima_atualizacao": p.get("last_saved_to_blob", None),
-                "project_id": project_id
+                "nome_projeto": resumo_state.get("nome_projeto", ""),
+                "ultima_analysis_type": resumo_state.get("ultima_analysis_type", ""),
+                "created_at": resumo_state.get("created_at", None),
+                "ultima_atualizacao": resumo_state.get("ultima_atualizacao", resumo_state.get("last_saved_to_blob", None)),
+                "project_id": resumo_state.get("project_id")
             }
             resumo_list.append(resumo)
+        else:
+            resumo_list.append(p)
+    logger.info(f"Login bem-sucedido para usuario_executor={usuario_executor}. Projetos retornados: {len(resumo_list)}")
     return AuthLoginResponse(user_info=current_user, projects=resumo_list)


### PR DESCRIPTION
O endpoint de login foi ajustado para receber o token do frontend, validar via middleware, extrair o usuario_executor dos claims, buscar os projetos associados via ProjectStateService e retornar ao frontend a lista de projetos resumidos, garantindo o fluxo correto de autenticação e autorização.