### PR TITLE
Validador customizado adicionado na classe EstadoResumoProjeto para garantir que o campo nome_projeto não seja None ou vazio, evitando erros de validação do Pydantic.

### DIFF
--- a/backend/app/models/project_state_models.py
+++ b/backend/app/models/project_state_models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from typing import Optional, List, Any
 from datetime import datetime
 
@@ -7,6 +7,12 @@ class EstadoResumoProjeto(BaseModel):
     ultima_analysis_type: Optional[str] = Field(None)
     created_at: datetime = Field(...)
     ultima_atualizacao: datetime = Field(...)
+
+    @validator('nome_projeto')
+    def nome_projeto_must_not_be_empty(cls, v):
+        if v is None or not isinstance(v, str) or not v.strip():
+            raise ValueError("Campo 'nome_projeto' é obrigatório e não pode ser None ou vazio para criar o estado de resumo.")
+        return v
 
 class EstadoEpicos(BaseModel):
     nome_projeto: str = Field(...)


### PR DESCRIPTION
Este PR adiciona um validador customizado na classe EstadoResumoProjeto do modelo Pydantic para assegurar que o campo nome_projeto seja sempre uma string não vazia. Caso contrário, um ValueError é lançado com mensagem clara. Isso previne erros de validação ao tentar criar instâncias com dados incompletos.