### PR TITLE
Validação defensiva nos métodos de criação e restauração de sessão para garantir campos obrigatórios.

### DIFF
--- a/backend/app/services/redis_session_service.py
+++ b/backend/app/services/redis_session_service.py
@@ -31,11 +31,11 @@ class RedisSessionService:
 
     def create_session(self, usuario_executor: str, nome_projeto: str, analysis_type: str, project_id: str, extracted_text: Optional[str] = None, initial_state: Optional[Dict[str, Any]] = None) -> str:
         if not usuario_executor or not isinstance(usuario_executor, str) or not usuario_executor.strip():
-            raise ValueError("Parâmetros obrigatórios (usuario_executor, nome_projeto, project_id) não podem ser None ou vazios. [usuario_executor]")
+            raise ValueError("Campo obrigatorio ausente: usuario_executor")
         if not nome_projeto or not isinstance(nome_projeto, str) or not nome_projeto.strip():
-            raise ValueError("Parâmetros obrigatórios (usuario_executor, nome_projeto, project_id) não podem ser None ou vazios. [nome_projeto]")
+            raise ValueError("Campo obrigatorio ausente: nome_projeto")
         if not project_id or not isinstance(project_id, str) or not project_id.strip():
-            raise ValueError("Parâmetros obrigatórios (usuario_executor, nome_projeto, project_id) não podem ser None ou vazios. [project_id]")
+            raise ValueError("Campo obrigatorio ausente: project_id")
         key = f"project:{project_id}:resumo"
         created_at = datetime.utcnow().isoformat()
         last_saved_to_blob = datetime.utcnow().isoformat()
@@ -81,7 +81,6 @@ class RedisSessionService:
         nome_projeto_val = project_state.get("nome_projeto")
         usuario_executor_val = project_state.get("usuario_executor")
         if not nome_projeto_val or not isinstance(nome_projeto_val, str) or not nome_projeto_val.strip():
-            self.logger.warning("Campo 'nome_projeto' ausente/inválido em project_state. Tentando buscar estado do Blob Storage...")
             blob_state = None
             try:
                 blob_state = asyncio.run(ProjectStateService.load_latest_state_from_blob(
@@ -94,7 +93,6 @@ class RedisSessionService:
             if blob_state:
                 nome_projeto_val = blob_state.get("nome_projeto")
         if not usuario_executor_val or not isinstance(usuario_executor_val, str) or not usuario_executor_val.strip():
-            self.logger.warning("Campo 'usuario_executor' ausente/inválido em project_state. Tentando buscar estado do Blob Storage...")
             blob_state = None
             try:
                 blob_state = asyncio.run(ProjectStateService.load_latest_state_from_blob(
@@ -107,7 +105,6 @@ class RedisSessionService:
             if blob_state:
                 usuario_executor_val = blob_state.get("usuario_executor")
         if not project_id or not isinstance(project_id, str) or not project_id.strip():
-            self.logger.warning("Campo 'project_id' ausente/inválido em project_state. Tentando buscar estado do Blob Storage...")
             blob_state = None
             try:
                 blob_state = asyncio.run(ProjectStateService.load_latest_state_from_blob(
@@ -120,7 +117,7 @@ class RedisSessionService:
             if blob_state:
                 project_id = blob_state.get("project_id")
         if not nome_projeto_val or not usuario_executor_val or not project_id:
-            raise ValueError("Parâmetros obrigatórios (usuario_executor, nome_projeto, project_id) não podem ser None ou vazios ao restaurar sessão.")
+            raise ValueError("Campos obrigatórios ausentes ao restaurar sessão: usuario_executor, nome_projeto, project_id")
         key = f"project:{project_id}:resumo"
         session_data = dict(project_state)
         session_data["usuario_executor"] = usuario_executor_val


### PR DESCRIPTION
Adicionada validação defensiva nos métodos create_session e restore_session_from_state da classe RedisSessionService para garantir que usuario_executor, nome_projeto e project_id estejam presentes antes de criar ou restaurar uma sessão. Se algum campo estiver ausente, lança ValueError com mensagem clara.