### PR TITLE
Endpoint /projects/check e listagem de projetos adaptados para trabalhar com nome_projeto como entrada e converter para project_id internamente.

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -22,11 +22,6 @@ async def check_project(
             return {"exists": False}
         state = await ProjectStateService.load_all_states_from_blob(usuario_executor, project_id=project_id)
         if state:
-            def normalize_report_field(field, default):
-                value = state.get(field)
-                if value is None:
-                    return [] if isinstance(default, list) else default
-                return value
             report_fields = [
                 "epicos",
                 "features",


### PR DESCRIPTION
O endpoint /projects/check agora retorna o estado do projeto usando o nome_projeto recebido, convertendo internamente para project_id via ProjectStateService. A listagem de projetos também mantém essa lógica, garantindo que o frontend nunca precise enviar project_id diretamente.