### PR TITLE
Atualização do documento ARCHITECTURE_FLOW.md para esclarecer que o frontend envia somente 'nome_projeto' e o backend converte para 'project_id'. Diagramas de fluxo e observações foram ajustados para refletir essa regra e evitar envio indevido do 'project_id' pelo frontend.

### DIFF
--- a/backend/docs/ARCHITECTURE_FLOW.md
+++ b/backend/docs/ARCHITECTURE_FLOW.md
@@ -32,15 +32,43 @@ sequenceDiagram
 
 ---
 
-## Etapas do Fluxo e Código Responsável
+## 2. Criação de Projeto e Conversão nome_projeto → project_id
 
-### 1. Login e Autenticação via Azure AD
-- O frontend envia o token JWT via header Authorization. O backend valida o token, extrai o usuario_executor e retorna a lista de projetos do usuário, contendo apenas o estado de resumo de cada projeto.
-- Código:
-  - `backend/app/api/auth.py` (`POST /auth/login`)
-  - `backend/app/middleware/auth_middleware.py` (`get_current_user`)
-  - `backend/app/services/azure_ad_service.py` (`validate_token`)
-  - `backend/app/services/project_state_service.py` (`_fetch_and_sanitize_projects`)
+O frontend deve sempre enviar apenas o campo `nome_projeto` para criação ou início de análise. O backend é responsável por converter internamente o `nome_projeto` para `project_id`:
+- Se o projeto já existe, o backend recupera o mesmo `project_id` do estado salvo.
+- Se o projeto é novo, o backend gera um novo `project_id` (UUID) e associa ao nome do projeto.
+- O `project_id` é retornado na resposta do backend para uso em operações subsequentes.
+
+Diagrama de Fluxo Atualizado:
+
+mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant BE as Backend
+    participant MCP as MCP Server
+    FE->>BE: POST /analysis/start (nome_projeto, analysis_type, ...)
+    BE->>BE: Converte nome_projeto para project_id (recupera existente ou gera novo)
+    BE->>MCP: Envia payload (project_id, analysis_type, ...)
+    MCP-->>BE: job_id, project_id
+    BE-->>FE: message, project_id, nome_projeto
+
+---
+
+## 3. Consulta de Projeto Existente
+
+mermaid
+sequenceDiagram
+    FE->>BE: GET /projects/check (nome_projeto)
+    BE->>BE: Busca project_id associado ao nome_projeto
+    BE-->>FE: exists: true, state (inclui project_id)
+
+---
+
+## 4. Observações Importantes
+
+- O campo `project_id` nunca deve ser enviado pelo frontend. O backend faz toda a conversão e retorna o `project_id` correto.
+- Toda comunicação interna e com MCP utiliza o `project_id` gerado ou recuperado pelo backend.
+- O frontend deve usar o `project_id` retornado para todas operações subsequentes (consultas, atualizações, etc).
 
 ---
 


### PR DESCRIPTION
Modificações no documento de arquitetura para explicitar o fluxo de conversão do nome do projeto para o project_id pelo backend. O frontend deve enviar apenas o nome do projeto nas requisições de criação e análise. O backend gera ou recupera o project_id conforme o caso e retorna esse ID para uso em operações futuras. Diagramas de sequência foram atualizados para ilustrar esse comportamento, e observações importantes foram adicionadas para reforçar a regra.