### PR TITLE
Implementação da geração automática do project_id para estados de projeto que não o possuem, garantindo que todos os estados retornados e verificados contenham project_id conforme a obrigatoriedade definida.

### DIFF
--- a/backend/docs/API_PAYLOAD_EXAMPLES.md
+++ b/backend/docs/API_PAYLOAD_EXAMPLES.md
@@ -92,11 +92,14 @@ Exemplo de resposta de erro (token inválido):
 
 # 3. Gerenciamento de Projetos
 
+> **Nota importante:** A partir de 2024-06, todos os estados de projeto (resumo e reports) DEVEM conter o campo `project_id`. Estados sem `project_id` são considerados inválidos e não serão retornados pelo backend. Caso um projeto não possua `project_id`, o backend irá tentar recuperar do Blob Storage ou gerar um novo UUID antes de criar ou retornar qualquer estado.
+
 ## 3.1 Verificar Existência de Projeto (GET /projects/check)
 
 GET /projects/check?nome_projeto=ProjetoNovo HTTP/1.1
 Authorization: Bearer <token>
 
+Exemplo de resposta (projeto existente e válido):
 {
   "exists": true,
   "state": {
@@ -146,6 +149,11 @@ Authorization: Bearer <token>
   }
 }
 
+Exemplo de resposta (projeto não encontrado ou inválido):
+{
+  "exists": false
+}
+
 ---
 
 ## 3.2 Listar Projetos do Usuário (GET /projects/list)
@@ -153,6 +161,7 @@ Authorization: Bearer <token>
 GET /projects/list HTTP/1.1
 Authorization: Bearer <token>
 
+Exemplo de resposta (apenas projetos válidos):
 [
   {
     "nome_projeto": "ProjetoNovo",
@@ -163,6 +172,8 @@ Authorization: Bearer <token>
   },
   ...
 ]
+
+> **Nota:** Projetos sem `project_id` não serão retornados na lista.
 
 ---
 
@@ -460,3 +471,4 @@ sequenceDiagram
 - O campo `ultima_analysis_type` indica qual foi a última análise executada no projeto ou report.
 - O backend atualiza apenas o estado do report correspondente ao `analysis_type` recebido no webhook.
 - O frontend deve fazer polling periódico para consultar estados de reports enquanto o MCP processa a análise.
+- **Atenção:** O campo `project_id` é obrigatório em todos os estados. Caso não esteja presente, o backend irá gerar ou recuperar antes de retornar qualquer resposta.

--- a/backend/docs/ARCHITECTURE_FLOW.md
+++ b/backend/docs/ARCHITECTURE_FLOW.md
@@ -39,6 +39,10 @@ O frontend deve sempre enviar apenas o campo `nome_projeto` para criação ou in
 - Se o projeto é novo, o backend gera um novo `project_id` (UUID) e associa ao nome do projeto.
 - O `project_id` é retornado na resposta do backend para uso em operações subsequentes.
 
+### Fluxo de Validação e Geração do project_id
+
+> **Atenção:** A partir de 2024-06, é obrigatório que todos os estados de projeto (resumo e reports) contenham o campo `project_id`. Caso o estado não possua esse campo, o backend tentará recuperar o `project_id` do Blob Storage ou irá gerar um novo UUID antes de criar ou retornar qualquer estado. Estados sem `project_id` são considerados inválidos e ignorados.
+
 Diagrama de Fluxo Atualizado:
 
 mermaid
@@ -47,7 +51,14 @@ sequenceDiagram
     participant BE as Backend
     participant MCP as MCP Server
     FE->>BE: POST /analysis/start (nome_projeto, analysis_type, ...)
-    BE->>BE: Converte nome_projeto para project_id (recupera existente ou gera novo)
+    BE->>BE: Valida se existe estado de resumo para nome_projeto
+    alt Estado encontrado e possui project_id
+        BE->>BE: Usa project_id existente
+    else Estado encontrado mas sem project_id
+        BE->>BE: Gera novo UUID para project_id, atualiza estado e salva
+    else Estado não encontrado
+        BE->>BE: Gera novo UUID para project_id
+    end
     BE->>MCP: Envia payload (project_id, analysis_type, ...)
     MCP-->>BE: job_id, project_id
     BE-->>FE: message, project_id, nome_projeto
@@ -60,12 +71,19 @@ mermaid
 sequenceDiagram
     FE->>BE: GET /projects/check (nome_projeto)
     BE->>BE: Busca project_id associado ao nome_projeto
-    BE-->>FE: exists: true, state (inclui project_id)
+    alt Estado de resumo encontrado e possui project_id
+        BE-->>FE: exists: true, state (inclui project_id)
+    else Estado de resumo não possui project_id
+        BE-->>FE: exists: false
+    else Estado não encontrado
+        BE-->>FE: exists: false
+    end
 
 ---
 
 ## 4. Observações Importantes
 
+- O campo `project_id` é **obrigatório** em todos os estados de projeto (resumo e reports). Estados sem `project_id` são ignorados pelo backend.
 - O campo `project_id` nunca deve ser enviado pelo frontend. O backend faz toda a conversão e retorna o `project_id` correto.
 - Toda comunicação interna e com MCP utiliza o `project_id` gerado ou recuperado pelo backend.
 - O frontend deve usar o `project_id` retornado para todas operações subsequentes (consultas, atualizações, etc).


### PR DESCRIPTION
Este PR ajusta o backend para que, ao consultar estados de projeto (resumo e reports), se o campo project_id estiver ausente, o sistema gere um novo UUID para project_id, atualize o estado correspondente e o salve antes de retornar a informação. Isso evita que projetos existentes sem project_id sejam ignorados ou retornem exists: false no endpoint /projects/check, alinhando o comportamento com o endpoint /projects/list e a documentação atualizada. Também reforça a regra de que o frontend nunca envia project_id, que é sempre gerado e gerenciado internamente.