### PR TITLE
Correção na limpeza e substituição do campo 'analysis_type' por 'ultima_analysis_type' no endpoint de listagem de projetos.

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -19,7 +19,6 @@ async def check_project(
         project_id = await ProjectStateService._get_project_id_by_name(usuario_executor, nome_projeto)
         if not project_id:
             logger.warning(f"[CHECK] Nenhum project_id encontrado para nome_projeto='{nome_projeto}' e usuario_executor='{usuario_executor}'. Verificando estados de resumo no Blob Storage...")
-            # Busca estados de resumo manualmente para rastrear possíveis problemas
             _, container_client = ProjectStateService._get_blob_clients()
             prefix = f"{usuario_executor}/{nome_projeto}/estados/resumo/"
             blobs = list(container_client.list_blobs(name_starts_with=prefix))
@@ -77,6 +76,11 @@ async def list_projects(current_user: dict = Depends(get_current_user)):
         p.pop("projeto", None)
         p.pop("comentario_usuario", None)
         p.pop("docx_blob_url", None)
+        if "ultima_analysis_type" not in p and "analysis_type" in p:
+            p["ultima_analysis_type"] = p["analysis_type"]
+            p.pop("analysis_type", None)
+        if "analysis_type" in p:
+            p.pop("analysis_type", None)
         projetos_validos.append(p)
     logger.info(f"[LIST] Total de projetos válidos retornados: {len(projetos_validos)}")
     return projetos_validos


### PR DESCRIPTION
O endpoint GET /projects/list foi revisado para garantir que o campo 'analysis_type' não seja retornado em nenhuma circunstância. Se o campo 'ultima_analysis_type' não existir, ele será criado a partir de 'analysis_type' antes de removê-lo. Além disso, foi ajustada a lógica para evitar que projetos com 'ultima_analysis_type' nulo ou 'analysis_type' nulo sejam retornados com o campo errado, garantindo consistência com o padrão de resposta do login.