### PR TITLE
Remoção do campo 'analysis_type' do modelo ProjectListItem e inclusão do campo 'ultima_analysis_type' com alias para correta serialização.

### DIFF
--- a/backend/app/models/project_models.py
+++ b/backend/app/models/project_models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 class ProjectListItem(BaseModel):
     nome_projeto: str = Field(...)
-    analysis_type: Optional[str] = Field(None)
+    ultima_analysis_type: Optional[str] = Field(None, alias="ultima_analysis_type")
     created_at: Optional[datetime] = Field(None)
     last_saved_to_blob: Optional[datetime] = Field(None)
     project_id: Optional[str] = Field(default=None)


### PR DESCRIPTION
O modelo ProjectListItem foi modificado para substituir o campo 'analysis_type' pelo campo 'ultima_analysis_type', garantindo que a serialização JSON utilize o nome correto do campo esperado pelo frontend.