### PR TITLE
Constrói o payload da requisição para o agente LLM combinando dados do backend e configurações carregadas.

### DIFF
--- a/services/llm_request_builder.py
+++ b/services/llm_request_builder.py
@@ -1,0 +1,17 @@
+from typing import Dict, Any
+from models.mcp_request import MCPRequest
+from models.task_config import TaskConfig
+
+class LLMRequestBuilder:
+    @staticmethod
+    def build_request(mcp_request: MCPRequest, task_config: TaskConfig, instrucoes_padrao: str) -> Dict[str, Any]:
+        return {
+            'project_id': mcp_request.project_id,
+            'analysis_type': mcp_request.analysis_type,
+            'instrucoes_extras': mcp_request.instrucoes_extras,
+            'arquivo_docx': mcp_request.arquivo_docx,
+            'nome_projeto': mcp_request.nome_projeto,
+            'usuario_executor': mcp_request.usuario_executor,
+            'model_name': task_config.model_name,
+            'instrucoes_padrao': instrucoes_padrao
+        }


### PR DESCRIPTION
Implementada a classe LLMRequestBuilder com método estático build_request que recebe o objeto MCPRequest, TaskConfig e o texto das instrucoes_padrao lidas do markdown, retornando um dicionário com todos os parâmetros necessários para a chamada do agente, garantindo o padrão de comunicação e integrando dados do backend e do config.