### PR TITLE
Adiciona dependência pyyaml para suporte à leitura do arquivo config_tasks.yaml.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gunicorn==23.0.0
 uvicorn==0.38.0
 starlette==0.47.2
 httpx==0.28.1
+pyyaml


### PR DESCRIPTION
Incluído pyyaml no requirements.txt para permitir a leitura e parsing do arquivo de configuração YAML usado para carregar parâmetros por tipo de análise.