### PR TITLE
Ajuste para injetar AzureSecretManager configurado para o cofre LLM nos providers LLM.

### DIFF
--- a/services/factories/llm_provider_factory.py
+++ b/services/factories/llm_provider_factory.py
@@ -3,6 +3,7 @@ from domain.interfaces.llm_provider_interface import ILLMProvider
 from tools.requisicao_openai import OpenAILLMProvider
 from tools.requisicao_claude import AnthropicClaudeProvider
 from tools.rag_retriever import AzureAISearchRAGRetriever
+from services.azure_secret_manager import AzureSecretManager, VaultType
 
 class LLMProviderFactory:
     _providers: Dict[str, Type[ILLMProvider]] = {
@@ -13,13 +14,12 @@ class LLMProviderFactory:
     @classmethod
     def create_provider(cls, model_name: Optional[str], rag_retriever: AzureAISearchRAGRetriever) -> ILLMProvider:
         model_lower = (model_name or "").lower()
-        
+        secret_manager = AzureSecretManager(vault_type=VaultType.LLM)
         if "claude" in model_lower:
             provider_class = cls._providers.get('claude', OpenAILLMProvider)
         else:
             provider_class = cls._providers.get('openai', OpenAILLMProvider)
-        
-        return provider_class(rag_retriever=rag_retriever)
+        return provider_class(rag_retriever=rag_retriever, secret_manager=secret_manager)
     
     @classmethod
     def register_provider(cls, key: str, provider_class: Type[ILLMProvider]) -> None:


### PR DESCRIPTION
No método create_provider, o AzureSecretManager é instanciado com vault_type=VaultType.LLM e passado como parâmetro secret_manager para os providers LLM. Isso assegura que as credenciais dos provedores OpenAI e Claude sejam obtidas exclusivamente do cofre LLM, conforme a nova arquitetura de múltiplos cofres.