### PR TITLE
Aprimoramento do AzureSecretManager para suportar múltiplos cofres e garantir validação e segurança na leitura dos segredos, incluindo o cofre LLM.

### DIFF
--- a/services/azure_secret_manager.py
+++ b/services/azure_secret_manager.py
@@ -24,6 +24,8 @@ class AzureSecretManager:
         if not self._key_vault_url:
             logging.error(f"URL do Key Vault para '{self.vault_type}' não encontrada nas variáveis de ambiente.")
             raise EnvironmentError(f"A URL do Key Vault para o tipo '{self.vault_type}' não foi configurada na variável de ambiente.")
+        if not self._key_vault_url.startswith("https://"):
+            raise EnvironmentError(f"A URL do Key Vault para o tipo '{self.vault_type}' é inválida: {self._key_vault_url}")
 
     def _get_secret_client(self) -> SecretClient:
         if self._secret_client is None:
@@ -46,4 +48,5 @@ class AzureSecretManager:
                 raise ValueError(f"Segredo '{secret_name}' está vazio no Key Vault '{self._key_vault_url}'.")
             return secret.value
         except Exception as e:
-            raise ValueError(f"Erro ao obter segredo '{secret_name}' do Azure Key Vault '{self._key_vault_url}': {e}") from e
+            logger.error(f"Erro ao obter segredo '{secret_name}' do Azure Key Vault '{self._key_vault_url}': {e}")
+            raise ValueError(f"Erro ao obter segredo '{secret_name}' do Azure Key Vault '{self._key_vault_url}'.")


### PR DESCRIPTION
O serviço AzureSecretManager foi ajustado para ler URLs dos cofres diretamente das variáveis de ambiente correspondentes, validar a URL (deve iniciar com https://) e garantir que o cliente de segredo seja inicializado uma única vez por instância. O método get_secret emite warnings quando o nome do segredo contém underscores, sugerindo o uso de hífens, e trata erros sem expor valores sensíveis. Suporte explícito para os cofres AZURE, DEVOPS, GITHUB e LLM foi mantido e reforçado.