### PR TITLE
Criação de método auxiliar para acesso simplificado a dados de job_info, reduzindo duplicação e melhorando legibilidade.

### DIFF
--- a/services/step_strategies/default_step_strategy.py
+++ b/services/step_strategies/default_step_strategy.py
@@ -6,27 +6,26 @@ class DefaultStepStrategy:
     def __init__(self, job_handler):
         self.job_handler = job_handler
     
+    def _get_job_data(self, job_info, key, default=None):
+        return job_info.get('data', {}).get(key, default)
+    
     def execute_step(self, job_id: str, job_info: Dict[str, Any], step: Dict[str, Any], 
                     current_step_index: int, previous_step_result: Dict[str, Any], 
                     repo_reader: ReaderGeral, llm_provider, agent_params: Dict[str, Any]) -> Dict[str, Any]:
-        
         agent_type = step.get('agent_type')
         if not agent_type:
             raise ValueError(f"Tipo de agente não especificado na etapa {current_step_index}")
-        
         executor = StepExecutorFactory.create_executor(agent_type, self.job_handler)
-        
         return executor.execute(
             job_id, job_info, step, current_step_index, 
             previous_step_result, repo_reader, llm_provider, agent_params
         )
     
     def should_finalize_workflow(self, job_info: Dict[str, Any], current_step_index: int) -> bool:
-        return job_info.get('data', {}).get('gerar_relatorio_apenas', False) and current_step_index == 0
+        return self._get_job_data(job_info, 'gerar_relatorio_apenas', False) and current_step_index == 0
 
     def should_pause_for_approval(self, job_info: Dict[str, Any], step: Dict[str, Any]) -> bool:
-        # Agora acessamos o 'job_info' diretamente
-        gerar_relatorio_apenas = job_info.get('data', {}).get('gerar_relatorio_apenas', False)
+        gerar_relatorio_apenas = self._get_job_data(job_info, 'gerar_relatorio_apenas', False)
         result = not gerar_relatorio_apenas and step.get('requires_approval', False)
         print(f"[should_pause_for_approval] step_index=?, gerar_relatorio_apenas={gerar_relatorio_apenas}, requires_approval={step.get('requires_approval', False)}, result={result}")
         return result


### PR DESCRIPTION
Implementado método privado _get_job_data na classe DefaultStepStrategy para encapsular o acesso a job_info.get('data', {}).get(key). Refatorados métodos should_finalize_workflow e should_pause_for_approval para usar esse método, evitando repetição de código e facilitando manutenção.