### PR TITLE
Remoção da função init_logger e suas importações em agents/logging_utils.py

### DIFF
--- a/agents/logging_utils.py
+++ b/agents/logging_utils.py
@@ -10,9 +10,6 @@ handler.setFormatter(formatter)
 if not logger.hasHandlers():
     logger.addHandler(handler)
 
-def init_logger():
-    pass
-
 def log_custom_data(
     job_id: Optional[str] = None,
     projeto: Optional[str] = None,


### PR DESCRIPTION
Foi removida a função init_logger que estava vazia e nunca era chamada, além das importações relacionadas que não eram mais necessárias. O logger foi configurado diretamente no módulo para simplificar o código.