### PR TITLE
Simplificação da hierarquia de interfaces LLMProvider no módulo domain/interfaces/llm_provider_interface.py

### DIFF
--- a/domain/interfaces/llm_provider_interface.py
+++ b/domain/interfaces/llm_provider_interface.py
@@ -2,16 +2,6 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 class ILLMProvider(ABC):
-    """
-    Interface base para provedores de Large Language Models (LLM).
-    
-    Contrato de Implementação:
-    - Implementações devem garantir thread-safety se usadas concorrentemente
-    - Respostas devem ser estruturadas consistentemente
-    - Erros de rede/API devem ser encapsulados em RuntimeError
-    - Validação de parâmetros deve gerar ValueError
-    """
-    
     @abstractmethod
     def executar_prompt(
         self,
@@ -23,11 +13,9 @@ class ILLMProvider(ABC):
         job_id: Optional[str] = None,
         max_token_out: int = 15000
     ) -> Dict[str, Any]:
-       
         pass
 
-class ILLMProviderWithRAG(ILLMProvider):
-  
+class ILLMProviderComplete(ILLMProvider):
     @abstractmethod
     def executar_prompt_com_rag(
         self,
@@ -39,12 +27,8 @@ class ILLMProviderWithRAG(ILLMProvider):
         job_id: Optional[str] = None,
         max_token_out: int = 15000
     ) -> Dict[str, Any]:
-       
         pass
 
-class ILLMProviderWithModelSelection(ILLMProvider):
-    
-    
     @abstractmethod
     def executar_prompt_com_modelo(
         self,
@@ -55,22 +39,4 @@ class ILLMProviderWithModelSelection(ILLMProvider):
         job_id: Optional[str] = None,
         max_token_out: int = 15000
     ) -> Dict[str, Any]:
-       
-        pass
-
-class ILLMProviderComplete(ILLMProviderWithRAG, ILLMProviderWithModelSelection):
-    
-    
-    @abstractmethod
-    def executar_prompt(
-        self,
-        tipo_tarefa: str,          
-        prompt_principal: str,   
-        instrucoes_extras: str = "",
-        usar_rag: bool = False,
-        model_name: Optional[str] = None,
-        job_id: Optional[str] = None,
-        max_token_out: int = 15000
-    ) -> Dict[str, Any]:
-        
         pass


### PR DESCRIPTION
As interfaces intermediárias ILLMProviderWithRAG e ILLMProviderWithModelSelection foram removidas, e seus métodos abstratos foram movidos para a interface ILLMProviderComplete, reduzindo a complexidade da hierarquia de interfaces.