### PR TITLE
Ajuste na seleção do provedor LLM para respeitar o campo 'provider' da configuração da tarefa e garantir que modelos Anthropic sejam chamados via AnthropicClaudeProvider.

### DIFF
--- a/services/factories/llm_provider_factory.py
+++ b/services/factories/llm_provider_factory.py
@@ -7,31 +7,26 @@ from services.azure_secret_manager import AzureSecretManager, VaultType
 class LLMProviderFactory:
     _providers: Dict[str, Type[ILLMProvider]] = {
         'openai': OpenAILLMProvider,
+        'anthropic': AnthropicClaudeProvider,
         'claude': AnthropicClaudeProvider
     }
     
     @classmethod
-    def create_provider(cls, context: Any, model_name: Optional[str] = None) -> ILLMProvider:
-        """
-        Cria uma instância do provedor de LLM.
-        
-        Args:
-            context: O contexto ou tipo da análise (ex: 'financial', 'legal'). 
-                     Adicionado para corrigir o erro de '3 arguments given'.
-            model_name: O nome específico do modelo (ex: 'gpt-4', 'claude-3').
-        """
-        
-        # Garante que model_name seja string para evitar erro no .lower() se vier None
+    def create_provider(cls, context: Any, model_name: Optional[str] = None, provider_hint: Optional[str] = None) -> ILLMProvider:
         model_lower = (model_name or "").lower()
-        
         secret_manager = AzureSecretManager(vault_type=VaultType.LLM)
-        
-        # Lógica de seleção
-        if "claude" in model_lower:
-            provider_class = cls._providers.get('claude', OpenAILLMProvider)
-        else:
-            provider_class = cls._providers.get('openai', OpenAILLMProvider)
-            
+        provider_class = None
+        if provider_hint:
+            hint_lower = provider_hint.lower()
+            if hint_lower == "anthropic":
+                provider_class = cls._providers.get('anthropic', AnthropicClaudeProvider)
+            elif hint_lower == "openai":
+                provider_class = cls._providers.get('openai', OpenAILLMProvider)
+        if not provider_class:
+            if "claude" in model_lower:
+                provider_class = cls._providers.get('claude', AnthropicClaudeProvider)
+            else:
+                provider_class = cls._providers.get('openai', OpenAILLMProvider)
         return provider_class(secret_manager=secret_manager)
     
     @classmethod


### PR DESCRIPTION
Foi corrigida a passagem do parâmetro 'provider_hint' na criação do provedor LLM para usar o valor do campo 'provider' extraído do arquivo de configuração YAML. Além disso, o método create_provider da fábrica foi revisado para priorizar o 'provider_hint' quando presente, retornando AnthropicClaudeProvider para 'anthropic' e para modelos que contenham 'claude' no nome. Essa alteração evita que o modelo 'claude-sonnet-4-5' utilize a API OpenAI, eliminando o erro de deployment não encontrado.