### PR TITLE
Inclusão e validação do campo 'provider: anthropic' na configuração da tarefa 'criacao_epicos_azure_devops' para direcionar o modelo claude-sonnet-4-5 à API correta.

### DIFF
--- a/config_tasks.yaml
+++ b/config_tasks.yaml
@@ -4,6 +4,7 @@ criacao_epicos_azure_devops:
   model_name: "claude-sonnet-4-5"
   agent_type: "processador"
   instrucoes_extras: "criacao_epicos_azure_devops"
+  provider: "anthropic"
 
 refinamento_epicos_azure_devops:
   description: "criação de epicos a partir de transcrição de reunião"


### PR DESCRIPTION
Foi modificado o arquivo de configuração para explicitar o provedor 'anthropic' na tarefa 'criacao_epicos_azure_devops'. Também foi revisado o fluxo para garantir que o campo 'instrucoes_extras' seja corretamente populado e que a chamada da API utilize o endpoint da Anthropic, evitando o erro 404 de deployment não encontrado da OpenAI.