### PR TITLE
Adicionada configuração ANALYSIS_CONTEXT_CONFIG para mapear analysis_type a múltiplos estados e reports a serem lidos e concatenados ao comentario_extra. Modificado endpoint /analysis/start para consultar essa configuração, carregar estados e reports correspondentes, serializar e concatenar ao texto original antes de enviar ao MCP.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -1,18 +1,18 @@
 import logging
 import uuid
-from datetime import datetime  # Movido para o topo
+from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Body, BackgroundTasks, UploadFile, File, Form, Request
 from pydantic import BaseModel
 
-# Imports dos serviços e middlewares
 from ..middleware.auth_middleware import get_current_user, _extract_usuario_executor
 from ..services.mcp_client_service import MCPClientService
 from ..services.redis_session_service import RedisSessionService
 from ..services.project_state_service import ProjectStateService
 from ..services.blob_storage_service import upload_docx_to_blob
 from ..services.docx_parser_service import extract_text_from_docx
+from ..services.context_enrichment_service import ContextEnrichmentService
 
 router = APIRouter()
 logger = logging.getLogger("analysis_api")
@@ -32,55 +32,45 @@ async def start_analysis(
     arquivo_docx: Optional[UploadFile] = File(None),
     current_user: dict = Depends(get_current_user)
 ):
-    # 1. Extração e Validação Inicial
     usuario_executor = _extract_usuario_executor(current_user)
-    
     logger.info(f"Iniciando análise para projeto '{nome_projeto}' (analysis_type: '{analysis_type}') para usuário {usuario_executor}")
-    
+
     if not usuario_executor or not isinstance(usuario_executor, str) or not usuario_executor.strip():
         logger.error(f"Falha ao extrair usuario_executor do token JWT: '{usuario_executor}'")
         raise HTTPException(status_code=401, detail="Campo 'usuario_executor' ausente ou inválido no token JWT.")
-        
+
     if not nome_projeto or not isinstance(nome_projeto, str) or not nome_projeto.strip():
         logger.error(f"Campo 'nome_projeto' ausente ou vazio no formulário: '{nome_projeto}'")
         raise HTTPException(status_code=400, detail="Campo 'nome_projeto' ausente ou vazio no formulário.")
 
-    # 2. Configuração de Sessão e IDs
     redis_service = RedisSessionService()
     project_id_final = await ProjectStateService._get_project_id_by_name(usuario_executor, nome_projeto)
-    
     project_state = None
-    
-    # Tenta carregar estado existente se houver project_id
+
     if project_id_final:
         project_state = await ProjectStateService.load_latest_state_from_blob(usuario_executor, project_id=project_id_final)
-        # Verifica se sessão existe no Redis apenas para log/controle, não bloqueia fluxo
         try:
             redis_service.get_session_by_project_id(project_id_final)
         except Exception:
-            pass # Sessão não existe no Redis, será recriada/restaurada abaixo
+            pass
     else:
         project_id_final = str(uuid.uuid4())
 
-    # Validação final do ID
     if not project_id_final or not isinstance(project_id_final, str) or not project_id_final.strip():
         logger.error(f"Falha ao gerar ou recuperar project_id_final: '{project_id_final}'")
         raise HTTPException(status_code=500, detail="Falha ao gerar ou recuperar project_id do projeto.")
 
-    # 3. Processamento de Arquivo (se houver)
     texto_extraido = None
     blob_url = None
-    
+
     if arquivo_docx is not None:
         try:
             texto_extraido = await extract_text_from_docx(arquivo_docx)
         except Exception as e:
             logger.error(f"Erro ao extrair texto do docx: {e}")
             raise HTTPException(status_code=400, detail=f"Erro ao extrair texto do docx: {str(e)}")
-            
         blob_folder = f"{usuario_executor}/{nome_projeto}/arquivos_recebidos/docx"
         blob_filename = f"{analysis_type}/{arquivo_docx.filename}"
-        
         blob_url = await upload_docx_to_blob(
             arquivo_docx,
             blob_folder,
@@ -88,9 +78,7 @@ async def start_analysis(
             background_tasks
         )
 
-    # 4. Construção ou Restauração do Estado (CORREÇÃO APLICADA AQUI)
     if project_state:
-        # Caminho A: Estado já existe, restaurar no Redis
         redis_service.restore_session_from_state(
             usuario_executor,
             nome_projeto,
@@ -98,32 +86,24 @@ async def start_analysis(
             project_state
         )
     else:
-        # Caminho B: Novo estado - Aqui ocorria o erro de campos ausentes
         created_at = datetime.utcnow().isoformat()
         last_saved_to_blob = created_at
-        
-        # Criação explícita do dicionário de estado com TODAS as chaves obrigatórias
         resumo_state = {
             "nome_projeto": nome_projeto,
             "ultima_analysis_type": analysis_type,
             "created_at": created_at,
             "ultima_atualizacao": last_saved_to_blob,
-            "project_id": project_id_final,     # Garante que project_id está presente
-            "usuario_executor": usuario_executor # Garante que usuario_executor está presente
+            "project_id": project_id_final,
+            "usuario_executor": usuario_executor
         }
-
-        # Verificação defensiva antes de salvar
         campos_obrigatorios = ["nome_projeto", "usuario_executor", "project_id"]
         campos_faltando = [
             campo for campo in campos_obrigatorios 
             if not resumo_state.get(campo) or (isinstance(resumo_state.get(campo), str) and not resumo_state.get(campo).strip())
         ]
-        
         if campos_faltando:
             logger.critical(f"Erro crítico: Tentativa de salvar estado com campos ausentes: {campos_faltando}")
             raise HTTPException(status_code=500, detail=f"Erro interno: Estado inválido, campos faltando: {campos_faltando}")
-
-        # Cria sessão no Redis
         redis_service.create_session(
             usuario_executor,
             nome_projeto,
@@ -132,29 +112,35 @@ async def start_analysis(
             extracted_text=texto_extraido,
             initial_state=resumo_state
         )
-        
-        # Salva no Blob Storage
         logger.info(f"Salvando novo estado no Blob Storage para {usuario_executor}, Projeto: {nome_projeto}, ID: {project_id_final}")
         await ProjectStateService.save_state_to_blob(resumo_state)
 
-    # 5. Atualização de referência de arquivo no Redis
     if blob_url:
         redis_service.add_docx_file(project_id_final, blob_url)
 
-    # 6. Disparo para o Agente (MCP)
+    # ===== ENRIQUECIMENTO DE CONTEXTO =====
+    instrucoes_extras = comentario_extra
+    try:
+        instrucoes_extras_enriquecidas = await ContextEnrichmentService.enrich_instructions(
+            project_id_final, analysis_type, instrucoes_extras
+        )
+        logger.info(f"Contexto enriquecido para analysis_type={analysis_type} (project_id={project_id_final}).")
+    except Exception as e:
+        logger.error(f"Erro ao enriquecer instrucoes_extras: {e}")
+        instrucoes_extras_enriquecidas = instrucoes_extras
+
     mcp_payload = {
         "project_id": project_id_final,
         "texto_extraido_do_docx": texto_extraido,
-        "comentario_extra": comentario_extra,
+        "comentario_extra": instrucoes_extras_enriquecidas,
         "analysis_type": analysis_type
     }
-    
+
     mcp_client = MCPClientService()
     try:
         await mcp_client.start_analysis(mcp_payload)
     except Exception as e:
         logger.error(f"Erro na comunicação com MCP: {e}")
-        # Nota: 502 Bad Gateway é apropriado para falha de upstream
         raise HTTPException(status_code=502, detail=f"Erro ao comunicar com o servidor de Inteligência (MCP): {str(e)}")
 
     return StartAnalysisResponse(

--- a/backend/docs/ARCHITECTURE_FLOW.md
+++ b/backend/docs/ARCHITECTURE_FLOW.md
@@ -72,4 +72,33 @@ sequenceDiagram
 
 ---
 
-# As demais seções permanecem inalteradas.
+## 5. Enriquecimento de Contexto para Refinamento
+
+Quando o frontend envia um `analysis_type` de refinamento (ex: `refinamento_epicos_azure_devops`), o backend executa um processo de enriquecimento de contexto antes de enviar o payload ao MCP:
+
+1. O backend consulta uma configuração (`ANALYSIS_CONTEXT_CONFIG`) que mapeia o `analysis_type` para uma lista de estados/reports a serem lidos do Blob Storage.
+2. Para cada entrada, o backend recupera o estado correspondente usando `ProjectStateService.load_latest_state_from_blob()` e extrai o campo de report relevante (ex: `epicos_report`).
+3. O conteúdo do report é serializado em string (usando JSON ou formatação legível).
+4. Todos os textos extraídos são concatenados junto com o texto original de `instrucoes_extras` enviado pelo frontend.
+5. O texto enriquecido é enviado no campo `comentario_extra` do payload para o MCP.
+
+Diagrama Mermaid:
+
+mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant BE as Backend
+    participant Blob as Blob Storage
+    participant MCP as MCP Server
+    FE->>BE: POST /analysis/start (nome_projeto, analysis_type, instrucoes_extras)
+    BE->>BE: Consulta ANALYSIS_CONTEXT_CONFIG para analysis_type
+    loop Para cada estado/report
+        BE->>Blob: Busca estado e extrai report
+        BE->>BE: Serializa report como texto
+    end
+    BE->>BE: Concatena textos dos reports + instrucoes_extras
+    BE->>MCP: Envia payload enriquecido (comentario_extra)
+    MCP-->>BE: job_id, project_id
+    BE-->>FE: message, project_id, nome_projeto
+
+---


### PR DESCRIPTION
Este PR introduz um arquivo de configuração que define para cada analysis_type uma lista de estados e reports a serem lidos do Blob Storage. No endpoint POST /analysis/start, antes de enviar o payload ao MCP, o backend carrega os estados configurados, extrai os reports indicados, serializa os conteúdos em texto, concatena todos com o texto original de instrucoes_extras e envia o texto enriquecido. Isso generaliza o fluxo de enriquecimento para múltiplos tipos de análise, permitindo futura extensão para múltiplos estados e reports.