### PR TITLE
Adicionados logs de debug detalhados e validação para garantir que o texto enriquecido contém o conteúdo do report, com foco no enriquecimento do contexto para analysis_type específicos.

### DIFF
--- a/backend/app/services/context_enrichment_service.py
+++ b/backend/app/services/context_enrichment_service.py
@@ -8,24 +8,30 @@ class ContextEnrichmentService:
     @staticmethod
     async def enrich_instructions(project_id: str, analysis_type: str, instrucoes_extras: Optional[str]) -> str:
         logger = logging.getLogger("ContextEnrichmentService")
+        logger.debug(f"[ENRICH] analysis_type={analysis_type}, project_id={project_id}, instrucoes_extras (orig): '{instrucoes_extras}'")
         config_entries = ANALYSIS_CONTEXT_CONFIG.get(analysis_type)
+        logger.debug(f"[ENRICH] config_entries: {config_entries}")
         if not config_entries:
+            logger.debug("[ENRICH] Nenhuma configuração encontrada para analysis_type. Retornando instrucoes_extras original.")
             return instrucoes_extras or ""
         enriched_parts = []
         estados_lidos = 0
         for entry in config_entries:
             estado_para_ler = entry.get("estado_para_ler")
             report_para_ler = entry.get("report_para_ler")
+            logger.debug(f"[ENRICH] Loop: estado_para_ler={estado_para_ler}, report_para_ler={report_para_ler}")
             if not estado_para_ler or not report_para_ler:
                 logger.warning(f"Configuração inválida para analysis_type={analysis_type}: {entry}")
                 continue
             try:
+                logger.debug(f"[ENRICH] Chamando ProjectStateService.load_latest_state_from_blob(project_id={project_id}, report_type={report_para_ler})")
                 state = await ProjectStateService.load_latest_state_from_blob(
-                    usuario_executor=None,  # ProjectStateService aceita project_id
+                    usuario_executor=None,
                     project_id=project_id,
                     nome_projeto=None,
                     report_type=report_para_ler
                 )
+                logger.debug(f"[ENRICH] Estado retornado: {state}")
                 if not state:
                     logger.warning(f"Estado '{estado_para_ler}' não encontrado para project_id={project_id}")
                     continue
@@ -37,6 +43,7 @@ class ContextEnrichmentService:
                     report_str = json.dumps(report_content, ensure_ascii=False, indent=2)
                 except Exception:
                     report_str = str(report_content)
+                logger.debug(f"[ENRICH] report_str tamanho={len(report_str)}, preview={report_str[:200]}")
                 enriched_parts.append(f"[{report_para_ler}]:\n{report_str}")
                 estados_lidos += 1
             except Exception as e:
@@ -45,5 +52,15 @@ class ContextEnrichmentService:
         if instrucoes_extras:
             enriched_parts.append(instrucoes_extras)
         enriched_text = "\n\n".join(enriched_parts)
-        logger.info(f"Contexto enriquecido para analysis_type={analysis_type}: {estados_lidos} estados lidos.")
+        logger.debug(f"[ENRICH] instrucoes_extras ENRIQUECIDO: '{enriched_text}'")
+        if config_entries and estados_lidos > 0:
+            # Validação: o texto enriquecido deve conter o conteúdo do report
+            algum_report = False
+            for entry in config_entries:
+                report_para_ler = entry.get("report_para_ler")
+                if report_para_ler and f"[{report_para_ler}]" in enriched_text:
+                    algum_report = True
+                    break
+            if not algum_report:
+                logger.error(f"[ENRICH] ERRO: Texto enriquecido não contém conteúdo do report para analysis_type={analysis_type}, project_id={project_id}")
         return enriched_text


### PR DESCRIPTION
Modificações no serviço de enriquecimento de contexto para adicionar logs antes, durante e após o processamento, além de validar que o conteúdo do report está presente no texto enriquecido retornado. Isso ajuda a diagnosticar problemas na composição das instruções extras enviadas ao MCP.