### PR TITLE
Ajuste na chamada para ContextEnrichmentService.enrich_instructions no endpoint /analysis/start para passar usuario_executor, nome_projeto e project_id, garantindo que o enriquecimento de contexto funcione corretamente para tipos de análise de refinamento.

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -121,7 +121,11 @@ async def start_analysis(
     instrucoes_extras = comentario_extra
     try:
         instrucoes_extras_enriquecidas = await ContextEnrichmentService.enrich_instructions(
-            project_id_final, analysis_type, instrucoes_extras
+            usuario_executor=usuario_executor,
+            nome_projeto=nome_projeto,
+            project_id=project_id_final,
+            analysis_type=analysis_type,
+            instrucoes_extras=instrucoes_extras
         )
         logger.debug(f"[ANALYSIS] instrucoes_extras_enriquecidas para MCP: '{instrucoes_extras_enriquecidas}'")
         logger.debug(f"[ANALYSIS] Tamanho instrucoes_extras_enriquecidas: {len(instrucoes_extras_enriquecidas) if instrucoes_extras_enriquecidas else 0}")


### PR DESCRIPTION
No endpoint /analysis/start, a função start_analysis foi modificada para extrair e passar os parâmetros usuario_executor, nome_projeto e project_id para o método enrich_instructions. Isso corrige o problema do enriquecimento de contexto falho causado pela ausência desses parâmetros, especialmente para analysis_type que começam com 'refinamento_'.