### PR TITLE
Adição do campo obrigatório job_id e validadores para garantir string não vazia nos modelos MCPStartAnalysisPayload e MCPWebhookPayload.

### DIFF
--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -9,6 +9,7 @@ class MCPStartAnalysisPayload(BaseModel):
     usuario_executor: str = Field(..., description="Usuário executor extraído do token JWT.")
     project_id: str = Field(..., description="Identificador único do projeto.")
     nome_projeto: Optional[str] = Field(None, description="Nome legível do projeto (apenas para log/debug).")
+    job_id: str = Field(..., description="Identificador único do job.")
 
     @validator('analysis_type')
     def analysis_type_must_not_be_empty(cls, v):
@@ -20,6 +21,12 @@ class MCPStartAnalysisPayload(BaseModel):
     def project_id_must_not_be_empty(cls, v):
         if not v or not isinstance(v, str) or not v.strip():
             raise ValueError('project_id deve ser uma string não vazia')
+        return v
+
+    @validator('job_id')
+    def job_id_must_not_be_empty(cls, v):
+        if not v or not isinstance(v, str) or not v.strip():
+            raise ValueError('job_id deve ser uma string não vazia')
         return v
 
 class MCPStartAnalysisResponse(BaseModel):

--- a/backend/app/models/mcp_webhook_models.py
+++ b/backend/app/models/mcp_webhook_models.py
@@ -10,6 +10,12 @@ class MCPWebhookPayload(BaseModel):
     error_message: Optional[str] = Field(None)
     project_id: Optional[str] = Field(None)
 
+    @validator('job_id')
+    def job_id_must_not_be_empty(cls, v):
+        if not v or not isinstance(v, str) or not v.strip():
+            raise ValueError('job_id deve ser uma string não vazia')
+        return v
+
     @validator('status')
     def status_must_be_valid(cls, v):
         allowed = {'in_progress', 'done', 'error'}


### PR DESCRIPTION
Os modelos de payloads para requisição e webhook MCP foram atualizados para incluir o campo job_id como obrigatório. Foram implementados validadores para assegurar que job_id seja uma string não vazia, aumentando a robustez e integridade dos dados trafegados.