### PR TITLE
Adição do campo completed_at ao modelo JobData para registrar a data de conclusão do job.

### DIFF
--- a/backend/app/models/job_models.py
+++ b/backend/app/models/job_models.py
@@ -11,6 +11,7 @@ class JobData(BaseModel):
     updated_at: datetime = Field(...)
     request_timestamp: datetime = Field(...)
     response_timestamp: Optional[datetime] = Field(default=None)
+    completed_at: Optional[datetime] = Field(default=None)
 
     @validator('job_id', 'project_id', 'analysis_type')
     def not_empty(cls, v):


### PR DESCRIPTION
Incluído campo Optional[datetime] completed_at no modelo JobData para suportar lógica de verificação de jobs concluídos e evitar jobs zumbis.