### PR TITLE
Ajuste no endpoint POST /webhooks/mcp para garantir que, ao receber status 'done', o método update_job_status seja chamado para atualizar o campo completed_at no Redis e que o estado atualizado seja salvo no Blob Storage.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -54,6 +54,8 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
                 session["ultima_atualizacao"] = agora.isoformat()
             if hasattr(session, "project_id") and not session.project_id:
                 session.project_id = payload.project_id
+            # Garantia extra: update_job_status já preenche completed_at, mas reforçamos aqui caso necessário
+            redis_service.update_job_status(payload.job_id, "done")
             await ProjectStateService.save_state_to_blob(session)
             state = session.to_project_state() if hasattr(session, "to_project_state") else session
             return {


### PR DESCRIPTION
No arquivo backend/app/api/webhooks.py, o endpoint /webhooks/mcp foi modificado para após processar um webhook com status 'done', chamar update_job_status para garantir o preenchimento do campo completed_at no Redis. Em seguida, o estado atualizado da sessão é salvo no Blob Storage via ProjectStateService.save_state_to_blob, garantindo persistência do estado final do projeto.