### PR TITLE
Inclusão do job_id no report_data no webhook MCP para garantir propagação do job_id no estado salvo.

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -15,72 +15,43 @@ async def mcp_webhook(payload: MCPWebhookPayload, request: Request):
     logger.info(f"webhook_start: job_id={payload.job_id}, status={payload.status}")
 
     try:
-        # Validações Básicas
         if not getattr(payload, 'project_id', None):
             raise HTTPException(status_code=400, detail="project_id é obrigatório.")
-        
-        # 1. Atualização de Status Intermediário
         if payload.status == "in_progress":
             redis_service.update_job_status(payload.job_id, "in_progress")
             return {"status": "ok", "msg": "Job marcado como in_progress"}
-
-        # 2. Tratamento de Erro
         if payload.status == "error":
             redis_service.update_job_status(payload.job_id, "error")
             logger.error(f"Job falhou: {payload.error_message}")
             return {"status": "ok", "msg": "Job marcado como error"}
-
-        # 3. Tratamento de Sucesso (DONE)
         if payload.status == "done":
-            # A. Valida Payload
             report_data = payload.report_data
             if not report_data or not isinstance(report_data, dict):
                 raise HTTPException(status_code=400, detail="report_data inválido")
-
-            # B. Atualiza Redis (Dados de Negócio)
+            # Adiciona o job_id no report_data
+            report_data["job_id"] = payload.job_id
             redis_service.update_report(payload.project_id, report_data)
-            
-            # C. Atualiza Blob Storage (Persistência)
             session = redis_service.get_session_by_project_id(payload.project_id)
             if session:
-                # Usa objeto datetime para o Pydantic (evita warnings)
                 agora_dt = datetime.utcnow()
-                
-                # Atualiza Timestamps
                 if hasattr(session, "ultima_atualizacao"):
                     session.ultima_atualizacao = agora_dt
-                
                 if hasattr(session, "last_saved_to_blob"):
                     session.last_saved_to_blob = agora_dt
-
-                # --- NOVO: SALVAR O JOB ID NO ESTADO ---
                 if hasattr(session, "last_job_id"):
                     session.last_job_id = payload.job_id
-                # ---------------------------------------
-
-                # Fallback para dict (caso não seja modelo Pydantic)
                 if isinstance(session, dict):
                     agora_iso = agora_dt.isoformat()
                     session["ultima_atualizacao"] = agora_iso
                     session["last_saved_to_blob"] = agora_iso
-                    session["last_job_id"] = payload.job_id # <--- Salva aqui também
-
-                # Garante Project ID
+                    session["last_job_id"] = payload.job_id
                 if hasattr(session, "project_id") and not session.project_id:
                     session.project_id = payload.project_id
-                
-                # Salva no Blob
                 await ProjectStateService.save_state_to_blob(session)
                 logger.info("Estado salvo no Blob Storage com sucesso.")
-
-            # D. FINALMENTE: Marca o Job como DONE no Redis
-            # Só marcamos como done APÓS o save_state_to_blob ter sucesso.
-            # Isso impede que a API leia 'done', tente pegar o blob e falhe.
             redis_service.update_job_status(payload.job_id, "done")
             logger.info(f"Job {payload.job_id} finalizado e marcado como DONE no Redis.")
-
             return {"status": "ok", "project_id": payload.project_id}
-
     except Exception as e:
         logger.error(f"Erro crítico no webhook: {e}")
         try:


### PR DESCRIPTION
No endpoint POST /webhooks/mcp, o job_id do payload é incluído em report_data antes de chamar update_report, garantindo que o job_id seja salvo no estado do report e atualizado corretamente.