### PR TITLE
Validação e inclusão do campo job_id em cada report retornado na consulta GET /project/{project_id}/{job_id}/reports e GET /project/{project_id}/report/{report_type}.

### DIFF
--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -15,38 +15,32 @@ class UpdateReportRequest(BaseModel):
 @router.get("/project/{project_id}/{job_id}/reports")
 async def get_project_reports(
     project_id: str,
-    job_id: str, # Agora é obrigatório na URL
+    job_id: str,
     current_user: dict = Depends(get_current_user)
 ):
     usuario_executor = _extract_usuario_executor(current_user)
     logger = logging.getLogger("session_api")
     redis_service = RedisSessionService()
-
-    # 1. TENTA LER O BLOB (LEITURA FORÇADA COM VALIDAÇÃO DE JOB)
     try:
         blob_state = await ProjectStateService.load_all_states_from_blob(usuario_executor, project_id)
-        
         if blob_state:
-            # Verifica se o blob tem conteúdo real
             tem_conteudo = _check_content(blob_state)
             saved_job_id = blob_state.get("last_job_id")
-            
-            # Se o ID bater, é sucesso garantido.
+            # Valida job_id em cada report
+            for report_key in ["epicos", "features", "times_descricao", "alocacao_times", "premissas_riscos"]:
+                report = blob_state.get(report_key)
+                if report is not None:
+                    if "job_id" not in report:
+                        logger.warning(f"Report '{report_key}' não possui job_id (estado legado ou erro).")
+                        report["job_id"] = None
             if saved_job_id and saved_job_id == job_id:
                 logger.info(f"✅ Blob encontrado com Job ID correspondente ({job_id}). Retornando 200.")
                 return _format_state_response(blob_state)
-            
-            # Se o Job ID existe mas é diferente, o blob é de outro processamento.
             if saved_job_id:
                 logger.warning(f"⚠️ Blob encontrado, mas Job ID diverge (Esperado: {job_id}, Encontrado: {saved_job_id}). Ignorando blob.")
-
     except Exception as e:
         logger.warning(f"Erro ao tentar ler blob: {e}")
-
-    # 2. SE O BLOB NÃO SERVIU, CHECA O REDIS PARA DAR 202
     active_job = redis_service.get_active_job_for_project(project_id)
-    
-    # Se o job solicitado ainda está rodando
     if active_job and active_job.job_id == job_id:
         return JSONResponse(
             content={
@@ -57,16 +51,12 @@ async def get_project_reports(
             },
             status_code=status.HTTP_202_ACCEPTED
         )
-
-    # 3. SE NÃO ESTÁ NO BLOB E NÃO ESTÁ RODANDO -> 404
-    # Isso cobre o caso onde o Job ID não existe, falhou sem salvar, ou o blob ainda não sincronizou.
     raise HTTPException(
         status_code=404, 
         detail=f"Relatório para o Job {job_id} não encontrado ou ainda não processado. Tente novamente em instantes."
     )
 
 def _check_content(blob_state):
-    """Verifica se há conteúdo real no estado"""
     chaves = ["epicos_report", "features_report", "resumo_report", "epicos", "features"]
     for chave in chaves:
         val = blob_state.get(chave)
@@ -75,26 +65,28 @@ def _check_content(blob_state):
     return False
 
 def _format_state_response(state: dict):
-    """Garante que a resposta tenha os campos de lista vazios em vez de None"""
     report_fields = ["epicos", "features", "times_descricao", "alocacao_times", "premissas_riscos"]
     for field in report_fields:
         if state.get(field) is None:
             state[field] = {} 
-        
         report_key = field + "_report"
         if state.get(report_key) is None:
-             if state[field].get(report_key) is None:
-                 state[field][report_key] = []
+            if state[field].get(report_key) is None:
+                state[field][report_key] = []
+        if "job_id" not in state[field]:
+            state[field]["job_id"] = None
     return state
 
-# ... (Outros endpoints update, save, docx permanecem iguais) ...
-# Apenas a rota GET reports mudou a assinatura.
 @router.get("/project/{project_id}/report/{report_type}")
 async def get_project_report_state(project_id: str, report_type: str, current_user: dict = Depends(get_current_user)):
     try:
         state = await ProjectStateService.get_report_state(project_id, report_type)
         if not state:
             raise HTTPException(status_code=404, detail=f"Estado do report '{report_type}' não encontrado para project_id '{project_id}'")
+        if "job_id" not in state:
+            logger = logging.getLogger("session_api")
+            logger.warning(f"Report '{report_type}' não possui job_id (estado legado ou erro).")
+            state["job_id"] = None
         return state
     except Exception as e:
         raise HTTPException(status_code=404, detail=f"Erro ao buscar estado do report: {e}")


### PR DESCRIPTION
No endpoint GET /project/{project_id}/{job_id}/reports, validado se cada report contém o campo job_id. Se ausente, loga um aviso e inclui job_id: null na resposta. Mesma lógica aplicada ao endpoint GET /project/{project_id}/report/{report_type}. Isso assegura que a versão do report consultada corresponde ao job_id correto, conforme solicitado.