### PR TITLE
Adição do campo job_id no modelo MCPRequest e propagação correta do job_id no builder de requisição LLM.

### DIFF
--- a/models/mcp_request.py
+++ b/models/mcp_request.py
@@ -8,3 +8,4 @@ class MCPRequest(BaseModel):
     nome_projeto: Optional[str] = None
     usuario_executor: Optional[str] = None
     texto_extraido_do_docx: Optional[str] = None
+    job_id: Optional[str] = None

--- a/services/llm_request_builder.py
+++ b/services/llm_request_builder.py
@@ -13,6 +13,7 @@ class LLMRequestBuilder:
             'nome_projeto': mcp_request.nome_projeto,
             'usuario_executor': mcp_request.usuario_executor,
             'model_name': task_config.model_name,
-            'provider': getattr(task_config, 'provider', None), 
-            'instrucoes_padrao': instrucoes_padrao
+            'provider': getattr(task_config, 'provider', None),
+            'instrucoes_padrao': instrucoes_padrao,
+            'job_id': mcp_request.job_id
         }


### PR DESCRIPTION
Incluído o campo job_id no modelo MCPRequest para receber o identificador único do job enviado pelo backend. Atualizado o LLMRequestBuilder para incluir job_id no dicionário de parâmetros, garantindo a propagação correta do job_id para o agente.