### PR TITLE
Propagação correta de job_id e project_id no agente e remoção de parâmetros e logs desnecessários.

### DIFF
--- a/agents/agente_processador.py
+++ b/agents/agente_processador.py
@@ -63,16 +63,12 @@ class AgenteProcessador:
 
         log_custom_data(
             job_id=job_id,
-            projeto=projeto,
+            project_id=project_id,
             data_hora=datetime.now(timezone.utc).isoformat(),
-            tokens_in=resultado_da_ia['tokens_entrada'],
-            tokens_out=resultado_da_ia['tokens_saida'],
-            tipo_repositorio=repository_type,
-            nome_repositorio=repositorio,
             tipo_analise=tipo_analise,
             model_name=model_name,
-            modo_adicao_incremental=modo_adicao_incremental,
-            usuario_executor=usuario_executor
+            tokens_in=resultado_da_ia.get('tokens_entrada'),
+            tokens_out=resultado_da_ia.get('tokens_saida')
         )
 
         return {"resultado": {"reposta_final": resultado_da_ia}}


### PR DESCRIPTION
O método main da classe AgenteProcessador foi ajustado para receber explicitamente job_id e project_id, repassando-os corretamente para a função de log. Campos nulos e desnecessários foram removidos para evitar logs poluídos e inconsistentes. A propagação correta evita que project_id e job_id sejam confundidos ou nulos.