### PR TITLE
Correção da geração e propagação de job_id distinto do project_id e ajuste no webhook para refletir essa distinção, além de limpeza do payload enviado ao agente.

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,8 @@ async def start_analysis(payload: Dict[str, Any], background_tasks: BackgroundTa
     )
     project_id = mcp_request.project_id
     job_id = mcp_request.job_id if mcp_request.job_id else str(uuid.uuid4())
+    if job_id == project_id:
+        job_id = str(uuid.uuid4())
     project_tracker.set_status(project_id, 'processing')
     background_tasks.add_task(
         process_analysis_task,


### PR DESCRIPTION
No endpoint /start, o job_id é gerado ou validado para ser diferente do project_id. O job_id é propagado para o llm_request_params e para a task de background. No envio do webhook, project_id e job_id são enviados corretamente distintos. Ajustes para garantir que o log do agente e o payload do webhook estejam consistentes com a separação dos IDs.