### PR TITLE
Ajustado endpoint GET /project/{project_id}/{job_id}/reports para buscar relatórios primeiro no Redis e, se não encontrados ou com divergência de job_id, buscar no Blob Storage.

### DIFF
--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -22,11 +22,25 @@ async def get_project_reports(
     logger = logging.getLogger("session_api")
     redis_service = RedisSessionService()
     try:
+        redis_reports = redis_service.get_all_reports_for_project(project_id)
+        if redis_reports:
+            all_match = True
+            for report_key, report in redis_reports.items():
+                if report is not None:
+                    if "job_id" not in report:
+                        logger.warning(f"Report '{report_key}' não possui job_id (estado legado ou erro).")
+                        report["job_id"] = None
+                    if report["job_id"] != job_id:
+                        all_match = False
+                        logger.warning(f"Divergência de job_id no report '{report_key}': esperado '{job_id}', encontrado '{report['job_id']}'")
+                        break
+            if all_match:
+                logger.info(f"✅ Relatórios encontrados no Redis com job_id correspondente ({job_id}). Retornando 200.")
+                return redis_reports
         blob_state = await ProjectStateService.load_all_states_from_blob(usuario_executor, project_id)
         if blob_state:
             tem_conteudo = _check_content(blob_state)
             saved_job_id = blob_state.get("last_job_id")
-            # Valida job_id em cada report
             for report_key in ["epicos", "features", "times_descricao", "alocacao_times", "premissas_riscos"]:
                 report = blob_state.get(report_key)
                 if report is not None:


### PR DESCRIPTION
No endpoint GET /project/{project_id}/{job_id}/reports, a busca dos relatórios é feita inicialmente no Redis com validação do job_id. Caso os relatórios não sejam encontrados ou haja divergência no job_id, é feito fallback para o Blob Storage, mantendo a lógica de validação e status conforme instruções dos passos 2 e 3.