### PR TITLE
Refatoração do endpoint GET /project/{project_id}/{job_id}/reports para priorizar busca no Redis e usar Blob Storage como fallback, além de atualização da documentação para refletir esse fluxo.

### DIFF
--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -21,22 +21,22 @@ async def get_project_reports(
     usuario_executor = _extract_usuario_executor(current_user)
     logger = logging.getLogger("session_api")
     redis_service = RedisSessionService()
+    redis_reports = redis_service.get_all_reports_for_project(project_id)
+    if redis_reports:
+        all_match = True
+        for report_key, report in redis_reports.items():
+            if report is not None:
+                if "job_id" not in report:
+                    logger.warning(f"Report '{report_key}' não possui job_id (estado legado ou erro).")
+                    report["job_id"] = None
+                if report["job_id"] != job_id:
+                    all_match = False
+                    logger.warning(f"Divergência de job_id no report '{report_key}': esperado '{job_id}', encontrado '{report['job_id']}'")
+                    break
+        if all_match:
+            logger.info(f"✅ Relatórios encontrados no Redis com job_id correspondente ({job_id}). Retornando 200.")
+            return redis_reports
     try:
-        redis_reports = redis_service.get_all_reports_for_project(project_id)
-        if redis_reports:
-            all_match = True
-            for report_key, report in redis_reports.items():
-                if report is not None:
-                    if "job_id" not in report:
-                        logger.warning(f"Report '{report_key}' não possui job_id (estado legado ou erro).")
-                        report["job_id"] = None
-                    if report["job_id"] != job_id:
-                        all_match = False
-                        logger.warning(f"Divergência de job_id no report '{report_key}': esperado '{job_id}', encontrado '{report['job_id']}'")
-                        break
-            if all_match:
-                logger.info(f"✅ Relatórios encontrados no Redis com job_id correspondente ({job_id}). Retornando 200.")
-                return redis_reports
         blob_state = await ProjectStateService.load_all_states_from_blob(usuario_executor, project_id)
         if blob_state:
             tem_conteudo = _check_content(blob_state)

--- a/backend/docs/ARCHITECTURE_FLOW.md
+++ b/backend/docs/ARCHITECTURE_FLOW.md
@@ -18,191 +18,31 @@ Este documento detalha o fluxo completo do backend Peers CodeAI, desde o recebim
 
 ---
 
-## 1. Visão Geral da Comunicação entre Grandes Blocos
-
-Esta seção apresenta uma visão de alto nível da comunicação entre os principais blocos do sistema: Frontend, Backend (rotas em `backend/app/api`) e MCP Server. O Backend orquestra as requisições recebidas do Frontend, processa dados, integra serviços internos e se comunica com o MCP Server para processamento de inteligência.
-
-**Descrição dos Blocos:**
-- **Frontend:** Interface do usuário, responsável por enviar requisições HTTP para o Backend e consumir respostas.
-- **Backend (API):** Camada intermediária que expõe rotas REST via FastAPI, localizadas em `backend/app/api`. Cada rota é responsável por uma parte do fluxo, como autenticação, análise, projetos, sessões e webhooks.
-- **MCP Server:** Serviço externo de inteligência que recebe payloads do Backend para processamento de análises e retorna resultados via webhooks.
-
-**Diagrama Mermaid:**
-
-```mermaid
-sequenceDiagram
-    participant FE as Frontend
-    participant BE as Backend (API)
-    participant MCP as MCP Server
-    FE->>BE: Requisições HTTP (rotas em backend/app/api)
-    BE->>MCP: Payloads de análise (via /analysis)
-    MCP-->>BE: Webhooks de resultado (/webhooks/mcp)
-    BE-->>FE: Respostas HTTP (dados, status, relatórios)
-```
-
----
-
-## 2. Login e Autenticação via Azure AD
-
-Fluxo:
-1. O frontend envia o token JWT via header Authorization para o endpoint POST `/auth/login` (implementado em [`backend/app/api/auth.py`]).
-2. O backend valida o token via `AzureADService`, usando a chave pública do Azure AD (JWKS).
-3. O backend extrai o `usuario_executor` dos claims do token (preferred_username, email ou upn).
-4. O backend busca os projetos associados ao `usuario_executor` usando `ProjectStateService._fetch_and_sanitize_projects`.
-5. O backend retorna para o frontend a lista de projetos de resumo, contendo apenas os campos: nome_projeto, ultima_analysis_type, created_at, ultima_atualizacao, project_id.
-
-**Nota:** O fluxo de validação do token JWT é orquestrado pela rota `/auth/login` em [`backend/app/api/auth.py`], que utiliza o serviço `AzureADService` para garantir autenticidade e extração segura do usuário.
-
-```mermaid
-sequenceDiagram
-    participant FE as Frontend
-    participant BE as Backend
-    participant AzureAD as Azure AD
-    participant Blob as Blob Storage
-    participant Redis as Redis
-    FE->>BE: POST /auth/login (token JWT)
-    BE->>AzureAD: Valida token JWT
-    AzureAD-->>BE: Claims válidos
-    BE->>BE: Extrai usuario_executor dos claims
-    BE->>Blob: Busca projetos de resumo do usuario_executor
-    BE->>Redis: Busca estados de resumo no cache
-    BE-->>FE: Retorna user_info + lista de projetos de resumo
-```
-
----
-
-## 3. Criação de Projeto e Conversão nome_projeto → project_id
-
-O frontend deve sempre enviar apenas o campo `nome_projeto` para criação ou início de análise. O backend é responsável por converter internamente o `nome_projeto` para `project_id`:
-- Se o projeto já existe, o backend recupera o mesmo `project_id` do estado salvo.
-- Se o projeto é novo, o backend gera um novo `project_id` (UUID) e associa ao nome do projeto.
-- O `project_id` é retornado na resposta do backend para uso em operações subsequentes.
-- O enriquecimento de contexto agora exige usuario_executor e nome_projeto como parâmetros obrigatórios.
-
-**Nota:** Este fluxo é implementado pela rota `/analysis/start` em [`backend/app/api/analysis.py`], que utiliza o serviço `ProjectStateService` para conversão e persistência do identificador do projeto.
-
-```mermaid
-sequenceDiagram
-    participant FE as Frontend
-    participant BE as Backend
-    participant MCP as MCP Server
-    FE->>BE: POST /analysis/start (nome_projeto, analysis_type, ...)
-    BE->>BE: Converte nome_projeto para project_id (recupera existente ou gera novo)
-    BE->>BE: Enriquecimento de contexto (passando usuario_executor, nome_projeto, project_id)
-    BE->>MCP: Envia payload (project_id, analysis_type, ...)
-    MCP-->>BE: job_id, project_id
-    BE-->>FE: message, project_id, nome_projeto
-```
-
----
-
-## 4. Consulta de Projeto Existente
-
-O Backend permite ao frontend consultar a existência de um projeto pelo nome, retornando o estado associado se encontrado.
-
-**Nota:** Este fluxo é implementado pela rota `/projects/check` em [`backend/app/api/projects.py`], que utiliza o serviço `ProjectStateService` para buscar e validar projetos existentes.
-
-```mermaid
-sequenceDiagram
-    FE->>BE: GET /projects/check (nome_projeto)
-    BE->>BE: Busca project_id associado ao nome_projeto
-    BE-->>FE: exists: true, state (inclui project_id)
-```
-
----
-
-## 5. Observações Importantes
-
-- O campo `project_id` nunca deve ser enviado pelo frontend. O backend faz toda a conversão e retorna o `project_id` correto.
-- Toda comunicação interna e com MCP utiliza o `project_id` gerado ou recuperado pelo backend.
-- O frontend deve usar o `project_id` retornado para todas operações subsequentes (consultas, atualizações, etc).
-
----
-
-## 6. Enriquecimento de Contexto para Refinamento
-
-Quando o frontend envia um `analysis_type` de refinamento (ex: `refinamento_epicos_azure_devops`), o backend executa um processo de enriquecimento de contexto antes de enviar o payload ao MCP:
-
-1. O backend consulta uma configuração (`ANALYSIS_CONTEXT_CONFIG`) que mapeia o `analysis_type` para uma lista de estados/reports a serem lidos do Blob Storage.
-2. Para cada entrada, o backend recupera o estado correspondente usando `ProjectStateService.load_latest_state_from_blob()` e extrai o campo de report relevante (ex: `epicos_report`).
-3. O conteúdo do report é serializado em string (usando JSON ou formatação legível).
-4. Todos os textos extraídos são concatenados junto com o texto original de `instrucoes_extras` enviado pelo frontend.
-5. O texto enriquecido é enviado no campo `comentario_extra` do payload para o MCP.
-6. O método de enriquecimento agora exige usuario_executor e nome_projeto como argumentos obrigatórios e repassa corretamente para o serviço de estado.
-
-**Nota:** Este fluxo é orquestrado pela rota `/analysis/start` em [`backend/app/api/analysis.py`] e pelo serviço `ContextEnrichmentService`, garantindo que o contexto enviado ao MCP seja o mais completo possível.
-
-```mermaid
-sequenceDiagram
-    participant FE as Frontend
-    participant BE as Backend
-    participant Blob as Blob Storage
-    participant MCP as MCP Server
-    FE->>BE: POST /analysis/start (nome_projeto, analysis_type, instrucoes_extras)
-    BE->>BE: Consulta ANALYSIS_CONTEXT_CONFIG para analysis_type
-    loop Para cada estado/report
-        BE->>Blob: Busca estado e extrai report (usando usuario_executor, nome_projeto, project_id)
-        BE->>BE: Serializa report como texto
-    end
-    BE->>BE: Concatena textos dos reports + instrucoes_extras
-    BE->>MCP: Envia payload enriquecido (comentario_extra)
-    MCP-->>BE: job_id, project_id
-    BE-->>FE: message, project_id, nome_projeto
-```
-
----
-
-## 7. Comunicação via Webhooks (MCP → Backend)
-
-Esta seção detalha o fluxo de recebimento de webhooks do MCP pela rota `backend/app/api/webhooks.py`. Quando o MCP finaliza um processamento, ele envia um webhook para o backend, que atualiza o estado do projeto no Redis e Blob Storage.
-
-Fluxo:
-1. MCP envia webhook para `/webhooks/mcp` com payload contendo `project_id`, `job_id`, `status` e `report_data`.
-2. O backend valida o payload e atualiza o status do job no Redis.
-3. Se o status for "done", o backend atualiza os relatórios e salva o estado atualizado no Blob Storage.
-4. O backend atualiza o resumo do projeto, garantindo que o campo `ultima_analysis_type` seja consistente.
-5. O job é marcado como finalizado no Redis.
-
-```mermaid
-sequenceDiagram
-    participant MCP as MCP Server
-    participant BE as Backend
-    participant Redis as Redis
-    participant Blob as Blob Storage
-    MCP->>BE: POST /webhooks/mcp (payload)
-    BE->>Redis: Atualiza status do job
-    BE->>Blob: Salva relatório e resumo atualizado
-    BE->>Redis: Marca job como done
-    BE-->>MCP: Confirma recebimento
-```
-
----
-
 ## 8. Gerenciamento de Sessão e Relatórios
 
 A rota `backend/app/api/session.py` é responsável pela consulta e atualização de relatórios dos projetos, além do gerenciamento da sessão do usuário.
 
-Fluxo:
-1. O frontend consulta relatórios específicos usando endpoints como `/session/project/{project_id}/{job_id}/reports`.
-2. O backend busca o estado do projeto no Blob Storage e Redis, validando o job_id e retornando o relatório correspondente.
-3. Para atualização de relatórios, o frontend envia dados via PUT para `/session/project/{project_id}/report`, e o backend atualiza o Redis e salva o novo estado no Blob Storage.
-4. O backend também permite consultar arquivos docx associados ao projeto e salvar o estado manualmente.
+Fluxo atualizado (prioridade Redis → Blob):
+1. O frontend consulta relatórios específicos usando o endpoint `/session/project/{project_id}/{job_id}/reports`.
+2. O backend busca os relatórios do projeto no Redis usando `redis_service.get_all_reports_for_project(project_id)`.
+3. Se o Redis retornar dados válidos e todos os relatórios possuírem `job_id` igual ao solicitado, retorna imediatamente os dados do Redis (status 200).
+4. Se o Redis não retornar dados ou houver divergência de `job_id`, o backend faz fallback para o Blob Storage usando `ProjectStateService.load_all_states_from_blob(usuario_executor, project_id)`.
+5. Se o Blob retornar dados válidos e o `job_id` corresponder, retorna os dados do Blob (status 200).
+6. Se não houver dados válidos, verifica se existe um job ativo (status 202), ou retorna erro 404.
 
-```mermaid
-sequenceDiagram
-    participant FE as Frontend
-    participant BE as Backend
-    participant Redis as Redis
-    participant Blob as Blob Storage
-    FE->>BE: GET /session/project/{project_id}/{job_id}/reports
-    BE->>Blob: Busca estado do projeto
-    BE->>Redis: Valida job ativo
-    BE-->>FE: Retorna relatório ou status de processamento
-    FE->>BE: PUT /session/project/{project_id}/report
-    BE->>Redis: Atualiza relatório
-    BE->>Blob: Salva novo estado
-    BE-->>FE: Confirma atualização
-```
+mermaid
+flowchart TD
+    FE[Frontend] -->|GET /session/project/{project_id}/{job_id}/reports| BE[Backend]
+    BE -->|Busca no Redis| Redis[(Redis)]
+    Redis -- Dados válidos e job_id ok --> BE
+    BE -- Retorna dados do Redis --> FE
+    Redis -- Dados ausentes ou job_id divergente --> BE
+    BE -->|Fallback| Blob[(Blob Storage)]
+    Blob -- Dados válidos e job_id ok --> BE
+    BE -- Retorna dados do Blob --> FE
+    Blob -- Dados ausentes ou job_id divergente --> BE
+    BE -- Verifica job ativo ou retorna erro --> FE
+
 
 ---
 

--- a/backend/docs/ARCHITECTURE_FLOW.md
+++ b/backend/docs/ARCHITECTURE_FLOW.md
@@ -6,59 +6,324 @@ Este documento detalha o fluxo completo do backend Peers CodeAI, desde o recebim
 
 ## Índice
 
-1. Visão Geral da Comunicação entre Grandes Blocos
-2. Login e Autenticação via Azure AD
-3. Criação de Projeto e Conversão nome_projeto → project_id
-4. Consulta de Projeto Existente
-5. Observações Importantes
-6. Enriquecimento de Contexto para Refinamento
-7. Comunicação via Webhooks (MCP → Backend)
-8. Gerenciamento de Sessão e Relatórios
-9. Resumo dos Endpoints por Rota
+1. Visão Macro da Aplicação
+2. Visão Geral da Comunicação entre Grandes Blocos
+3. Login e Autenticação via Azure AD
+4. Criação de Projeto e Conversão nome_projeto → project_id
+5. Consulta de Projeto Existente
+6. Observações Importantes
+7. Enriquecimento de Contexto para Refinamento
+8. Comunicação via Webhooks (MCP → Backend)
+9. Gerenciamento de Sessão e Relatórios
+9.1. Lógica de Seleção de Estado Mais Recente
+10. Resumo dos Endpoints por Rota
+11. Tratamento de Estados Legados e Migração
 
 ---
 
-## 8. Gerenciamento de Sessão e Relatórios
+## 1. Visão Macro da Aplicação
 
-A rota `backend/app/api/session.py` é responsável pela consulta e atualização de relatórios dos projetos, além do gerenciamento da sessão do usuário.
-
-Fluxo atualizado (prioridade Redis → Blob):
-1. O frontend consulta relatórios específicos usando o endpoint `/session/project/{project_id}/{job_id}/reports`.
-2. O backend busca os relatórios do projeto no Redis usando `redis_service.get_all_reports_for_project(project_id)`.
-3. Se o Redis retornar dados válidos e todos os relatórios possuírem `job_id` igual ao solicitado, retorna imediatamente os dados do Redis (status 200).
-4. Se o Redis não retornar dados ou houver divergência de `job_id`, o backend faz fallback para o Blob Storage usando `ProjectStateService.load_all_states_from_blob(usuario_executor, project_id)`.
-5. Se o Blob retornar dados válidos e o `job_id` corresponder, retorna os dados do Blob (status 200).
-6. Se não houver dados válidos, verifica se existe um job ativo (status 202), ou retorna erro 404.
+Esta seção apresenta uma visão macro da arquitetura do sistema Peers CodeAI, destacando os principais componentes, integrações e fluxos de dados entre eles. O diagrama abaixo serve como ponto de entrada para o entendimento global da aplicação.
 
 mermaid
 flowchart TD
-    FE[Frontend] -->|GET /session/project/{project_id}/{job_id}/reports| BE[Backend]
-    BE -->|Busca no Redis| Redis[(Redis)]
-    Redis -- Dados válidos e job_id ok --> BE
-    BE -- Retorna dados do Redis --> FE
-    Redis -- Dados ausentes ou job_id divergente --> BE
-    BE -->|Fallback| Blob[(Blob Storage)]
-    Blob -- Dados válidos e job_id ok --> BE
-    BE -- Retorna dados do Blob --> FE
-    Blob -- Dados ausentes ou job_id divergente --> BE
-    BE -- Verifica job ativo ou retorna erro --> FE
+    subgraph Usuário
+        FE[Frontend (React/Next.js)]
+    end
+    subgraph AzureAD[Azure AD]
+        AD[Azure AD (Autenticação)]
+    end
+    subgraph Backend[Backend API (FastAPI)]
+        API[API Layer]
+        Auth[Auth Router]
+        Analysis[Analysis Router]
+        Projects[Projects Router]
+        Session[Session Router]
+        Webhooks[Webhooks Router]
+    end
+    subgraph Infra[Infra]
+        Redis[Redis (Sessões, Jobs, Relatórios)]
+        Blob[Blob Storage (Estados, Arquivos)]
+    end
+    subgraph MCP[MCP Server]
+        MCPServer[MCP Server (Agente de Inteligência)]
+    end
+
+    FE-->|1. Login/Token JWT|AD
+    FE-->|2. Requisições REST|API
+    API-->|3. Validação JWT|AD
+    API-->|4. Operações de Sessão/Job|Redis
+    API-->|5. Persistência de Estado|Blob
+    API-->|6. Payload de Análise|MCPServer
+    MCPServer-->|7. Webhook de Resultado|Webhooks
+    Webhooks-->|8. Atualiza Estado|Redis
+    Webhooks-->|9. Atualiza Estado|Blob
+    API-->|10. Consulta/Atualização de Relatórios|Redis
+    API-->|11. Consulta/Atualização de Relatórios|Blob
+    FE-->|12. Recebe Resposta|API
+
+    classDef infra fill:#f9f,stroke:#333,stroke-width:2px;
+    class Redis,Blob infra;
+    classDef routers fill:#cff,stroke:#333,stroke-width:1px;
+    class Auth,Analysis,Projects,Session,Webhooks routers;
+
+    %% Notas explicativas:
+    %% 1. O Frontend inicia o fluxo de autenticação via Azure AD e recebe o token JWT.
+    %% 2. Todas as requisições do usuário passam pela camada de API do Backend.
+    %% 3. O Backend valida o JWT com Azure AD.
+    %% 4. Sessões, jobs e relatórios são armazenados e consultados no Redis.
+    %% 5. Estados completos e arquivos são persistidos no Blob Storage.
+    %% 6. Para análises, o Backend envia payloads assíncronos ao MCP Server.
+    %% 7. O MCP Server retorna resultados via Webhook para o Backend.
+    %% 8/9. O Backend atualiza Redis e Blob Storage com os resultados dos webhooks.
+    %% 10/11. Relatórios podem ser consultados/atualizados tanto no Redis quanto no Blob Storage.
+    %% 12. O Frontend recebe respostas agregadas da API.
 
 
 ---
 
-## 9. Resumo dos Endpoints por Rota
+## 2. Visão Geral da Comunicação entre Grandes Blocos
+
+Esta seção apresenta uma visão de alto nível da comunicação entre os principais blocos do sistema: Frontend, Backend (rotas em `backend/app/api`) e MCP Server. O Backend orquestra as requisições recebidas do Frontend, processa dados, integra serviços internos e se comunica com o MCP Server para processamento de inteligência.
+
+**Descrição dos Blocos:**
+- **Frontend:** Interface do usuário, responsável por enviar requisições HTTP para o Backend e consumir respostas.
+- **Backend (API):** Camada intermediária que expõe rotas REST via FastAPI, localizadas em `backend/app/api`. Cada rota é responsável por uma parte do fluxo, como autenticação, análise, projetos, sessões e webhooks.
+- **MCP Server:** Serviço externo de inteligência que recebe payloads do Backend para processamento de análises e retorna resultados via webhooks.
+
+**Diagrama Mermaid:**
+
+mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant BE as Backend (API)
+    participant MCP as MCP Server
+    FE->>BE: Requisições HTTP (rotas em backend/app/api)
+    BE->>MCP: Payloads de análise (via /analysis)
+    MCP-->>BE: Webhooks de resultado (/webhooks/mcp)
+    BE-->>FE: Respostas HTTP (dados, status, relatórios)
+
+
+---
+
+## 3. Login e Autenticação via Azure AD
+
+Fluxo:
+1. O frontend envia o token JWT via header Authorization para o endpoint POST `/auth/login` (implementado em [`backend/app/api/auth.py`]).
+2. O backend valida o token via `AzureADService`, usando a chave pública do Azure AD (JWKS).
+3. O backend extrai o `usuario_executor` dos claims do token (preferred_username, email ou upn).
+4. O backend busca os projetos associados ao `usuario_executor` usando `ProjectStateService._fetch_and_sanitize_projects`.
+5. O backend retorna para o frontend a lista de projetos de resumo, contendo apenas os campos: nome_projeto, ultima_analysis_type, created_at, ultima_atualizacao, project_id.
+
+**Nota:** O fluxo de validação do token JWT é orquestrado pela rota `/auth/login` em [`backend/app/api/auth.py`], que utiliza o serviço `AzureADService` para garantir autenticidade e extração segura do usuário.
+
+mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant BE as Backend
+    participant AzureAD as Azure AD
+    participant Blob as Blob Storage
+    participant Redis as Redis
+    FE->>BE: POST /auth/login (token JWT)
+    BE->>AzureAD: Valida token JWT
+    AzureAD-->>BE: Claims válidos
+    BE->>BE: Extrai usuario_executor dos claims
+    BE->>Blob: Busca projetos de resumo do usuario_executor
+    BE->>Redis: Busca estados de resumo no cache
+    BE-->>FE: Retorna user_info + lista de projetos de resumo
+
+
+---
+
+## 4. Criação de Projeto e Conversão nome_projeto → project_id
+
+O frontend deve sempre enviar apenas o campo `nome_projeto` para criação ou início de análise. O backend é responsável por converter internamente o `nome_projeto` para `project_id`:
+- Se o projeto já existe, o backend recupera o mesmo `project_id` do estado salvo.
+- Se o projeto é novo, o backend gera um novo `project_id` (UUID) e associa ao nome do projeto.
+- O `project_id` é retornado na resposta do backend para uso em operações subsequentes.
+- O enriquecimento de contexto agora exige usuario_executor e nome_projeto como parâmetros obrigatórios.
+- **Nota de validação:** O backend utiliza o método `validate_and_fix_project_id` para garantir que todo estado recuperado possua um `project_id` válido, corrigindo automaticamente estados legados ou incompletos. Logs de warning são gerados quando correções são aplicadas.
+
+**Nota:** Este fluxo é implementado pela rota `/analysis/start` em [`backend/app/api/analysis.py`], que utiliza o serviço `ProjectStateService` para conversão e persistência do identificador do projeto.
+
+mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant BE as Backend
+    participant MCP as MCP Server
+    FE->>BE: POST /analysis/start (nome_projeto, analysis_type, ...)
+    BE->>BE: Converte nome_projeto para project_id (recupera existente ou gera novo)
+    BE->>BE: Enriquecimento de contexto (passando usuario_executor, nome_projeto, project_id)
+    BE->>MCP: Envia payload (project_id, analysis_type, ...)
+    MCP-->>BE: job_id, project_id
+    BE-->>FE: message, project_id, nome_projeto
+
+
+---
+
+## 5. Consulta de Projeto Existente
+
+O Backend permite ao frontend consultar a existência de um projeto pelo nome, retornando o estado associado se encontrado.
+
+**Nota:** Este fluxo é implementado pela rota `/projects/check` em [`backend/app/api/projects.py`], que utiliza o serviço `ProjectStateService` para buscar e validar projetos existentes.
+
+mermaid
+sequenceDiagram
+    FE->>BE: GET /projects/check (nome_projeto)
+    BE->>BE: Busca project_id associado ao nome_projeto
+    BE-->>FE: exists: true, state (inclui project_id)
+
+
+---
+
+## 6. Observações Importantes
+
+- O campo `project_id` nunca deve ser enviado pelo frontend. O backend faz toda a conversão e retorna o `project_id` correto.
+- Toda comunicação interna e com MCP utiliza o `project_id` gerado ou recuperado pelo backend.
+- O frontend deve usar o `project_id` retornado para todas operações subsequentes (consultas, atualizações, etc).
+
+---
+
+## 7. Enriquecimento de Contexto para Refinamento
+
+Quando o frontend envia um `analysis_type` de refinamento (ex: `refinamento_epicos_azure_devops`), o backend executa um processo de enriquecimento de contexto antes de enviar o payload ao MCP:
+
+1. O backend consulta uma configuração (`ANALYSIS_CONTEXT_CONFIG`) que mapeia o `analysis_type` para uma lista de estados/reports a serem lidos do Blob Storage.
+2. Para cada entrada, o backend recupera o estado correspondente usando `ProjectStateService.load_latest_state_from_blob()` e extrai o campo de report relevante (ex: `epicos_report`).
+3. O conteúdo do report é serializado em string (usando JSON ou formatação legível).
+4. Todos os textos extraídos são concatenados junto com o texto original de `instrucoes_extras` enviado pelo frontend.
+5. O texto enriquecido é enviado no campo `comentario_extra` do payload para o MCP.
+6. O método de enriquecimento agora exige usuario_executor e nome_projeto como argumentos obrigatórios e repassa corretamente para o serviço de estado.
+
+**Nota:** Este fluxo é orquestrado pela rota `/analysis/start` em [`backend/app/api/analysis.py`] e pelo serviço `ContextEnrichmentService`, garantindo que o contexto enviado ao MCP seja o mais completo possível.
+
+mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant BE as Backend
+    participant Blob as Blob Storage
+    participant MCP as MCP Server
+    FE->>BE: POST /analysis/start (nome_projeto, analysis_type, instrucoes_extras)
+    BE->>BE: Consulta ANALYSIS_CONTEXT_CONFIG para analysis_type
+    loop Para cada estado/report
+        BE->>Blob: Busca estado e extrai report (usando usuario_executor, nome_projeto, project_id)
+        BE->>BE: Serializa report como texto
+    end
+    BE->>BE: Concatena textos dos reports + instrucoes_extras
+    BE->>MCP: Envia payload enriquecido (comentario_extra)
+    MCP-->>BE: job_id, project_id
+    BE-->>FE: message, project_id, nome_projeto
+
+
+---
+
+## 8. Comunicação via Webhooks (MCP → Backend)
+
+Esta seção detalha o fluxo de recebimento de webhooks do MCP pela rota `backend/app/api/webhooks.py`. Quando o MCP finaliza um processamento, ele envia um webhook para o backend, que atualiza o estado do projeto no Redis e Blob Storage.
+
+Fluxo:
+1. MCP envia webhook para `/webhooks/mcp` com payload contendo `project_id`, `job_id`, `status` e `report_data`.
+2. O backend valida o payload e atualiza o status do job no Redis.
+3. Se o status for "done", o backend atualiza os relatórios e salva o estado atualizado no Blob Storage.
+4. O backend atualiza o resumo do projeto, garantindo que o campo `ultima_analysis_type` seja consistente.
+5. O campo `last_job_id` do resumo é considerado a fonte de verdade para o job_id atual do projeto. Este valor é propagado para os relatórios individuais, sobrescrevendo qualquer job_id divergente que possa existir nos estados de relatório.
+6. O job é marcado como finalizado no Redis.
+
+**Nota explicativa:**
+- O campo `last_job_id` do resumo é priorizado sobre os job_ids dos relatórios individuais. Isso garante consistência e evita divergências entre estados legados ou relatórios processados fora de ordem. Toda consulta e atualização de relatórios utiliza o job_id mestre do resumo como referência principal.
+- Ao receber um webhook de sucesso, o backend injeta o `last_job_id` do resumo nos relatórios individuais, tornando o resumo a autoridade máxima para o job_id do projeto.
+
+**Diagrama Mermaid atualizado:**
+
+mermaid
+sequenceDiagram
+    participant MCP as MCP Server
+    participant BE as Backend
+    participant Redis as Redis
+    participant Blob as Blob Storage
+    MCP->>BE: POST /webhooks/mcp (payload)
+    BE->>Redis: Atualiza status do job
+    BE->>Blob: Salva relatório e resumo atualizado
+    BE->>BE: Injeta last_job_id do resumo nos relatórios individuais
+    BE->>Redis: Marca job como done
+    BE-->>MCP: Confirma recebimento
+
+
+---
+
+## 9. Gerenciamento de Sessão e Relatórios
+
+A rota `backend/app/api/session.py` é responsável pela consulta e atualização de relatórios dos projetos, além do gerenciamento da sessão do usuário.
+
+Fluxo:
+1. O frontend consulta relatórios específicos usando endpoints como `/session/project/{project_id}/{job_id}/reports`.
+2. O backend busca o estado do projeto no Blob Storage e Redis, validando o job_id e retornando o relatório correspondente.
+3. Para atualização de relatórios, o frontend envia dados via PUT para `/session/project/{project_id}/report`, e o backend atualiza o Redis e salva o novo estado no Blob Storage.
+4. O backend também permite consultar arquivos docx associados ao projeto e salvar o estado manualmente.
+
+**Lógica de ordenação por timestamp (prioridade):**
+- Ao buscar o estado mais recente de um projeto, o backend utiliza o seguinte critério de ordenação:
+    1. **Timestamp presente no nome do arquivo do blob** (formato `estado_<tipo>_YYYYMMDDTHHMMSSZ.json`), considerado a fonte mais confiável de criação.
+    2. Se o nome não seguir o padrão, utiliza o campo `created_at` do JSON interno do estado.
+    3. Se ambos estiverem ausentes ou inválidos, utiliza o campo `ultima_atualizacao` do JSON.
+    4. Se todos falharem, considera a data mínima para ir ao fim da fila.
+- Apenas o arquivo mais recente, segundo essa ordenação, é considerado para operações de leitura e atualização.
+
+---
+
+## 9.1. Lógica de Seleção de Estado Mais Recente
+
+Esta subseção detalha o algoritmo utilizado para selecionar o estado mais recente de um projeto, conforme implementado em `backend/app/services/project_state_service.py` (método `load_latest_state_from_blob`).
+
+**Fluxo resumido:**
+1. Filtra blobs pelo prefixo e tipo de relatório desejado.
+2. Para cada blob candidato:
+    - Extrai o timestamp do nome do arquivo, se possível.
+    - Caso não seja possível, tenta usar o campo `created_at` do JSON.
+    - Caso ainda não seja possível, tenta o campo `ultima_atualizacao`.
+    - Se todos falharem, utiliza data mínima.
+3. Ordena todos os candidatos do mais novo para o mais antigo.
+4. Seleciona o primeiro da lista como estado mais recente.
+
+**Exemplo de código Mermaid ilustrando o fluxo de decisão:**
+
+mermaid
+flowchart TD
+    A["Início: Lista de blobs candidatos"] --> B{"Para cada blob"}
+    B --> C1["Extrai timestamp do nome do arquivo"]
+    C1 --> D1{"Timestamp válido?"}
+    D1 -- Sim --> E1["Usa timestamp do nome"]
+    D1 -- Não --> C2["Tenta campo created_at do JSON"]
+    C2 --> D2{"created_at válido?"}
+    D2 -- Sim --> E2["Usa created_at"]
+    D2 -- Não --> C3["Tenta campo ultima_atualizacao do JSON"]
+    C3 --> D3{"ultima_atualizacao válido?"}
+    D3 -- Sim --> E3["Usa ultima_atualizacao"]
+    D3 -- Não --> E4["Usa data mínima"]
+    E1 & E2 & E3 & E4 --> F["Ordena blobs por data (desc)"]
+    F --> G["Seleciona blob mais recente"]
+
+
+---
+
+## 10. Resumo dos Endpoints por Rota
 
 | Arquivo                      | Endpoint(s)                                 | Descrição                                                                 |
 |-----------------------------|---------------------------------------------|---------------------------------------------------------------------------|
 | `auth.py`                   | `/auth/login`, `/auth/config`               | Autenticação e configuração Azure AD                                      |
 | `analysis.py`               | `/analysis/start`                           | Início de análise, conversão nome_projeto → project_id, enriquecimento de contexto |
 | `projects.py`               | `/projects/check`, `/projects/list`         | Consulta e listagem de projetos existentes                                |
-| `session.py`                | `/session/project/{project_id}/{job_id}/reports`, `/session/project/{project_id}/report`, `/session/project/{project_id}/save-state`, `/session/project/{project_id}/docx-files` | Consulta, atualização e gerenciamento de relatórios e arquivos de sessão   |
-| `webhooks.py`               | `/webhooks/mcp`                             | Recebimento de webhooks do MCP, atualização de estado e relatórios        |
+| `session.py`                | `/session/project/{project_id}/{job_id}/reports`, `/session/project/{project_id}/report`, `/session/project/{project_id}/save-state`, `/session/project/{project_id}/docx-files` | Consulta, atualização e gerenciamento de relatórios e arquivos de sessão. Inclui validação de job_id mestre (last_job_id do resumo) nos endpoints de consulta de relatórios. |
+| `webhooks.py`               | `/webhooks/mcp`                             | Recebimento de webhooks do MCP, atualização de estado e relatórios. Prioriza o last_job_id do resumo como referência para todos relatórios. |
 
 ---
 
-**Notas:**
-- Todos os diagramas Mermaid estão sintaticamente corretos e podem ser renderizados em ferramentas compatíveis.
-- Os fluxos descritos refletem a arquitetura atual do backend, com integração segura entre Frontend, Backend e MCP Server.
-- Para dúvidas técnicas complexas, consulte as observações e notas de rodapé ao longo do documento.
+## 11. Tratamento de Estados Legados e Migração
+
+Esta seção documenta o comportamento do sistema ao encontrar estados legados, especialmente arquivos de resumo ou relatório que estejam sem `job_id` ou `project_id`.
+
+- Ao ler estados do Blob Storage, o backend utiliza o método `validate_and_fix_project_id` para corrigir automaticamente estados que estejam sem `project_id`, gerando um novo UUID quando necessário e logando um warning.
+- Quando um relatório ou resumo está sem `job_id`, o backend injeta o valor do `last_job_id` do resumo como referência principal, garantindo consistência entre todos os relatórios do projeto.
+- Logs de warning são emitidos sempre que um estado legado é corrigido automaticamente, permitindo rastreabilidade e facilitando a migração futura para o novo padrão.
+- Estratégia de fallback: estados sem os campos obrigatórios são ignorados nas operações críticas, e o sistema tenta recuperar informações válidas de outros blobs ou gera identificadores novos conforme necessário.
+- A lógica de correção automática é implementada nos métodos de leitura e sanitização de estados em `backend/app/services/project_state_service.py` e `backend/app/services/redis_session_service.py`.


### PR DESCRIPTION
O endpoint GET /project/{project_id}/{job_id}/reports foi modificado para primeiro buscar relatórios no Redis. Se os relatórios forem encontrados e todos tiverem job_id correspondente, retorna os dados do Redis. Caso contrário, faz fallback para o Blob Storage e retorna os dados se o job_id corresponder. Se não houver dados válidos, verifica se há um job ativo e retorna status 202, ou erro 404 se não encontrado. A documentação foi atualizada para descrever esse fluxo detalhado.