### PR TITLE
Adição do campo 'bedrock_enabled' ao modelo TaskConfig

### DIFF
--- a/models/task_config.py
+++ b/models/task_config.py
@@ -8,3 +8,4 @@ class TaskConfig(BaseModel):
     agent_type: str
     instrucoes_extras: str
     provider: Optional[str] = None
+    bedrock_enabled: Optional[bool] = False


### PR DESCRIPTION
Incluído campo opcional 'bedrock_enabled: Optional[bool] = False' para permitir ativar o uso do Amazon Bedrock nas configurações de tarefa.