### PR TITLE
Ajustes na factory LLMProviderFactory e no LLMOrchestrator para suportar o parâmetro bedrock_enabled e instanciar AmazonBedrockProvider quando configurado.

### DIFF
--- a/services/factories/llm_provider_factory.py
+++ b/services/factories/llm_provider_factory.py
@@ -2,6 +2,7 @@ from typing import Optional, Dict, Type, Any
 from domain.interfaces.llm_provider_interface import ILLMProvider
 from tools.requisicao_openai import OpenAILLMProvider
 from tools.requisicao_claude import AnthropicClaudeProvider
+from tools.requisicao_bedrock import AmazonBedrockProvider
 from services.azure_secret_manager import AzureSecretManager, VaultType
 
 class LLMProviderFactory:
@@ -12,21 +13,35 @@ class LLMProviderFactory:
     }
     
     @classmethod
-    def create_provider(cls, context: Any, model_name: Optional[str] = None, provider_hint: Optional[str] = None) -> ILLMProvider:
+    def create_provider(
+        cls,
+        context: Any,
+        model_name: Optional[str] = None,
+        provider_hint: Optional[str] = None,
+        bedrock_enabled: bool = False
+    ) -> ILLMProvider:
         model_lower = (model_name or "").lower()
         secret_manager = AzureSecretManager(vault_type=VaultType.LLM)
         provider_class = None
-        if provider_hint:
-            hint_lower = provider_hint.lower()
-            if hint_lower == "anthropic":
-                provider_class = cls._providers.get('anthropic', AnthropicClaudeProvider)
-            elif hint_lower == "openai":
-                provider_class = cls._providers.get('openai', OpenAILLMProvider)
+        if bedrock_enabled:
+            if provider_hint:
+                hint_lower = provider_hint.lower()
+                if hint_lower == "anthropic" or "claude" in model_lower:
+                    provider_class = AmazonBedrockProvider
+            elif "claude" in model_lower:
+                provider_class = AmazonBedrockProvider
         if not provider_class:
-            if "claude" in model_lower:
-                provider_class = cls._providers.get('claude', AnthropicClaudeProvider)
-            else:
-                provider_class = cls._providers.get('openai', OpenAILLMProvider)
+            if provider_hint:
+                hint_lower = provider_hint.lower()
+                if hint_lower == "anthropic":
+                    provider_class = cls._providers.get('anthropic', AnthropicClaudeProvider)
+                elif hint_lower == "openai":
+                    provider_class = cls._providers.get('openai', OpenAILLMProvider)
+            if not provider_class:
+                if "claude" in model_lower:
+                    provider_class = cls._providers.get('claude', AnthropicClaudeProvider)
+                else:
+                    provider_class = cls._providers.get('openai', OpenAILLMProvider)
         return provider_class(secret_manager=secret_manager)
     
     @classmethod

--- a/services/llm_orchestrator.py
+++ b/services/llm_orchestrator.py
@@ -9,10 +9,12 @@ class LLMOrchestrator:
         model_name = llm_request_params.get('model_name')
         agent_type = llm_request_params.get('agent_type', 'processador')
         provider = llm_request_params.get('provider')
+        bedrock_enabled = llm_request_params.get('bedrock_enabled', False)
         llm_provider = LLMProviderFactory.create_provider(
             model_name, 
             self.rag_retriever, 
-            provider_hint=provider
+            provider_hint=provider,
+            bedrock_enabled=bedrock_enabled
         )
         job_id = llm_request_params.get('job_id')
         agente = AgentFactory.create_agent(agent_type, llm_provider=llm_provider)


### PR DESCRIPTION
Modificado o método create_provider da factory para aceitar o parâmetro bedrock_enabled e escolher AmazonBedrockProvider para modelos Anthropic quando habilitado. Ajustado LLMOrchestrator para extrair bedrock_enabled do parâmetro e repassá-lo à factory.