### PR TITLE
Inclusão do parâmetro bedrock_enabled no builder de requests para propagar a configuração até o orquestrador.

### DIFF
--- a/services/llm_request_builder.py
+++ b/services/llm_request_builder.py
@@ -15,5 +15,6 @@ class LLMRequestBuilder:
             'model_name': task_config.model_name,
             'provider': getattr(task_config, 'provider', None),
             'instrucoes_padrao': instrucoes_padrao,
-            'job_id': mcp_request.job_id
+            'job_id': mcp_request.job_id,
+            'bedrock_enabled': getattr(task_config, 'bedrock_enabled', False)
         }


### PR DESCRIPTION
Modificado o método build_request da classe LLMRequestBuilder para incluir o campo bedrock_enabled no dicionário retornado, permitindo controle da ativação do Amazon Bedrock nas requisições.