### PR TITLE
Adicionar suporte para requisições via Amazon Bedrock no módulo de requisições Anthropic, mantendo suporte ao método original.

### DIFF
--- a/config_tasks.yaml
+++ b/config_tasks.yaml
@@ -5,6 +5,7 @@ criacao_epicos_azure_devops:
   agent_type: "processador"
   instrucoes_extras: "criacao_epicos_azure_devops"
   provider: "anthropic"
+  bedrock_enabled: true
 
 refinamento_epicos_azure_devops:
   description: "criação de epicos a partir de transcrição de reunião"

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,4 @@ typing-inspection==0.4.1
 typing_extensions==4.14.1
 urllib3==2.5.0
 wheel==0.45.1
+boto3==1.35.90


### PR DESCRIPTION
Este PR introduz a capacidade de enviar requisições para modelos Anthropic usando a API Amazon Bedrock, controlado por parâmetro 'bedrock_enabled' na configuração da tarefa. Inclui autenticação AWS via credenciais armazenadas no Azure Key Vault, criação do cliente boto3 para Bedrock e seleção dinâmica do método de requisição. Nenhuma remoção de código antigo foi feita, garantindo compatibilidade reversa.