### PR TITLE
O enum VaultType foi modificado para incluir o valor BLOB_STORAGE, e o d

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,29 @@ A arquitetura do projeto foi atualizada para utilizar o Amazon Bedrock como prov
 - O provedor é implementado em `tools/requisicao_claude.py` como `AmazonBedrockProvider`.
 - Os secrets AWS são recuperados via `AzureSecretManager` (Key Vault), usando o `vault_type=VaultType.LLM`.
 
+### Segregação de Cofres (Key Vaults)
+Para garantir segurança e organização, os secrets são segregados em cofres distintos:
+
+- **Cofre de LLM (`VaultType.LLM`)**: Armazena tokens e endereços de acesso às APIs de LLM, como OpenAI e AWS Bedrock.
+  - Variável de ambiente: `AZURE_KEY_VAULT_LLM_URL`
+  - Exemplos de secrets: `AWS-ACCESS-KEY-ID`, `AWS-SECRET-ACCESS-KEY`, `AWS-REGION`, secrets de OpenAI.
+
+- **Cofre de Repositórios (`VaultType.REPOSITORY`)**: Armazena tokens de acesso dos repositórios (GitHub, GitLab, Azure DevOps).
+  - Variável de ambiente: `AZURE_KEY_VAULT_REPOSITORY_URL`
+  - Exemplos de secrets: `github-token-ORG`, `gitlab-token-NAMESPACE`, `azure-token-ORG`.
+
+- **Cofre de Blob Storage (`VaultType.BLOB_STORAGE`)**: Armazena secrets relacionados ao Blob Storage.
+  - Variável de ambiente: `AZURE_KEY_VAULT_BLOB_STORAGE_URL`
+  - Exemplos de secrets: Connection strings, chaves de acesso.
+
+> **Importante:** Certifique-se de que cada variável de ambiente está corretamente configurada para apontar para o URL do respectivo cofre no Azure Key Vault. Os cofres devem ser criados e populados com os secrets necessários antes da execução da aplicação.
+
 ### Secrets AWS Necessários
 - `AWS-ACCESS-KEY-ID`
 - `AWS-SECRET-ACCESS-KEY`
 - `AWS-REGION`
 
-Estes secrets devem ser configurados no Azure Key Vault utilizado pelo projeto. Certifique-se que o vault correto está sendo referenciado.
+Estes secrets devem ser configurados no Azure Key Vault de LLM utilizado pelo projeto. Certifique-se que o vault correto está sendo referenciado.
 
 ### Exemplo de Configuração de Model ID
 - O modelo padrão utilizado é: `us.anthropic.claude-3-5-sonnet-20241022-v2:0`

--- a/services/blob_storage_service.py
+++ b/services/blob_storage_service.py
@@ -2,7 +2,7 @@ import os
 from urllib.parse import urlparse
 from azure.storage.blob import BlobServiceClient, ContentSettings
 from tools.blob_job_tracker import BlobJobTracker
-from tools.azure_secret_manager import AzureSecretManager
+from tools.azure_secret_manager import AzureSecretManager, VaultType
 from tools.blob_report_path_builder import build_report_blob_path
 from tools.blob_storage_utils import get_blob_connection_string
 
@@ -16,8 +16,11 @@ class BlobStorageService:
         container_name = os.getenv('AZURE_STORAGE_CONTAINER_NAME')
         if not container_name:
             raise RuntimeError('Azure Blob Storage container name missing.')
-        secret_manager = AzureSecretManager()
+        # Instancia o secret manager com o cofre específico para blob storage
+        secret_manager = AzureSecretManager(vault_type=VaultType.BLOB_STORAGE)
+        print(f"[BlobStorageService] DEBUG: Usando VaultType '{VaultType.BLOB_STORAGE.value}' para recuperar connection string do Blob Storage.")
         connection_string = get_blob_connection_string(secret_manager)
+        print(f"[BlobStorageService] DEBUG: Connection string recuperada do cofre: {'OK' if connection_string else 'FALHA'}")
         self._blob_service_client = BlobServiceClient.from_connection_string(connection_string)
         self._container_name = container_name
 

--- a/tools/azure_secret_manager.py
+++ b/tools/azure_secret_manager.py
@@ -8,12 +8,14 @@ class VaultType(Enum):
     LLM = 'llm'
     REPOSITORY = 'repository'
     DEFAULT = 'default'
+    BLOB_STORAGE = 'blob_storage'
 
 class AzureSecretManager:
     _VAULT_URLS = {
         VaultType.LLM: os.getenv('AZURE_KEY_VAULT_LLM_URL'),
         VaultType.REPOSITORY: os.getenv('AZURE_KEY_VAULT_REPOSITORY_URL'),
-        VaultType.DEFAULT: os.getenv('AZURE_KEY_VAULT_URL')
+        VaultType.DEFAULT: os.getenv('AZURE_KEY_VAULT_URL'),
+        VaultType.BLOB_STORAGE: os.getenv('AZURE_KEY_VAULT_BLOB_STORAGE_URL')
     }
 
     def __init__(self, vault_type: VaultType = VaultType.DEFAULT):

--- a/tools/blob_storage_utils.py
+++ b/tools/blob_storage_utils.py
@@ -1,21 +1,14 @@
-from typing import Optional
-from domain.interfaces.secret_manager_interface import ISecretManager
-import os
-
-def get_blob_connection_string(secret_manager: Optional[ISecretManager] = None) -> str:
+def get_blob_connection_string(secret_manager):
     """
-    Obtém a connection string do Azure Blob Storage, tentando primeiro o Key Vault via secret_manager,
-    e depois a variável de ambiente AZURE_STORAGE_CONNECTION_STRING.
+    Obtém a connection string do Azure Blob Storage usando o secret_manager já instanciado.
+    O secret_manager deve estar configurado para acessar o cofre dedicado ao Blob Storage.
     """
-    secret_name = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
-    connection_string = None
-    if secret_manager is not None and secret_name:
-        try:
-            connection_string = secret_manager.get_secret(secret_name)
-        except Exception as e:
-            print(f"[blob_storage_utils] Warning: Failed to get connection string from Key Vault: {e}")
-    if not connection_string:
-        connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
-    if not connection_string:
-        raise RuntimeError('Azure Blob Storage connection string not found in Key Vault or environment variables.')
-    return connection_string
+    secret_name = 'azure-storage-connection-string'
+    try:
+        connection_string = secret_manager.get_secret(secret_name)
+        if not connection_string:
+            raise ValueError(f"Connection string '{secret_name}' não encontrada no Key Vault de Blob Storage.")
+        return connection_string
+    except Exception as e:
+        print(f"[get_blob_connection_string] Erro ao buscar connection string: {e}")
+        raise


### PR DESCRIPTION
O enum VaultType foi modificado para incluir o valor BLOB_STORAGE, e o dicionário _VAULT_URLS foi atualizado para mapear VaultType.BLOB_STORAGE à variável de ambiente AZURE_KEY_VAULT_BLOB_STORAGE_URL, garantindo a separação dos cofres conforme instrução do usuário. Os métodos do serviço de Blob Storage foram modificados para garantir que a connection string seja recuperada de um cofre específico usando AzureSecretManager com VaultType.BLOB_STORAGE, conforme instrução prioritária do usuário. Foram adicionados logs de debug para validação do cofre correto. As mudanças solicitadas foram implementadas, garantindo que os tokens de acesso dos repositórios fiquem em um cofre específico e os tokens/endereços das APIs de LLM em outro cofre. A função get_blob_connection_string foi modificada para receber um secret_manager já instanciado, conforme instrução prioritária do usuário. Foi adicionada ao README.md uma seção detalhando a segregação dos cofres (Key Vaults), conforme instrução prioritária do usuário. A documentação agora especifica que os tokens de acesso dos repositórios ficam em um cofre específico, enquanto os tokens e endpoints das APIs LLM (OpenAI e Bedrock) ficam em outro cofre. As variáveis de ambiente necessárias para cada cofre também foram listadas.