### PR TITLE
Os ajustes solicitados foram aplicados: o campo 'usuario' no modelo agor

### DIFF
--- a/models/user_group_mapping.py
+++ b/models/user_group_mapping.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel
+from typing import Optional
 
 class UserGroupMapping(BaseModel):
-    usuario: str
+    usuario: str  # Email completo do usuário (ex: joao.silva@exemplo.com)
     empresa: str
     grupo: str
+    descricao: Optional[str] = None  # Campo opcional para descrição

--- a/services/mongodb_group_resolver_service.py
+++ b/services/mongodb_group_resolver_service.py
@@ -6,7 +6,6 @@ import os
 
 class MongoDBGroupResolverService:
     def __init__(self, secret_manager: Optional[AzureSecretManager] = None, vault_type: VaultType = VaultType.AZURE_INFRASTRUCTURE, collection_name: Optional[str] = None):
-        # Sempre usar o cofre de infraestrutura Azure para segredos do MongoDB
         self.secret_manager = AzureSecretManager(vault_type=VaultType.AZURE_INFRASTRUCTURE)
         self.collection_name = os.getenv('AZURE_MONGODB_GROUP_COLLECTION')
         self.mongo_connection_string = self._get_mongo_connection_string()
@@ -25,9 +24,12 @@ class MongoDBGroupResolverService:
         except Exception as e:
             raise RuntimeError(f"Erro ao obter connection string do MongoDB: {e}")
 
-    def get_group_for_user(self, usuario: str, empresa: str) -> str:
-        query = {"usuario": usuario, "empresa": empresa}
+    def get_group_for_user(self, usuario_email: str) -> str:
+        """
+        Recebe o email completo do usuário e retorna o grupo correspondente consultando o MongoDB.
+        """
+        query = {"usuario": usuario_email}
         result = self.collection.find_one(query)
         if not result or 'grupo' not in result:
-            raise ValueError(f"Grupo não encontrado para usuario='{usuario}' e empresa='{empresa}' no MongoDB. Sem fallback.")
+            raise ValueError(f"Grupo não encontrado para usuario_email='{usuario_email}' no MongoDB. Sem fallback.")
         return result['grupo']

--- a/tools/azure_secret_manager.py
+++ b/tools/azure_secret_manager.py
@@ -39,10 +39,17 @@ class AzureSecretManager:
             raise ValueError(f"Secret '{secret_name}' não encontrado ou erro de acesso ao Key Vault.")
 
     def get_secret_with_user_context(self, secret_base_name: str, user_email: str, group_resolver: Optional[object] = None) -> str:
+        """
+        Obtém o secret usando o email completo do usuário e o group_resolver.
+        O nome do secret é construído como '{secret_base_name}-{grupo}-{empresa}',
+        onde grupo é obtido via group_resolver.get_group_for_user(user_email) e empresa via UserEmailParser.parse_email(user_email).
+        """
         if group_resolver is not None:
-            usuario, empresa, grupo = UserEmailParser.parse_email_with_group(user_email, group_resolver)
+            grupo = group_resolver.get_group_for_user(user_email)
+            _, empresa = UserEmailParser.parse_email(user_email)
             secret_name = f"{secret_base_name}-{grupo}-{empresa}"
         else:
+            # Fallback: utiliza apenas usuario e empresa (não recomendado)
             usuario, empresa = UserEmailParser.parse_email(user_email)
             secret_name = f"{secret_base_name}-{usuario}-{empresa}"
         try:

--- a/tools/blob_storage_utils.py
+++ b/tools/blob_storage_utils.py
@@ -1,20 +1,25 @@
 from tools.azure_secret_manager import VaultType
+from tools.user_email_parser import UserEmailParser
 
 def get_blob_connection_string(secret_manager, user_email: str, group_resolver: object = None, vault_type: VaultType = VaultType.AZURE_INFRASTRUCTURE):
     """
     Obtém a connection string do Azure Blob Storage usando o secret_manager já instanciado.
-    O secret_manager deve estar configurado para acessar o cofre dedicado ao Blob Storage.
-    Se group_resolver for fornecido, utiliza o contexto de grupo na busca do secret.
-    O vault_type agora é explicitamente VaultType.AZURE_INFRASTRUCTURE por padrão, garantindo leitura do cofre correto.
+    O nome do secret é construído como 'azure-storage-connection-string-{grupo}-{empresa}',
+    onde grupo é obtido via group_resolver.get_group_for_user(user_email) e empresa via UserEmailParser.parse_email(user_email).
     """
-    secret_name = 'azure-storage-connection-string'
+    secret_base_name = 'azure-storage-connection-string'
     if not user_email:
         raise ValueError("user_email é obrigatório para buscar a connection string do Blob Storage.")
     try:
         if group_resolver is not None:
-            connection_string = secret_manager.get_secret_with_user_context(secret_name, user_email, group_resolver=group_resolver)
+            grupo = group_resolver.get_group_for_user(user_email)
+            _, empresa = UserEmailParser.parse_email(user_email)
+            secret_name = f"{secret_base_name}-{grupo}-{empresa}"
+            connection_string = secret_manager.get_secret(secret_name)
         else:
-            connection_string = secret_manager.get_secret_with_user_context(secret_name, user_email)
+            usuario, empresa = UserEmailParser.parse_email(user_email)
+            secret_name = f"{secret_base_name}-{usuario}-{empresa}"
+            connection_string = secret_manager.get_secret(secret_name)
         if not connection_string:
             raise ValueError(f"Connection string '{secret_name}' não encontrada para o usuário '{user_email}' no Key Vault de Blob Storage (infraestrutura Azure).")
         return connection_string

--- a/tools/conectores/base_token_manager.py
+++ b/tools/conectores/base_token_manager.py
@@ -7,10 +7,21 @@ class BaseTokenManager:
         self.group_resolver = group_resolver
         self.secret_manager = AzureSecretManager(vault_type=vault_type)
 
-    def get_token(self, platform: str, org_name: str, user_email: str) -> str:
-        token_secret_name = f"{platform.lower()}-token"
+    def get_token(self, platform: str, user_email: str) -> str:
+        """
+        Obtém o token usando o email completo do usuário e o group_resolver.
+        O nome do secret é construído como '{platform.lower()}-token-{grupo}-{empresa}',
+        onde grupo é obtido via group_resolver.get_group_for_user(user_email) e empresa via UserEmailParser.parse_email(user_email).
+        """
+        if self.group_resolver is not None:
+            grupo = self.group_resolver.get_group_for_user(user_email)
+            _, empresa = UserEmailParser.parse_email(user_email)
+            token_secret_name = f"{platform.lower()}-token-{grupo}-{empresa}"
+        else:
+            usuario, empresa = UserEmailParser.parse_email(user_email)
+            token_secret_name = f"{platform.lower()}-token-{usuario}-{empresa}"
         try:
-            token = self.secret_manager.get_secret_with_user_context(token_secret_name, user_email, group_resolver=self.group_resolver)
+            token = self.secret_manager.get_secret(token_secret_name)
             return token
         except Exception as e:
             raise ValueError(f"Token '{token_secret_name}' não encontrado para plataforma '{platform}'. Detalhes: {e}") from e

--- a/tools/readers/gitlab_reader.py
+++ b/tools/readers/gitlab_reader.py
@@ -127,7 +127,8 @@ class GitLabReader(BaseFileReader):
         branch_a_ler = branch_name or 'main'
         usuario = empresa = grupo = None
         if user_email:
-            usuario, empresa, grupo = UserEmailParser.parse_email_with_group(user_email, group_resolver)
+            grupo = group_resolver.get_group_for_user(user_email) if group_resolver is not None else None
+            usuario, empresa = UserEmailParser.parse_email(user_email)
         if arquivos_especificos and len(arquivos_especificos) > 0:
             print(f"Modo de leitura filtrada GitLab ativado para {len(arquivos_especificos)} arquivos específicos no repositório '{getattr(repo_name, 'path_with_namespace', 'desconhecido')}'.")
             arquivos_lidos = self._ler_arquivos_especificos(repo_name, branch_a_ler, arquivos_especificos)

--- a/tools/readers/reader_geral.py
+++ b/tools/readers/reader_geral.py
@@ -8,7 +8,9 @@ class ReaderGeral:
         self.user_email = user_email
         self.group_resolver = group_resolver
         if user_email:
-            usuario, empresa, grupo = UserEmailParser.parse_email_with_group(user_email, group_resolver)
+            # Obtém grupo diretamente do MongoDB usando o e-mail
+            grupo = group_resolver.get_group_for_user(user_email) if group_resolver is not None else None
+            usuario, empresa = UserEmailParser.parse_email(user_email)
             self.usuario = usuario
             self.empresa = empresa
             self.grupo = grupo

--- a/tools/requisicao_claude.py
+++ b/tools/requisicao_claude.py
@@ -14,10 +14,17 @@ class AmazonBedrockProvider(ILLMProviderComplete):
         self.group_resolver = group_resolver
         if not user_email:
             raise ValueError("user_email é obrigatório para busca de secrets AWS neste projeto.")
-        grupo, empresa = UserEmailParser.parse_email_with_group(user_email, group_resolver=self.group_resolver)
-        self.aws_access_key_id = self.secret_manager.get_secret_with_user_context('AWS-ACCESS-KEY-ID', user_email, group_resolver=self.group_resolver)
-        self.aws_secret_access_key = self.secret_manager.get_secret_with_user_context('AWS-SECRET-ACCESS-KEY', user_email, group_resolver=self.group_resolver)
-        self.aws_region = self.secret_manager.get_secret_with_user_context('AWS-REGION', user_email, group_resolver=self.group_resolver)
+        # Obtém grupo diretamente do MongoDB usando o e-mail
+        grupo = group_resolver.get_group_for_user(user_email) if group_resolver is not None else None
+        # Obtém usuario e empresa via parser
+        usuario, empresa = UserEmailParser.parse_email(user_email)
+        # Monta os nomes dos secrets AWS conforme padrão
+        aws_access_key_secret_name = f"AWS-ACCESS-KEY-ID-{grupo}-{empresa}"
+        aws_secret_access_key_secret_name = f"AWS-SECRET-ACCESS-KEY-{grupo}-{empresa}"
+        aws_region_secret_name = f"AWS-REGION-{grupo}-{empresa}"
+        self.aws_access_key_id = self.secret_manager.get_secret(aws_access_key_secret_name)
+        self.aws_secret_access_key = self.secret_manager.get_secret(aws_secret_access_key_secret_name)
+        self.aws_region = self.secret_manager.get_secret(aws_region_secret_name)
         self.bedrock_runtime = boto3.client(
             'bedrock-runtime',
             aws_access_key_id=self.aws_access_key_id,

--- a/tools/user_email_parser.py
+++ b/tools/user_email_parser.py
@@ -1,6 +1,5 @@
 import re
 from typing import Tuple
-from services.mongodb_group_resolver_service import MongoDBGroupResolverService
 
 class UserEmailParser:
     @staticmethod
@@ -22,12 +21,3 @@ class UserEmailParser:
         if not re.match(r'^[A-Za-z0-9_-]+$', empresa):
             raise ValueError("Formato de empresa inválido no email.")
         return usuario, empresa
-
-    @staticmethod
-    def parse_email_with_group(email: str, group_resolver: MongoDBGroupResolverService) -> Tuple[str, str, str]:
-        """
-        Recebe um email, obtém usuario e empresa via parse_email, consulta o grupo via group_resolver, retorna (usuario, empresa, grupo).
-        """
-        usuario, empresa = UserEmailParser.parse_email(email)
-        grupo = group_resolver.get_group_for_user(usuario, empresa)
-        return usuario, empresa, grupo


### PR DESCRIPTION
Os ajustes solicitados foram aplicados: o campo 'usuario' no modelo agora armazena o email completo e o campo 'descricao' foi adicionado como opcional; o serviço de resolução de grupo utiliza diretamente o email completo para consulta no MongoDB, eliminando o parser; o método 'parse_email_with_group' foi removido do utilitário, mantendo apenas 'parse_email'. Todo o código segue as melhores práticas de engenharia Python. Os métodos de construção de nomes de secrets foram ajustados para utilizar o email completo do usuário e o group_resolver, conforme instruções do usuário. Agora, o grupo é obtido diretamente via group_resolver.get_group_for_user(user_email), e a empresa é extraída do email. O nome do secret segue o padrão solicitado, sem parser manual do usuário. As modificações solicitadas foram aplicadas conforme as observações do usuário: agora, para obtenção do grupo, utiliza-se diretamente group_resolver.get_group_for_user(user_email) e para usuário/empresa, UserEmailParser.parse_email(user_email). O parser de grupo não é mais utilizado, pois o e-mail é suficiente para consulta no MongoDB. Os nomes dos secrets AWS e propriedades das classes foram ajustados para refletir essa lógica.