### PR TITLE
As melhorias para garantir que toda comunicação entre backend e MCP seja

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -119,7 +119,7 @@ async def start_analysis(
     # 3. Gera job_id único
     job_id = str(uuid.uuid4())
 
-    # 4. Monta payload para MCP
+    # 4. Monta payload para MCP, incluindo job_id explicitamente
     mcp_payload = {
         "email": email,
         "nome_projeto": nome_projeto,

--- a/backend/app/models/mcp_models.py
+++ b/backend/app/models/mcp_models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from typing import Optional
 
 class MCPStartAnalysisPayload(BaseModel):
@@ -7,6 +7,12 @@ class MCPStartAnalysisPayload(BaseModel):
     analysis_type: str = Field(..., description="Tipo de análise a ser realizada pelo MCP.")
     job_id: str = Field(..., description="Identificador único do job.")
     arquivo_docx: Optional[bytes] = Field(None, description="Arquivo DOCX enviado pelo frontend. O backend apenas repassa este arquivo para o MCP, sem realizar qualquer processamento ou extração de texto.")
+
+    @validator('job_id')
+    def job_id_must_not_be_empty(cls, v):
+        if not v or not isinstance(v, str) or not v.strip():
+            raise ValueError('job_id é obrigatório e não pode ser vazio')
+        return v
 
 class MCPStartAnalysisResponse(BaseModel):
     project_id: str = Field(..., description="Identificador único do projeto.")

--- a/backend/app/services/mcp_client_service.py
+++ b/backend/app/services/mcp_client_service.py
@@ -16,6 +16,12 @@ class MCPStartAnalysisPayload(BaseModel):
     comentario_extra: Optional[str] = Field(None)
     instrucoes_extras: Optional[str] = Field(None)
 
+    @staticmethod
+    def validate_job_id(job_id):
+        if not job_id or not isinstance(job_id, str) or not job_id.strip():
+            raise ValueError('job_id é obrigatório e não pode ser vazio')
+        return job_id
+
 class MCPStartAnalysisResponse(BaseModel):
     project_id: str
     job_id: Optional[str] = None
@@ -34,9 +40,12 @@ class MCPClientService:
         url = f"{base}/start"
         logging.info(f"🔌 [MCP Client] URL Final Limpa: '[{url}]'")
 
+        job_id = payload.get("job_id")
+        MCPStartAnalysisPayload.validate_job_id(job_id)
+
         data = {
             "project_id": payload.get("project_id"),
-            "job_id": payload.get("job_id"),
+            "job_id": job_id,
             "email": payload.get("email"),
             "nome_projeto": payload.get("nome_projeto"),
             "agent_name": payload.get("agent_name"),
@@ -73,7 +82,7 @@ class MCPClientService:
                 data_resp = response.json()
                 return MCPStartAnalysisResponse(
                     project_id=data_resp.get("project_id", payload.get("project_id")),
-                    job_id=data_resp.get("job_id", payload.get("job_id"))
+                    job_id=data_resp.get("job_id", job_id)
                 )
         except httpx.HTTPStatusError as exc:
             raise Exception(f"Erro ao comunicar com MCP Server: {exc.response.status_code} - {exc.response.text}")

--- a/backend/tests/test_mcp_client_service.py
+++ b/backend/tests/test_mcp_client_service.py
@@ -1,0 +1,47 @@
+import pytest
+import uuid
+from unittest.mock import patch, AsyncMock
+from backend.app.services.mcp_client_service import MCPClientService
+from fastapi import UploadFile
+
+@pytest.mark.asyncio
+async def test_start_analysis_includes_job_id_in_payload():
+    # Setup
+    mcp_service_url = 'http://fake-mcp-service'
+    job_id = str(uuid.uuid4())
+    payload = {
+        "project_id": "proj123",
+        "job_id": job_id,
+        "email": "user@example.com",
+        "nome_projeto": "Projeto Teste",
+        "agent_name": "agentA",
+        "analysis_type": "agentA",
+        "branch": "main",
+        "repository": "repo-url",
+        "comentario_extra": "comentário"
+    }
+
+    # Mock response do MCP
+    mcp_response = {
+        "project_id": payload["project_id"],
+        "job_id": payload["job_id"]
+    }
+
+    async def mock_post(*args, **kwargs):
+        # Verifica que o job_id está no payload enviado
+        if 'data' in kwargs:
+            sent = kwargs['data']
+        elif 'json' in kwargs:
+            sent = kwargs['json']
+        else:
+            sent = {}
+        assert sent.get('job_id') == job_id
+        return AsyncMock(status_code=200, json=lambda: mcp_response)()
+
+    with patch('httpx.AsyncClient.post', new=mock_post):
+        client = MCPClientService(base_url=mcp_service_url)
+        result = await client.start_analysis(payload, mcp_service_url)
+        assert result.project_id == payload["project_id"]
+        assert result.job_id == job_id
+        # Verifica que o job_id é um UUID válido
+        assert uuid.UUID(result.job_id)

--- a/backend/tests/test_project_creation.py
+++ b/backend/tests/test_project_creation.py
@@ -11,6 +11,13 @@ from main import app
 
 client = TestClient(app)
 
+def is_valid_uuid(val):
+    try:
+        uuid.UUID(str(val))
+        return True
+    except Exception:
+        return False
+
 @pytest.mark.asyncio
 async def test_create_project_when_user_has_agent_access(monkeypatch):
     # Mock MongoDBService methods
@@ -43,6 +50,10 @@ async def test_create_project_when_user_has_agent_access(monkeypatch):
     assert response.status_code == 200
     assert 'project_id' in response.json()
     assert response.json()['message'].startswith('Análise multiagente solicitada')
+    # Verifica job_id
+    job_id = response.json().get('job_id')
+    assert job_id is not None
+    assert is_valid_uuid(job_id)
 
 @pytest.mark.asyncio
 async def test_error_when_user_has_no_agent_access(monkeypatch):
@@ -71,6 +82,8 @@ async def test_error_when_user_has_no_agent_access(monkeypatch):
     )
     assert response.status_code == 403
     assert response.json()['detail'] == 'Usuário não possui permissão para usar este agente.'
+    # Não deve retornar job_id
+    assert 'job_id' not in response.json()
 
 @pytest.mark.asyncio
 async def test_use_existing_project(monkeypatch):
@@ -99,6 +112,10 @@ async def test_use_existing_project(monkeypatch):
     )
     assert response.status_code == 200
     assert response.json()['project_id'] == 'existing_project_id'
+    # Verifica job_id
+    job_id = response.json().get('job_id')
+    assert job_id is not None
+    assert is_valid_uuid(job_id)
 
 @pytest.mark.asyncio
 async def test_project_name_normalization(monkeypatch):
@@ -127,3 +144,7 @@ async def test_project_name_normalization(monkeypatch):
         }
     )
     assert response.status_code == 200
+    # Verifica job_id
+    job_id = response.json().get('job_id')
+    assert job_id is not None
+    assert is_valid_uuid(job_id)


### PR DESCRIPTION
As melhorias para garantir que toda comunicação entre backend e MCP seja guiada por um job_id único foram implementadas. O campo job_id foi tornado obrigatório no modelo MCPStartAnalysisPayload, explicitamente incluído no payload enviado ao MCP no endpoint /start, e validado no serviço MCPClientService. As mudanças solicitadas foram implementadas: os testes de criação de projeto agora verificam que o job_id retornado não é None e possui formato UUID válido; foi criado um teste unitário para MCPClientService.start_analysis() garantindo que o job_id é incluído no payload enviado ao MCP.